### PR TITLE
TRA-126: Web cleanup and shared UI components

### DIFF
--- a/apps/mobile/app/trip/[id]/activities.tsx
+++ b/apps/mobile/app/trip/[id]/activities.tsx
@@ -13,6 +13,8 @@ import {
 import type { DiscoverItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { PageTransition, useTabAccent } from './_layout';
+import { SkeletonBlock } from '@/components/ui/SkeletonBlock';
+import { RatingStars } from '@/components/ui/RatingStars';
 
 // ---- Placeholder colors for cards without images ----
 const PLACEHOLDER_COLORS = ['#e0f2fe', '#fef3c7', '#ede9fe', '#ecfdf5', '#fce7f3', '#fff7ed', '#f0fdfa'];
@@ -22,23 +24,6 @@ function placeholderColor(id: string): string {
   return PLACEHOLDER_COLORS[Math.abs(hash) % PLACEHOLDER_COLORS.length];
 }
 
-// ---- Rating Stars ----
-function RatingStars({ rating, size = 12 }: { rating: number; size?: number }) {
-  const full = Math.floor(rating);
-  const half = rating - full >= 0.3;
-  const empty = 5 - full - (half ? 1 : 0);
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 1 }}>
-      {Array.from({ length: full }).map((_, i) => (
-        <FontAwesome key={`f${i}`} name="star" size={size} color="#fbbf24" />
-      ))}
-      {half && <FontAwesome name="star-half-o" size={size} color="#fbbf24" />}
-      {Array.from({ length: empty }).map((_, i) => (
-        <FontAwesome key={`e${i}`} name="star-o" size={size} color="#e5e7eb" />
-      ))}
-    </View>
-  );
-}
 
 // ---- Min Rating Filter ----
 function MinRatingFilter({ value, onChange }: { value: number | null; onChange: (v: number | null) => void }) {
@@ -699,10 +684,6 @@ function ActivityDetailSheet({
 }
 
 // ---- Skeleton ----
-function SkeletonBlock({ width, height, radius = 6, style }: { width: number | string; height: number; radius?: number; style?: any }) {
-  const colors = useThemeColors();
-  return <View style={[{ width, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
-}
 
 function SkeletonCard() {
   const colors = useThemeColors();

--- a/apps/mobile/app/trip/[id]/budget.tsx
+++ b/apps/mobile/app/trip/[id]/budget.tsx
@@ -6,6 +6,7 @@ import { useItineraryScreen, MOCK_BUDGET_ITEMS } from '@travyl/shared';
 import type { BudgetItem, BudgetExpense } from '@travyl/shared';
 import { PageTransition, useTabAccent } from './_layout';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { SkeletonBlock } from '@/components/ui/SkeletonBlock';
 
 /* ================================================================
    Icon + colour mapping (matches web CATEGORY_COLORS / CATEGORY_ICONS)
@@ -57,11 +58,6 @@ function categoryHealthColors(pct: number): { bg: string; border: string } {
 /* ================================================================
    Skeleton (loading state)
    ================================================================ */
-
-function SkeletonBlock({ width, height, radius = 6, style }: { width: number | string; height: number; radius?: number; style?: any }) {
-  const colors = useThemeColors();
-  return <View style={[{ width, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
-}
 
 function BudgetSkeleton() {
   const colors = useThemeColors();

--- a/apps/mobile/app/trip/[id]/cars.tsx
+++ b/apps/mobile/app/trip/[id]/cars.tsx
@@ -5,6 +5,7 @@ import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { LinearGradient } from 'expo-linear-gradient';
 import { PageTransition, useTabAccent } from './_layout';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { SkeletonBlock } from '@/components/ui/SkeletonBlock';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -252,11 +253,6 @@ function generateConfirmation(): string {
 /* ------------------------------------------------------------------ */
 /*  Skeleton                                                           */
 /* ------------------------------------------------------------------ */
-
-function SkeletonBlock({ width, height, radius = 6, style }: { width: number | string; height: number; radius?: number; style?: any }) {
-  const colors = useThemeColors();
-  return <View style={[{ width, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
-}
 
 function SkeletonCarCard() {
   const ACCENT = useTabAccent('cars');

--- a/apps/mobile/app/trip/[id]/flights.tsx
+++ b/apps/mobile/app/trip/[id]/flights.tsx
@@ -4,17 +4,11 @@ import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { LinearGradient } from 'expo-linear-gradient';
 import { PageTransition, useTabAccent } from './_layout';
+import { adjustBrightness } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 /* ================================================================
    MOCK DATA — Paris trip: JFK <-> CDG
    ================================================================ */
-
-function adjustBrightness(hex: string, amount: number): string {
-  const r = Math.min(255, Math.max(0, parseInt(hex.slice(1, 3), 16) + amount));
-  const g = Math.min(255, Math.max(0, parseInt(hex.slice(3, 5), 16) + amount));
-  const b = Math.min(255, Math.max(0, parseInt(hex.slice(5, 7), 16) + amount));
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
-}
 
 const POPULAR_AIRPORTS = [
   { code: 'JFK', name: 'John F. Kennedy Intl', city: 'New York' },

--- a/apps/mobile/app/trip/[id]/restaurants.tsx
+++ b/apps/mobile/app/trip/[id]/restaurants.tsx
@@ -14,6 +14,8 @@ import {
 import type { DiscoverItem } from '@travyl/shared';
 import { PageTransition, useTabAccent } from './_layout';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { SkeletonBlock } from '@/components/ui/SkeletonBlock';
+import { RatingStars } from '@/components/ui/RatingStars';
 
 
 /* -- Menu highlights mock data (keyed by restaurant id) -------- */
@@ -61,23 +63,6 @@ const RESTAURANT_DISTANCES: Record<string, string> = {
   rd1: '0.5 km', rd2: '1.5 km', rd3: '0.7 km', rd4: '2.1 km', rd5: '0.4 km',
 };
 
-// -- Rating stars -------------------------------------------------
-function RatingStars({ rating, size = 11 }: { rating: number; size?: number }) {
-  const full = Math.floor(rating);
-  const half = rating - full >= 0.3;
-  const empty = 5 - full - (half ? 1 : 0);
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 1 }}>
-      {Array.from({ length: full }).map((_, i) => (
-        <FontAwesome key={`f${i}`} name="star" size={size} color="#fbbf24" />
-      ))}
-      {half && <FontAwesome name="star-half-full" size={size} color="#fbbf24" />}
-      {Array.from({ length: empty }).map((_, i) => (
-        <FontAwesome key={`e${i}`} name="star-o" size={size} color="#e5e7eb" />
-      ))}
-    </View>
-  );
-}
 
 // -- Price level dots ---------------------------------------------
 function PriceLevel({ price }: { price: string }) {
@@ -801,10 +786,6 @@ function RestaurantDetailSheet({ item, onClose }: { item: DiscoverItem; onClose:
 }
 
 // -- Skeleton card ------------------------------------------------
-function SkeletonBlock({ width, height, radius = 6, style }: { width: number | string; height: number; radius?: number; style?: any }) {
-  const colors = useThemeColors();
-  return <View style={[{ width, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
-}
 
 function SkeletonDiscoverCard() {
   const colors = useThemeColors();

--- a/apps/web/app/(main)/explore/page.tsx
+++ b/apps/web/app/(main)/explore/page.tsx
@@ -5,19 +5,10 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { MapPin, Calendar, Users, GitFork, Search, Filter, Loader2 } from 'lucide-react';
-import { fetchPublicTrips, useForkTrip, useAuthStore, canForkTrip } from '@travyl/shared';
+import { fetchPublicTrips, useForkTrip, useAuthStore, canForkTrip, formatDateRange } from '@travyl/shared';
 import type { Trip } from '@travyl/shared';
 
 const BRAND = '#1e3a5f';
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start + 'T00:00:00');
-  const e = new Date(end + 'T00:00:00');
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-  const sStr = s.toLocaleDateString('en-US', opts);
-  const eStr = e.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
-  return `${sStr} – ${eStr}`;
-}
 
 interface PublicTripCardProps {
   trip: Trip & { profiles?: { display_name: string | null; avatar_url: string | null } };

--- a/apps/web/app/(main)/trip/[id]/budget/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/budget/page.tsx
@@ -8,6 +8,7 @@ import {
 import { AnimatePresence, motion } from 'motion/react';
 import { useItineraryScreen } from '@travyl/shared';
 import type { LucideIcon } from 'lucide-react';
+import { Skeleton } from '@/components/ui';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -147,10 +148,6 @@ const DEFAULT_COLORS: typeof CATEGORY_COLORS[string] = { bg: 'bg-gray-100', text
 /* ------------------------------------------------------------------ */
 /*  Skeleton                                                           */
 /* ------------------------------------------------------------------ */
-
-function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`rounded-md bg-gray-200 animate-pulse ${className}`} />;
-}
 
 function BudgetSkeleton() {
   return (

--- a/apps/web/app/(main)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/itinerary/page.tsx
@@ -35,11 +35,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   outdoor: 'var(--trip-base)',
 };
 
-// ─── Skeleton ───────────────────────────────────────────────────
-
-function SkeletonBlock({ className, style }: { className?: string; style?: React.CSSProperties }) {
-  return <div className={`bg-gray-200 rounded animate-pulse ${className ?? ''}`} style={style} />;
-}
+import { Skeleton } from '@/components/ui';
 
 function SkeletonItinerary() {
   return (
@@ -47,24 +43,24 @@ function SkeletonItinerary() {
       {/* Day selector skeleton */}
       <div className="flex items-center gap-2 mb-3 overflow-hidden">
         {[1, 2, 3, 4, 5, 6].map((i) => (
-          <SkeletonBlock key={i} className="shrink-0 rounded-lg" style={{ width: 56, height: 52 }} />
+          <Skeleton key={i} className="shrink-0 rounded-lg" style={{ width: 56, height: 52 }} />
         ))}
       </div>
       {/* Flight section skeleton */}
       <div className="mb-3.5">
-        <SkeletonBlock className="rounded-lg" style={{ height: 52 }} />
+        <Skeleton className="rounded-lg" style={{ height: 52 }} />
       </div>
       {/* Hotel section skeleton */}
       <div className="mb-3.5">
-        <SkeletonBlock className="rounded-lg" style={{ height: 52 }} />
+        <Skeleton className="rounded-lg" style={{ height: 52 }} />
       </div>
       {/* Time group sections */}
       {[1, 2, 3].map((i) => (
         <div key={i} className="mb-3.5">
-          <SkeletonBlock className="rounded-lg mb-2" style={{ height: 36 }} />
+          <Skeleton className="rounded-lg mb-2" style={{ height: 36 }} />
           <div className="space-y-2 pl-1">
             {[1, 2].map((j) => (
-              <SkeletonBlock key={j} className="rounded-lg" style={{ height: 72 }} />
+              <Skeleton key={j} className="rounded-lg" style={{ height: 72 }} />
             ))}
           </div>
         </div>

--- a/apps/web/app/(main)/trip/[id]/packing/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/packing/page.tsx
@@ -6,13 +6,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { MOCK_PACKING_LIST, MOCK_WEATHER, MOCK_TRIP } from '@travyl/shared';
 import type { PackingItem, PackingList } from '@travyl/shared';
 
-/* ------------------------------------------------------------------ */
-/*  Skeleton                                                          */
-/* ------------------------------------------------------------------ */
-
-function SkeletonBlock({ className, style }: { className?: string; style?: React.CSSProperties }) {
-  return <div className={`bg-gray-200 rounded animate-pulse ${className ?? ''}`} style={style} />;
-}
+import { Skeleton } from '@/components/ui';
 
 function SkeletonPacking() {
   return (
@@ -20,20 +14,20 @@ function SkeletonPacking() {
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
         {[1, 2, 3].map((i) => (
           <div key={i} className="rounded-lg p-3 border border-gray-200 bg-white">
-            <SkeletonBlock style={{ width: 120, height: 14 }} />
-            <SkeletonBlock className="mt-2" style={{ height: 6 }} />
+            <Skeleton style={{ width: 120, height: 14 }} />
+            <Skeleton className="mt-2" style={{ height: 6 }} />
           </div>
         ))}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {[1, 2, 3].map((i) => (
           <div key={i} className="rounded-xl p-3.5 border border-gray-200 bg-white">
-            <SkeletonBlock style={{ width: 80, height: 14 }} />
+            <Skeleton style={{ width: 80, height: 14 }} />
             <div className="space-y-2 mt-3">
               {[1, 2, 3, 4].map((j) => (
                 <div key={j} className="flex items-center gap-2.5">
-                  <SkeletonBlock style={{ width: 16, height: 16 }} />
-                  <SkeletonBlock style={{ width: 80 + j * 15, height: 12 }} />
+                  <Skeleton style={{ width: 16, height: 16 }} />
+                  <Skeleton style={{ width: 80 + j * 15, height: 12 }} />
                 </div>
               ))}
             </div>

--- a/apps/web/app/(main)/trip/[id]/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/page.tsx
@@ -11,10 +11,7 @@ import {
   MOCK_WEATHER, MOCK_WEATHER_FORECAST, MOCK_NEWS,
 } from '@travyl/shared';
 import type { NewsItem } from '@travyl/shared';
-
-function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`rounded-md bg-gray-200 ${className}`} />;
-}
+import { Skeleton } from '@/components/ui';
 
 // ─── Collapsible Section ─────────────────────────────────────
 

--- a/apps/web/app/(main)/trip/[id]/settings/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/settings/page.tsx
@@ -710,7 +710,6 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
       setIsPublic(!isPublic);
       refetch();
     } catch (error) {
-      console.error('Failed to update trip visibility:', error);
       alert('Failed to update trip visibility');
     }
   };

--- a/apps/web/app/(main)/trip/[id]/share/[token]/page.tsx
+++ b/apps/web/app/(main)/trip/[id]/share/[token]/page.tsx
@@ -4,19 +4,10 @@ import { use } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { MapPin, Calendar, Users, GitFork, Loader2, Lock, AlertCircle } from 'lucide-react';
-import { fetchTripByShareToken, useForkTrip, useAuthStore, canForkTrip } from '@travyl/shared';
+import { fetchTripByShareToken, useForkTrip, useAuthStore, canForkTrip, formatDateRange } from '@travyl/shared';
 import type { Trip } from '@travyl/shared';
 
 const BRAND = '#1e3a5f';
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start + 'T00:00:00');
-  const e = new Date(end + 'T00:00:00');
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-  const sStr = s.toLocaleDateString('en-US', opts);
-  const eStr = e.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
-  return `${sStr} – ${eStr}`;
-}
 
 interface SharedTripViewProps {
   trip: Trip;

--- a/apps/web/app/(main)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(main)/trip/[id]/trip-layout-inner.tsx
@@ -129,7 +129,7 @@ function ContentHeader({ tripId, mapOpen, onToggleMap, calendarOpen, onToggleCal
         <div className="flex-1">
           <h2
             className="text-[17px] tracking-tight"
-            style={{ color: '#1e3a5f', fontWeight: 700 }}
+            style={{ color: 'var(--trip-base)', fontWeight: 700 }}
           >
             {tab.label}
           </h2>
@@ -140,9 +140,10 @@ function ContentHeader({ tripId, mapOpen, onToggleMap, calendarOpen, onToggleCal
             onClick={onToggleCalendar}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-all duration-200 ${
               calendarOpen
-                ? 'border-[#1e3a5f] bg-[#1e3a5f] text-white shadow-md scale-[1.02]'
+                ? 'text-white shadow-md scale-[1.02]'
                 : 'border-gray-200 hover:bg-gray-50 hover:border-gray-300 text-gray-600'
             }`}
+            style={calendarOpen ? { borderColor: 'var(--trip-base)', backgroundColor: 'var(--trip-base)' } : undefined}
             title={calendarOpen ? 'List view' : 'Calendar view'}
           >
             <Calendar size={13} />
@@ -152,9 +153,10 @@ function ContentHeader({ tripId, mapOpen, onToggleMap, calendarOpen, onToggleCal
             onClick={onToggleMap}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-all duration-200 ${
               mapOpen
-                ? 'border-[#1e3a5f] bg-[#1e3a5f] text-white shadow-md scale-[1.02]'
+                ? 'text-white shadow-md scale-[1.02]'
                 : 'border-gray-200 hover:bg-gray-50 hover:border-gray-300 text-gray-600'
             }`}
+            style={mapOpen ? { borderColor: 'var(--trip-base)', backgroundColor: 'var(--trip-base)' } : undefined}
             title={mapOpen ? 'Hide map' : 'Show map'}
           >
             <Map size={13} />
@@ -313,7 +315,7 @@ function TripLayoutContent({
                   className="hidden md:flex w-[340px] lg:w-[440px] xl:w-[520px] shrink-0 border-l border-gray-200 bg-white flex-col overflow-hidden rounded-r-2xl">
                   <div className="flex items-center justify-between px-3 py-2.5 border-b border-gray-100">
                     <div className="flex items-center gap-2">
-                      <Map size={13} className="text-[#1e3a5f]" />
+                      <Map size={13} className="text-[var(--trip-base)]" />
                       <span className="text-xs font-semibold text-gray-800">
                         {hasMarkers ? `${mapMarkers.length} locations` : (trip?.destination || 'Paris, France')}
                       </span>
@@ -353,7 +355,7 @@ function TripLayoutContent({
                     {/* Location label bar */}
                     {!hasMarkers && (
                       <div className="absolute bottom-0 inset-x-0 flex items-center gap-2 px-3 py-2 bg-white/95 backdrop-blur-md border-t border-gray-100">
-                        <MapPin size={12} className="text-[#1e3a5f] shrink-0" />
+                        <MapPin size={12} className="text-[var(--trip-base)] shrink-0" />
                         <span className="text-[11px] font-medium text-gray-700 truncate">
                           {trip?.destination || 'Paris, France'}
                         </span>

--- a/apps/web/app/(main)/user/[username]/page.tsx
+++ b/apps/web/app/(main)/user/[username]/page.tsx
@@ -5,20 +5,11 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@travyl/shared';
-import { fetchUserPublicTrips, useForkTrip, useAuthStore, canForkTrip } from '@travyl/shared';
+import { fetchUserPublicTrips, useForkTrip, useAuthStore, canForkTrip, formatDateRange } from '@travyl/shared';
 import type { Trip, Profile } from '@travyl/shared';
 import { MapPin, Calendar, Users, GitFork, Loader2, Map } from 'lucide-react';
 
 const BRAND = '#1e3a5f';
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start + 'T00:00:00');
-  const e = new Date(end + 'T00:00:00');
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-  const sStr = s.toLocaleDateString('en-US', opts);
-  const eStr = e.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
-  return `${sStr} – ${eStr}`;
-}
 
 // Fetch user profile by username (display_name)
 async function fetchUserProfileByUsername(username: string): Promise<Profile | null> {

--- a/apps/web/components/home/screens/PaperPlane.tsx
+++ b/apps/web/components/home/screens/PaperPlane.tsx
@@ -1,2 +1,0 @@
-// Re-export from canonical location to avoid duplication
-export { PaperPlane } from "@/components/icons/PaperPlane";

--- a/apps/web/components/home/screens/WebSearchScreen.tsx
+++ b/apps/web/components/home/screens/WebSearchScreen.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from "motion/react";
 import { Search, MapPin, Calendar, Users, Sparkles } from "lucide-react";
-import { PaperPlane } from "./PaperPlane";
+import { PaperPlane } from "@/components/icons/PaperPlane";
 import { STEP1_QUICK_CHIPS, STEP1_RECENT_SEARCHES } from "@travyl/shared";
 
 const CHIP_ICONS: Record<string, React.ComponentType<{ size?: number }>> = {

--- a/apps/web/components/itinerary/ComparisonAlternatives.tsx
+++ b/apps/web/components/itinerary/ComparisonAlternatives.tsx
@@ -18,8 +18,90 @@ import {
   Star,
   Info,
 } from 'lucide-react';
-import { FLIGHT_OPTIONS, ALTERNATIVE_AIRPORTS } from '@travyl/shared';
 import type { FlightOption } from '@travyl/shared';
+
+/* ── Mock data ─────────────────────────────────────────────── */
+
+const ALTERNATIVE_AIRPORTS = [
+  { code: 'EWR', name: 'Newark Liberty Intl', savings: 45 },
+  { code: 'LGA', name: 'LaGuardia', savings: 30 },
+  { code: 'ORY', name: 'Paris Orly', savings: 60 },
+];
+
+const FLIGHT_OPTIONS: FlightOption[] = [
+  {
+    id: 'fl-1',
+    airline: 'American Airlines',
+    airlineLogo: 'AA',
+    flightNumber: 'AA 100',
+    aircraft: 'Boeing 777-300ER',
+    departure: { time: '7:30 PM', airport: 'JFK', terminal: '8' },
+    arrival: { time: '9:15 AM', airport: 'CDG', terminal: '2A', nextDay: true },
+    duration: '7h 45m',
+    stops: 0,
+    fareClass: 'Economy',
+    price: { base: 412, taxes: 86, total: 498 },
+    baggage: { carryOn: true, checked: 1, checkedFee: 0 },
+    seatPitch: '31"',
+    seatWidth: '17.2"',
+    amenities: { wifi: true, power: true, meals: true, entertainment: true },
+    cancellation: { refundable: false, changeFee: 200, policy: 'Non-refundable. Change fee $200 + fare difference.' },
+    onTime: 82,
+    co2: 245,
+    co2Avg: 260,
+    milesEarned: 3640,
+    alliance: 'oneworld',
+    badge: 'Best Overall',
+  },
+  {
+    id: 'fl-2',
+    airline: 'Delta Air Lines',
+    airlineLogo: 'DL',
+    flightNumber: 'DL 264',
+    aircraft: 'Airbus A330-900neo',
+    departure: { time: '10:05 PM', airport: 'JFK', terminal: '4' },
+    arrival: { time: '11:35 AM', airport: 'CDG', terminal: '2E', nextDay: true },
+    duration: '7h 30m',
+    stops: 0,
+    fareClass: 'Economy',
+    price: { base: 389, taxes: 78, total: 467 },
+    baggage: { carryOn: true, checked: 1, checkedFee: 0 },
+    seatPitch: '32"',
+    seatWidth: '18"',
+    amenities: { wifi: true, power: true, meals: true, entertainment: true },
+    cancellation: { refundable: false, changeFee: 0, policy: 'No change fees. Fare difference may apply.' },
+    onTime: 86,
+    co2: 230,
+    co2Avg: 260,
+    milesEarned: 3640,
+    alliance: 'SkyTeam',
+    badge: 'Fastest',
+  },
+  {
+    id: 'fl-3',
+    airline: 'United Airlines',
+    airlineLogo: 'UA',
+    flightNumber: 'UA 57',
+    aircraft: 'Boeing 767-400ER',
+    departure: { time: '5:15 PM', airport: 'EWR', terminal: 'C' },
+    arrival: { time: '6:55 AM', airport: 'CDG', terminal: '1', nextDay: true },
+    duration: '7h 40m',
+    stops: 0,
+    fareClass: 'Economy',
+    price: { base: 358, taxes: 74, total: 432 },
+    baggage: { carryOn: true, checked: 0, checkedFee: 35 },
+    seatPitch: '30"',
+    seatWidth: '17.5"',
+    amenities: { wifi: true, power: true, meals: true, entertainment: false },
+    cancellation: { refundable: false, changeFee: 0, policy: 'No change fees. Fare difference may apply.' },
+    onTime: 79,
+    co2: 252,
+    co2Avg: 260,
+    milesEarned: 3640,
+    alliance: 'Star Alliance',
+    badge: 'Lowest Price',
+  },
+];
 
 /* ── Helpers ────────────────────────────────────────────────── */
 

--- a/apps/web/components/itinerary/FlightBookingDetails.tsx
+++ b/apps/web/components/itinerary/FlightBookingDetails.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { MOCK_FLIGHT_BOOKING_DETAILS } from '@travyl/shared';
 import type { FlightDetailsType } from '@travyl/shared';
 import {
   Ticket,
@@ -13,6 +12,24 @@ import {
   CheckCircle2,
 } from 'lucide-react';
 import { useState } from 'react';
+
+const MOCK_FLIGHT_BOOKING_DETAILS: FlightDetailsType = {
+  confirmationNumber: 'XHGT7K',
+  pnr: 'XHGT7K',
+  ticketNumbers: ['016-2345678901', '016-2345678902'],
+  fareClass: 'Economy (Y)',
+  fareType: 'Main Cabin',
+  baggageAllowance: {
+    carryOn: '1 personal item + 1 carry-on bag (max 10 kg)',
+    checked: '1 checked bag included (max 23 kg)',
+    fees: 0,
+  },
+  cancellationPolicy: 'Non-refundable. Cancellation fee of $199 applies. Residual value issued as flight credit valid for 1 year.',
+  changePolicy: 'Changes permitted with no change fee. Fare difference may apply.',
+  refundPolicy: 'Refund to original payment method within 24 hours of booking. After 24 hours, refund issued as flight credit minus cancellation fee.',
+  checkInUrl: 'https://www.aa.com/check-in',
+  checkInOpens: '24 hours before departure',
+};
 
 interface FlightBookingDetailsProps {
   isVisible: boolean;

--- a/apps/web/components/itinerary/FlightSearchSection.tsx
+++ b/apps/web/components/itinerary/FlightSearchSection.tsx
@@ -13,10 +13,22 @@ import {
   Minus,
   RotateCcw,
 } from 'lucide-react';
-import { POPULAR_AIRPORTS } from '@travyl/shared';
 import type { PopularAirport } from '@travyl/shared';
 
 /* ── Constants ──────────────────────────────────────────────── */
+
+const POPULAR_AIRPORTS: PopularAirport[] = [
+  { code: 'JFK', name: 'John F. Kennedy Intl', city: 'New York' },
+  { code: 'CDG', name: 'Charles de Gaulle', city: 'Paris' },
+  { code: 'EWR', name: 'Newark Liberty Intl', city: 'Newark' },
+  { code: 'LGA', name: 'LaGuardia', city: 'New York' },
+  { code: 'ORY', name: 'Paris Orly', city: 'Paris' },
+  { code: 'FCO', name: 'Leonardo da Vinci–Fiumicino', city: 'Rome' },
+  { code: 'LHR', name: 'Heathrow', city: 'London' },
+  { code: 'LAX', name: 'Los Angeles Intl', city: 'Los Angeles' },
+  { code: 'NRT', name: 'Narita Intl', city: 'Tokyo' },
+  { code: 'SFO', name: 'San Francisco Intl', city: 'San Francisco' },
+];
 
 const CABIN_CLASSES = ['Economy', 'Premium Economy', 'Business', 'First'];
 

--- a/apps/web/components/itinerary/HotelListView.tsx
+++ b/apps/web/components/itinerary/HotelListView.tsx
@@ -14,8 +14,108 @@ import {
   Mail,
   Map as MapIcon,
 } from 'lucide-react';
-import { HOTEL_SEARCH_RESULTS } from '@travyl/shared';
 import type { HotelSearchResult, RoomType } from '@travyl/shared';
+
+/* ------------------------------------------------------------------ */
+/*  Mock data                                                         */
+/* ------------------------------------------------------------------ */
+
+const HOTEL_SEARCH_RESULTS: HotelSearchResult[] = [
+  {
+    id: 1,
+    name: 'Hôtel Plaza Athénée',
+    stars: 5,
+    rating: 9.4,
+    reviews: 2841,
+    price: 580,
+    image: 'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=400',
+    images: [
+      'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=800',
+      'https://images.unsplash.com/photo-1582719508461-905c673771fd?w=800',
+    ],
+    address: '25 Avenue Montaigne, 75008 Paris',
+    neighborhood: 'Champs-Élysées',
+    distance: '1.2 km from Eiffel Tower',
+    amenities: ['Free Wi-Fi', 'Spa', 'Restaurant', 'Bar', 'Fitness Center', 'Room Service'],
+    roomTypes: [
+      { type: 'Superior Room', beds: '1 King', size: '35 m²', guests: 2, price: 580, image: '' },
+      { type: 'Deluxe Suite', beds: '1 King + Sofa', size: '55 m²', guests: 3, price: 920, image: '' },
+    ],
+    guestRatings: {
+      overall: 9.4,
+      categories: [
+        { label: 'Cleanliness', score: 9.7 },
+        { label: 'Location', score: 9.8 },
+        { label: 'Service', score: 9.5 },
+        { label: 'Value', score: 8.6 },
+      ],
+    },
+    taxesAndFees: { cityTax: 5, serviceFee: 15, vat: 10 },
+    freeCancellation: true,
+    lat: 48.8661,
+    lng: 2.3040,
+    phone: '+33 1 53 67 66 65',
+    email: 'reservations@plaza-athenee-paris.com',
+  },
+  {
+    id: 2,
+    name: 'Le Marais Boutique Hotel',
+    stars: 4,
+    rating: 8.8,
+    reviews: 1523,
+    price: 245,
+    image: 'https://images.unsplash.com/photo-1551882547-ff40c63fe5fa?w=400',
+    images: [
+      'https://images.unsplash.com/photo-1551882547-ff40c63fe5fa?w=800',
+      'https://images.unsplash.com/photo-1590490360182-c33d57733427?w=800',
+    ],
+    address: '12 Rue des Archives, 75004 Paris',
+    neighborhood: 'Le Marais',
+    distance: '2.8 km from Eiffel Tower',
+    amenities: ['Free Wi-Fi', 'Breakfast', 'Air Conditioning', 'Bar'],
+    roomTypes: [
+      { type: 'Classic Double', beds: '1 Queen', size: '22 m²', guests: 2, price: 245, image: '' },
+      { type: 'Superior Twin', beds: '2 Twins', size: '26 m²', guests: 2, price: 275, image: '' },
+    ],
+    guestRatings: {
+      overall: 8.8,
+      categories: [
+        { label: 'Cleanliness', score: 9.1 },
+        { label: 'Location', score: 9.5 },
+        { label: 'Service', score: 8.7 },
+        { label: 'Value', score: 8.9 },
+      ],
+    },
+    taxesAndFees: { cityTax: 3, serviceFee: 0, vat: 10 },
+    freeCancellation: true,
+    lat: 48.8588,
+    lng: 2.3550,
+  },
+  {
+    id: 3,
+    name: 'Saint-Germain Apart Hotel',
+    stars: 3,
+    rating: 8.2,
+    reviews: 967,
+    price: 175,
+    image: 'https://images.unsplash.com/photo-1618773928121-c32242e63f39?w=400',
+    images: [
+      'https://images.unsplash.com/photo-1618773928121-c32242e63f39?w=800',
+    ],
+    address: '45 Rue de Seine, 75006 Paris',
+    neighborhood: 'Saint-Germain-des-Prés',
+    distance: '1.9 km from Eiffel Tower',
+    amenities: ['Free Wi-Fi', 'Kitchenette', 'Laundry', 'Air Conditioning'],
+    roomTypes: [
+      { type: 'Studio', beds: '1 Double', size: '28 m²', guests: 2, price: 175, image: '' },
+      { type: 'One-Bedroom Apartment', beds: '1 Queen + Sofa', size: '42 m²', guests: 4, price: 260, image: '' },
+    ],
+    taxesAndFees: { cityTax: 2, serviceFee: 0, vat: 10 },
+    freeCancellation: false,
+    lat: 48.8546,
+    lng: 2.3370,
+  },
+];
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */

--- a/apps/web/components/trips/TripCard.tsx
+++ b/apps/web/components/trips/TripCard.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Calendar, Users, PieChart, MapPin, Users2 } from 'lucide-react';
+import { formatDateRange } from '@travyl/shared';
 import type { MockTripCard } from '@travyl/shared';
 import { TripRouteHover } from './TripRouteHover';
 
@@ -14,15 +15,6 @@ const STATUS_BADGE: Record<string, { label: string; bg: string; text: string }> 
   completed: { label: 'Completed', bg: 'bg-gray-500/90', text: 'text-white' },
   abandoned: { label: 'Cancelled', bg: 'bg-red-500/90', text: 'text-white' },
 };
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start + 'T00:00:00');
-  const e = new Date(end + 'T00:00:00');
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-  const sStr = s.toLocaleDateString('en-US', opts);
-  const eStr = e.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
-  return `${sStr} – ${eStr}`;
-}
 
 function formatCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: 0 }).format(amount);

--- a/apps/web/components/trips/TripListItem.tsx
+++ b/apps/web/components/trips/TripListItem.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Calendar, Users, PieChart, MapPin, Users2, ChevronRight } from 'lucide-react';
+import { formatDateRange } from '@travyl/shared';
 import type { MockTripCard } from '@travyl/shared';
 
 const STATUS_BADGE: Record<string, { label: string; bg: string; text: string }> = {
@@ -12,15 +13,6 @@ const STATUS_BADGE: Record<string, { label: string; bg: string; text: string }> 
   completed: { label: 'Completed', bg: 'bg-gray-500/90', text: 'text-white' },
   abandoned: { label: 'Cancelled', bg: 'bg-red-500/90', text: 'text-white' },
 };
-
-function formatDateRange(start: string, end: string): string {
-  const s = new Date(start + 'T00:00:00');
-  const e = new Date(end + 'T00:00:00');
-  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-  const sStr = s.toLocaleDateString('en-US', opts);
-  const eStr = e.toLocaleDateString('en-US', { ...opts, year: 'numeric' });
-  return `${sStr} – ${eStr}`;
-}
 
 function formatCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency, maximumFractionDigits: 0 }).format(amount);

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { GlassPill } from "./GlassPill";
+export { Skeleton } from "./Skeleton";


### PR DESCRIPTION
## Summary
- Clean up web page imports and remove dead code across trip pages
- Remove unused `PaperPlane` component
- Update `ComparisonAlternatives` to define mock data locally instead of importing from shared
- Clean up `HotelListView`, `FlightBookingDetails`, `FlightSearchSection` imports
- Update mobile tab screens (`activities`, `budget`, `cars`, `flights`, `restaurants`) with consistent patterns

## Test plan
- [ ] Verify web app builds and all trip pages render
- [ ] Confirm flight comparison page works without shared mock imports
- [ ] Check mobile tab screens render correctly