### PR TITLE
feat(TRA-148): TravelMosaic responsive redesign — dynamic spans & heights

### DIFF
--- a/apps/web/components/home/TravelMosaic.tsx
+++ b/apps/web/components/home/TravelMosaic.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { motion } from "motion/react";
 import {
   useMosaicTiles,
   TILE_CATEGORY_GRADIENTS,
-  TILE_CATEGORY_COLORS,
   EASE_OUT_EXPO,
 } from "@travyl/shared";
 import type { TileCategory, MosaicTile } from "@travyl/shared";
@@ -22,37 +22,56 @@ const PLACEHOLDER_TILES: MosaicTile[] = [
   { id: 'p-10', name: '', category: 'destination', tagline: '', image_url: null, gridSpan: [2, 1] },
 ];
 
+// Mobile: 7 tiles, hero + pairs
+const MOBILE_SPANS =   [12, 7, 5, 5, 7, 6, 6];
+const MOBILE_HEIGHTS = [240, 200, 200, 200, 200, 200, 200];
+
+// Desktop: 10 tiles, hero + varied rows including a 3-col row
+const DESKTOP_SPANS =   [12, 7, 5, 4, 4, 4, 5, 7, 6, 6];
+const DESKTOP_HEIGHTS = [320, 260, 260, 200, 200, 200, 260, 260, 220, 220];
+
 export function TravelMosaic() {
-  const { data: dbTiles, isLoading } = useMosaicTiles();
+  const { data: dbTiles } = useMosaicTiles();
   const tiles = dbTiles?.length ? dbTiles : PLACEHOLDER_TILES;
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    setIsDesktop(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const spanMap = isDesktop ? DESKTOP_SPANS : MOBILE_SPANS;
+  const heightMap = isDesktop ? DESKTOP_HEIGHTS : MOBILE_HEIGHTS;
+  const tileCount = isDesktop ? 10 : 7;
 
   return (
     <section className="py-16 px-6">
       <div className="max-w-6xl mx-auto">
-        <h2 className="text-2xl md:text-3xl font-bold text-foreground text-center mb-10">
-          Moments That <em>Move You</em>
+        <h2 className="text-2xl md:text-3xl text-foreground text-center mb-10">
+          <span className="font-extrabold">Moments That</span>{" "}
+          <span className="font-normal italic">Move You</span>
         </h2>
 
-        {/* Desktop: 6-col grid */}
-        <div
-          className="hidden md:grid grid-cols-6 auto-rows-[120px] gap-3"
-          style={{ gridAutoFlow: "dense" }}
-        >
-          {tiles.map((tile, i) => {
+        <div className="grid grid-cols-12 gap-2.5">
+          {tiles.slice(0, tileCount).map((tile, i) => {
             const grad = TILE_CATEGORY_GRADIENTS[tile.category as TileCategory];
-            const color = TILE_CATEGORY_COLORS[tile.category as TileCategory];
+            const colSpan = spanMap[i] ?? 6;
+            const height = heightMap[i] ?? 200;
             return (
               <motion.div
                 key={tile.id}
-                initial={{ opacity: 0, scale: 0.9 }}
+                initial={{ opacity: 0, scale: 0.95 }}
                 whileInView={{ opacity: 1, scale: 1 }}
-                viewport={{ once: true, margin: "-30px" }}
-                transition={{ duration: 0.4, delay: i * 0.04, ease: EASE_OUT_EXPO }}
-                whileHover={{ scale: 1.03 }}
-                className="rounded-xl overflow-hidden relative cursor-pointer group"
+                viewport={{ once: true }}
+                transition={{ duration: 0.3, delay: i * 0.05, ease: EASE_OUT_EXPO }}
+                whileHover={{ scale: 1.02 }}
+                className="rounded-2xl overflow-hidden relative cursor-pointer group"
                 style={{
-                  gridColumn: `span ${tile.gridSpan[0]}`,
-                  gridRow: `span ${tile.gridSpan[1]}`,
+                  gridColumn: `span ${colSpan}`,
+                  height,
                   background: tile.image_url
                     ? undefined
                     : `linear-gradient(135deg, ${grad.from}, ${grad.to})`,
@@ -65,62 +84,10 @@ export function TravelMosaic() {
                     className="absolute inset-0 w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
                   />
                 )}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-black/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
                 <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
-                <div className="relative h-full flex flex-col justify-end p-4 group-hover:-translate-y-0.5 transition-transform duration-300">
-                  <div className="flex items-center gap-1.5 mb-1">
-                    <span
-                      className="w-2 h-2 rounded-full"
-                      style={{ backgroundColor: color.hex }}
-                    />
-                    <span className="text-white/70 text-xs">{color.label}</span>
-                  </div>
-                  <h3 className="text-white font-bold text-base leading-tight">
-                    {tile.name}
-                  </h3>
-                </div>
-              </motion.div>
-            );
-          })}
-        </div>
-
-        {/* Mobile: 2-col grid */}
-        <div className="grid md:hidden grid-cols-2 gap-3">
-          {tiles.slice(0, 8).map((tile, i) => {
-            const grad = TILE_CATEGORY_GRADIENTS[tile.category as TileCategory];
-            const color = TILE_CATEGORY_COLORS[tile.category as TileCategory];
-            return (
-              <motion.div
-                key={tile.id}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.3, delay: i * 0.06, ease: EASE_OUT_EXPO }}
-                className={`rounded-xl overflow-hidden relative ${
-                  i === 0 ? "col-span-2 h-48" : "h-36"
-                }`}
-                style={{
-                  background: tile.image_url
-                    ? undefined
-                    : `linear-gradient(135deg, ${grad.from}, ${grad.to})`,
-                }}
-              >
-                {tile.image_url && (
-                  <img
-                    src={tile.image_url}
-                    alt={tile.name}
-                    className="absolute inset-0 w-full h-full object-cover"
-                  />
-                )}
-                <div className="h-full flex flex-col justify-end p-4">
-                  <div className="flex items-center gap-1.5 mb-1">
-                    <span
-                      className="w-2 h-2 rounded-full"
-                      style={{ backgroundColor: color.hex }}
-                    />
-                    <span className="text-white/70 text-xs">{color.label}</span>
-                  </div>
-                  <h3 className="text-white font-bold text-sm">{tile.name}</h3>
+                <div className="relative h-full flex flex-col justify-end p-3 sm:p-4">
+                  <h3 className="text-white font-bold text-sm sm:text-base leading-tight">{tile.name}</h3>
                 </div>
               </motion.div>
             );


### PR DESCRIPTION
## Summary
- Separate mobile (7 tiles) and desktop (10 tiles) layouts
- Dynamic column spans and per-tile heights
- matchMedia listener for responsive breakpoint detection
- Updated heading typography

## Test plan
- [ ] Mobile shows 7 tiles with correct spans
- [ ] Desktop shows 10 tiles including 3-column row
- [ ] Resizing browser triggers layout switch