### PR TITLE
feat(TRA-152): Calendar view — parent block redesign, sub-activity support

### DIFF
--- a/apps/web/components/itinerary/ActivityCard.tsx
+++ b/apps/web/components/itinerary/ActivityCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { MapPin, Clock, Heart, Image as ImageIcon } from 'lucide-react';
-import { getActivityTypeColor } from '@travyl/shared';
+import { MapPin, Clock, Heart } from 'lucide-react';
+import { getActivityTypeColor, Navy } from '@travyl/shared';
 import type { ActivityViewModel } from '@travyl/shared';
 
 interface ActivityCardProps {
@@ -12,18 +12,22 @@ interface ActivityCardProps {
 
 export function ActivityCard({ activity, onClick }: ActivityCardProps) {
   const [isFavorited, setIsFavorited] = useState(false);
+  const [imgError, setImgError] = useState(false);
   const typeColor = getActivityTypeColor(activity.category);
-  const hasImage = false; // Will be true once we have real activity images
+  const hasImage = !!(activity as any).image && !imgError;
 
   return (
     <div className="rounded-[14px] bg-white border border-gray-200 overflow-hidden cursor-pointer group transition-all hover:shadow-lg hover:scale-[1.02]" onClick={onClick}>
       {/* Image section */}
       <div className="relative h-[150px] overflow-hidden" style={{ backgroundColor: typeColor.bg }}>
         {hasImage ? (
-          <img src="" alt={activity.name} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" />
+          <img src={(activity as any).image} alt={activity.name} className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105" onError={() => setImgError(true)} />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <ImageIcon size={28} style={{ color: typeColor.primary + '30' }} />
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ background: `linear-gradient(135deg, ${Navy.DEFAULT}, #2563eb)` }}
+          >
+            <MapPin size={28} className="text-white/30" />
           </div>
         )}
 
@@ -43,14 +47,6 @@ export function ActivityCard({ activity, onClick }: ActivityCardProps) {
             className={isFavorited ? 'text-red-500 fill-red-500' : 'text-gray-500'}
           />
         </button>
-
-        {/* Type badge */}
-        <span
-          className="absolute top-2.5 left-2.5 bg-white/92 backdrop-blur-sm text-[10px] font-semibold px-2.5 py-1 rounded-xl"
-          style={{ color: typeColor.primary }}
-        >
-          {activity.category}
-        </span>
 
         {/* Title overlay */}
         <div className="absolute bottom-0 left-0 right-0 p-3">

--- a/apps/web/components/itinerary/CalendarView.tsx
+++ b/apps/web/components/itinerary/CalendarView.tsx
@@ -180,10 +180,11 @@ const DiscoverCard = memo(({
 DiscoverCard.displayName = 'DiscoverCard';
 
 // ─── Parent Block Card ──────────────────────────────────────
+// Container-style: colored header strip + stacked sub-activity cards
 
 const ParentBlockCard = memo(({
   activity, children: childActivities, onCardClick, onSwapActivities, onRemove,
-  totalDays, expandedParents, onToggleExpand, collaborators, isDimmed,
+  totalDays, expandedParents, onToggleExpand, onAddSubActivity, collaborators, isDimmed,
 }: {
   activity: CalendarActivity;
   children: CalendarActivity[];
@@ -193,6 +194,7 @@ const ParentBlockCard = memo(({
   totalDays: number;
   expandedParents: Set<string>;
   onToggleExpand: (id: string) => void;
+  onAddSubActivity: (parentId: string) => void;
   collaborators: CollaboratorPresence[];
   isDimmed?: boolean;
 }) => {
@@ -217,9 +219,10 @@ const ParentBlockCard = memo(({
   const topPx = (activity.startHour - 7) * HOUR_HEIGHT;
   const heightPx = activity.duration * HOUR_HEIGHT;
   const cardHeight = Math.max(heightPx - 2, HOUR_HEIGHT * 2);
-  const isExpanded = expandedParents.has(activity.id);
+  const isExpanded = !expandedParents.has(activity.id);
   const blockCollaborators = collaborators.filter((c) => c.selectedBlockId === activity.id);
   const sortedChildren = [...childActivities].sort((a, b) => a.startHour - b.startHour);
+  const hasImage = !!activity.image;
 
   return (
     <div
@@ -228,17 +231,19 @@ const ParentBlockCard = memo(({
         isOver ? 'ring-2 ring-green-400 ring-offset-1 z-40 scale-[1.02]' : 'hover:shadow-xl hover:z-30'
       }`}
       style={{
-        left: `${left}%`, width: `calc(${dayWidth}% - 8px)`,
+        left: `${left}%`, width: `calc(${dayWidth}% - 6px)`,
         top: `${topPx}px`, height: `${cardHeight}px`,
-        margin: '1px 4px',
+        margin: '1px 3px',
         opacity: isDragging ? 0.3 : isDimmed ? 0.3 : 1,
         transition: 'opacity 0.2s',
         zIndex: isDragging ? 1000 : isOver ? 999 : 3,
-        boxShadow: '0 2px 8px rgb(var(--trip-base-rgb) / 0.12)',
+        border: `1.5px solid ${config.color}30`,
+        background: `${config.color}04`,
+        boxShadow: `0 2px 8px ${config.color}10`,
       }}
     >
       {isOver && (
-        <div className="absolute inset-0 bg-green-400/20 backdrop-blur-[1px] flex items-center justify-center z-50 pointer-events-none rounded-xl">
+        <div className="absolute inset-0 bg-green-400/15 flex items-center justify-center z-50 pointer-events-none rounded-xl">
           <div className="bg-green-500 text-white px-2 py-1 rounded-md text-[10px] font-bold flex items-center gap-1 shadow">
             <Plus size={10} /> Add inside
           </div>
@@ -255,117 +260,126 @@ const ParentBlockCard = memo(({
         </div>
       )}
 
-      {/* Background */}
-      <div className="absolute inset-0">
-        {activity.image ? (
-          <img src={activity.image} alt={activity.title} className="w-full h-full object-cover" loading="lazy" />
+      {/* ── Header strip with image ── */}
+      <div className="absolute top-0 left-0 right-0 z-10 overflow-hidden rounded-t-xl" style={{ height: '24px' }}>
+        {hasImage ? (
+          <>
+            <img src={activity.image} alt="" className="absolute inset-0 w-full h-full object-cover" style={{ objectPosition: 'center 35%' }} loading="lazy" />
+            <div className="absolute inset-0 bg-gradient-to-r from-black/40 via-black/15 to-transparent" />
+          </>
         ) : (
-          <div className="w-full h-full" style={{ background: config.bgGradient }} />
+          <div className="absolute inset-0" style={{ background: `linear-gradient(135deg, ${config.color}30, ${config.color}15)` }} />
         )}
-        <div className="absolute inset-0" style={{
-          background: isExpanded
-            ? 'linear-gradient(180deg, rgba(0,0,0,0.75) 0%, rgba(0,0,0,0.6) 100%)'
-            : 'linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.55) 100%)',
-        }} />
-      </div>
-
-      {/* Header */}
-      <div className="relative z-10 flex items-center gap-1.5 px-2.5 pt-2 pb-1">
-        <div className="w-5 h-5 rounded-md flex items-center justify-center shadow-sm flex-shrink-0" style={{ background: config.color }}>
-          <Icon size={10} className="text-white" />
+        <div className="relative h-full flex items-center gap-1.5 px-2 z-10">
+          <Icon size={10} className={hasImage ? 'text-white/90' : ''} style={hasImage ? undefined : { color: config.color }} />
+          <span className={`text-[10px] font-bold truncate flex-1 ${hasImage ? 'text-white' : ''}`} style={hasImage ? { textShadow: '0 1px 4px rgba(0,0,0,0.5)' } : { color: config.color }}>
+            {activity.title}
+          </span>
+          <button onClick={(e) => { e.stopPropagation(); onAddSubActivity(activity.id); }} className={`p-0.5 rounded transition-colors shrink-0 ${hasImage ? 'hover:bg-white/20' : 'hover:bg-black/5'}`}>
+            <Plus size={11} className={hasImage ? 'text-white/80' : ''} style={hasImage ? undefined : { color: config.color }} />
+          </button>
+          <button onClick={(e) => { e.stopPropagation(); onToggleExpand(activity.id); }} className={`p-0.5 rounded transition-colors shrink-0 ${hasImage ? 'hover:bg-white/20' : 'hover:bg-black/5'}`}>
+            {isExpanded
+              ? <ChevronDown size={10} className={hasImage ? 'text-white/80' : ''} style={hasImage ? undefined : { color: config.color }} />
+              : <ChevronRightIcon size={10} className={hasImage ? 'text-white/80' : ''} style={hasImage ? undefined : { color: config.color }} />}
+          </button>
         </div>
-        <p className="text-white text-[11px] font-bold truncate flex-1 drop-shadow-md">{activity.title}</p>
-        <span className="text-[9px] text-white/50 mr-1 hidden sm:inline">{activity.startTime} – {activity.endTime}</span>
-        {/* Hover delete */}
-        <button
-          onClick={(e) => { e.stopPropagation(); onRemove(activity.id); }}
-          className="p-0.5 rounded hover:bg-red-500/80 bg-red-500/0 transition-colors flex-shrink-0 opacity-0 group-hover:opacity-100"
-          title="Remove"
-        >
-          <X size={11} className="text-white/80" />
-        </button>
-        <button onClick={(e) => { e.stopPropagation(); onToggleExpand(activity.id); }} className="p-0.5 rounded hover:bg-white/20 transition-colors flex-shrink-0">
-          {isExpanded ? <ChevronDown size={12} className="text-white/80" /> : <ChevronRightIcon size={12} className="text-white/80" />}
-        </button>
       </div>
-
-      {/* Collapsed: chip summary */}
-      {!isExpanded && (
-        <div className="relative z-10 px-2.5 mt-0.5">
-          <div className="flex items-center gap-1 flex-wrap">
-            {sortedChildren.slice(0, 3).map((child) => {
-              const cfg = getConfig(child.type);
-              const CIcon = cfg.icon;
-              return (
-                <div key={child.id} className="flex items-center gap-1 px-1.5 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(255,255,255,0.2)', backdropFilter: 'blur(4px)' }}>
-                  <CIcon size={8} className="text-white/90" />
-                  <span className="text-[8px] text-white/90 font-medium truncate max-w-[60px]">{child.title}</span>
-                </div>
-              );
-            })}
-            {sortedChildren.length > 3 && <span className="text-[8px] text-white/50">+{sortedChildren.length - 3}</span>}
-          </div>
+      {/* Image bleed — subtle fade below header */}
+      {hasImage && (
+        <div className="absolute top-[24px] left-0 right-0 h-[18px] z-[0] overflow-hidden pointer-events-none">
+          <img src={activity.image} alt="" className="absolute -top-[24px] left-0 right-0 h-[42px] w-full object-cover opacity-40" style={{ objectPosition: 'center 35%' }} loading="lazy" />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-white" />
         </div>
       )}
 
-      {/* Expanded: time-aligned sub-cards over the image */}
-      {isExpanded && (
-        <div className="absolute inset-0 z-10 pt-[32px]" style={{ pointerEvents: 'none' }}>
+      {/* Hover remove — below header */}
+      <button
+        onClick={(e) => { e.stopPropagation(); onRemove(activity.id); }}
+        className="absolute top-[26px] right-1 w-4 h-4 rounded-full bg-black/40 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-20 hover:bg-red-500"
+      >
+        <X size={8} className="text-white" />
+      </button>
+
+      {/* ── Sub-activities ── */}
+      {isExpanded ? (
+        /* Time-grid-aligned sub-cards */
+        <div className="absolute inset-0">
           {sortedChildren.map((child) => {
             const cfg = getConfig(child.type);
             const CIcon = cfg.icon;
-            const relativeStart = child.startHour - activity.startHour;
-            const topPct = (relativeStart / activity.duration) * 100;
-            const heightPct = (child.duration / activity.duration) * 100;
+            const relTop = (child.startHour - activity.startHour) * HOUR_HEIGHT;
+            const relH = Math.max(child.duration * HOUR_HEIGHT - 2, 28);
             return (
               <div
                 key={child.id}
-                className="absolute left-1 right-1 rounded-lg overflow-hidden cursor-pointer transition-all hover:scale-[1.02] hover:shadow-lg group/sub"
+                className="absolute left-1 right-1 rounded-lg overflow-hidden cursor-pointer group/sub hover:scale-[1.01] transition-all"
                 onClick={(e) => { e.stopPropagation(); onCardClick(child); }}
                 style={{
-                  top: `${topPct}%`,
-                  height: `${Math.max(heightPct, 5)}%`,
-                  minHeight: '20px',
-                  pointerEvents: 'auto',
-                  backgroundColor: `${cfg.color}dd`,
-                  backdropFilter: 'blur(4px)',
+                  top: `${relTop}px`, height: `${relH}px`,
+                  boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
                 }}
               >
-                <div className="flex items-center gap-1 px-1.5 h-full">
-                  <CIcon size={9} className="text-white/90 flex-shrink-0" />
-                  <span className="text-[9px] font-semibold text-white truncate leading-tight">{child.title}</span>
-                  <span className="text-[7px] text-white/50 ml-auto flex-shrink-0 hidden sm:inline">{child.startTime}</span>
-                  {/* Sub-activity delete */}
-                  <button
-                    onClick={(e) => { e.stopPropagation(); onRemove(child.id); }}
-                    className="p-0.5 rounded opacity-0 group-hover/sub:opacity-100 hover:bg-white/20 transition-all flex-shrink-0"
-                  >
-                    <X size={8} className="text-white/80" />
-                  </button>
+                {/* Sub-card background */}
+                {child.image ? (
+                  <>
+                    <img src={child.image} alt={child.title} className="absolute inset-0 w-full h-full object-cover group-hover/sub:scale-105 transition-transform duration-300" loading="lazy" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+                  </>
+                ) : (
+                  <div className="absolute inset-0" style={{ background: cfg.bgGradient }} />
+                )}
+                {/* Sub-card icon — top right */}
+                <div className="absolute top-1 right-1 w-4 h-4 rounded flex items-center justify-center shrink-0 z-[1]" style={{ background: cfg.color }}>
+                  <CIcon size={8} className="text-white" />
                 </div>
+                {/* Sub-card content — bottom */}
+                <div className="relative h-full flex items-end px-1.5 pb-1">
+                  <span className={`text-[9px] font-semibold truncate flex-1 ${child.image ? 'text-white drop-shadow-md' : 'text-gray-800'}`}>{child.title}</span>
+                  <span className={`text-[8px] shrink-0 ml-1 ${child.image ? 'text-white/50' : 'text-gray-400'}`}>{child.startTime}</span>
+                </div>
+                {/* Sub-card hover remove */}
+                <button
+                  onClick={(e) => { e.stopPropagation(); onRemove(child.id); }}
+                  className="absolute top-0.5 right-0.5 w-4 h-4 rounded-full bg-black/30 flex items-center justify-center opacity-0 group-hover/sub:opacity-100 hover:bg-red-500 transition-all z-10"
+                >
+                  <X size={7} className="text-white" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        /* Collapsed — compact list below header */
+        <div className="absolute inset-x-0 top-[26px] bottom-0 overflow-hidden px-1 py-0.5 space-y-[2px]">
+          {sortedChildren.map((child) => {
+            const cfg = getConfig(child.type);
+            const CIcon = cfg.icon;
+            return (
+              <div
+                key={child.id}
+                className="flex items-center gap-1.5 px-1.5 py-[3px] rounded-md cursor-pointer hover:bg-white/80 transition-colors group/item"
+                onClick={(e) => { e.stopPropagation(); onCardClick(child); }}
+                style={{ background: `${cfg.color}12` }}
+              >
+                <div className="w-3.5 h-3.5 rounded flex items-center justify-center shrink-0" style={{ background: cfg.color }}>
+                  <CIcon size={7} className="text-white" />
+                </div>
+                <span className="text-[9px] font-semibold text-gray-700 truncate flex-1">{child.title}</span>
+                <span className="text-[8px] text-gray-400 shrink-0">{child.startTime}</span>
+                <button
+                  onClick={(e) => { e.stopPropagation(); onRemove(child.id); }}
+                  className="w-3.5 h-3.5 rounded-full flex items-center justify-center opacity-0 group-hover/item:opacity-100 hover:bg-red-100 transition-all shrink-0"
+                >
+                  <X size={7} className="text-red-400" />
+                </button>
               </div>
             );
           })}
         </div>
       )}
 
-      {/* Bottom */}
-      {!isExpanded && cardHeight > 80 && (
-        <div className="absolute bottom-0 left-0 right-0 z-10 px-2.5 pb-1.5">
-          <div className="flex items-center gap-1.5">
-            {activity.rating && (
-              <div className="flex items-center gap-0.5">
-                <Star size={8} className="fill-yellow-400 text-yellow-400" />
-                <span className="text-[9px] text-white font-semibold">{activity.rating}</span>
-              </div>
-            )}
-            {activity.price && <span className="text-[9px] text-white/70 font-medium">{activity.price}</span>}
-            <span className="text-[9px] bg-white/20 text-white px-1.5 py-0.5 rounded-full font-medium ml-auto">{childActivities.length} activities</span>
-          </div>
-        </div>
-      )}
-
-      <div className="absolute inset-0 z-[5]" onClick={(e) => { e.stopPropagation(); if (!isDragging) onCardClick(activity); }} style={{ pointerEvents: isExpanded ? 'none' : 'auto' }} />
+      {!isExpanded && <div className="absolute inset-0 z-[5]" onClick={(e) => { e.stopPropagation(); if (!isDragging) onCardClick(activity); }} />}
     </div>
   );
 });
@@ -400,13 +414,11 @@ const CalendarCard = memo(({
   }), [activity.id, onSwapActivities]);
 
   const config = getConfig(activity.type);
-  const Icon = config.icon;
   const dayWidth = 100 / totalDays;
   const left = activity.day * dayWidth;
   const topPx = (activity.startHour - 7) * HOUR_HEIGHT;
   const heightPx = activity.duration * HOUR_HEIGHT;
   const cardHeight = Math.max(heightPx - 2, HOUR_HEIGHT * 0.85);
-  const isTiny = cardHeight < 50;
   const blockCollaborator = collaborators.find((c) => c.selectedBlockId === activity.id);
 
   return (
@@ -417,16 +429,15 @@ const CalendarCard = memo(({
         isOver ? 'ring-2 ring-amber-400 ring-offset-1 z-40 scale-[1.02]' : 'hover:shadow-lg hover:z-30 hover:scale-[1.01]'
       }`}
       style={{
-        left: `${left}%`, width: `calc(${dayWidth}% - 8px)`,
+        left: `${left}%`, width: `calc(${dayWidth}% - 6px)`,
         top: `${topPx}px`, height: `${cardHeight}px`,
-        margin: '1px 4px',
+        margin: '1px 3px',
         opacity: isDragging ? 0.3 : isDimmed ? 0.3 : 1,
         transition: 'opacity 0.2s',
         zIndex: isDragging ? 1000 : isOver ? 999 : 2,
         boxShadow: blockCollaborator
-          ? `0 0 0 2px ${blockCollaborator.color}, 0 1px 4px rgba(0,0,0,0.08)`
-          : '0 1px 4px rgba(0,0,0,0.08)',
-        borderLeft: `4px solid ${config.color}`,
+          ? `0 0 0 2px ${blockCollaborator.color}, 0 2px 8px rgba(0,0,0,0.12)`
+          : '0 2px 8px rgba(0,0,0,0.1)',
       }}
     >
       {blockCollaborator && (
@@ -443,46 +454,39 @@ const CalendarCard = memo(({
         </div>
       )}
 
-      {/* Hover actions */}
-      <div className="absolute top-1 right-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-20">
-        <button
-          onClick={(e) => { e.stopPropagation(); onRemove(activity.id); }}
-          className="p-1 bg-red-500/90 hover:bg-red-600 backdrop-blur-sm rounded-md cursor-pointer transition-colors"
-          title="Remove"
-        >
-          <X size={10} className="text-white" />
-        </button>
-        <div className="p-0.5 bg-black/30 backdrop-blur-sm rounded">
-          <GripVertical size={10} className="text-white" />
+      {/* Hover remove */}
+      <button
+        onClick={(e) => { e.stopPropagation(); onRemove(activity.id); }}
+        className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-black/40 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity z-20 hover:bg-red-500"
+      >
+        <X size={9} className="text-white" />
+      </button>
+
+      <div className="h-full w-full relative overflow-hidden">
+        {activity.image ? (
+          <img src={activity.image} alt={activity.title} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" loading="lazy" />
+        ) : (
+          <div className="absolute inset-0" style={{ background: config.bgGradient }} />
+        )}
+        {activity.image && <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-black/5 pointer-events-none" />}
+        <div className="absolute bottom-0 left-0 right-0 px-2 pb-1.5 z-10">
+          {activity.image ? (
+            <>
+              <p className="text-white text-[11px] font-semibold truncate leading-tight drop-shadow-md">{activity.title}</p>
+              {cardHeight >= 60 && (
+                <p className="text-white/60 text-[9px] mt-0.5 truncate">{activity.startTime}</p>
+              )}
+            </>
+          ) : (
+            <>
+              <p className={`text-[11px] font-semibold truncate leading-tight ${config.textColor}`}>{activity.title}</p>
+              {cardHeight >= 60 && (
+                <p className="text-gray-400 text-[9px] mt-0.5 truncate">{activity.startTime}</p>
+              )}
+            </>
+          )}
         </div>
       </div>
-
-      {isTiny ? (
-        <div className="h-full flex items-center gap-1.5 px-2 overflow-hidden" style={{ background: config.bgGradient }}>
-          <div className={`w-3.5 h-3.5 rounded flex items-center justify-center flex-shrink-0 ${config.dotColor}`}>
-            <Icon size={8} className="text-white" />
-          </div>
-          <span className={`text-[10px] font-semibold ${config.textColor} truncate`}>{activity.title}</span>
-        </div>
-      ) : (
-        <div className="h-full w-full relative overflow-hidden">
-          {activity.image ? (
-            <img src={activity.image} alt={activity.title} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" loading="lazy" />
-          ) : (
-            <div className="absolute inset-0" style={{ background: config.bgGradient }} />
-          )}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/10 to-transparent pointer-events-none" />
-          <div className="absolute top-1.5 left-1.5 w-5 h-5 rounded-md flex items-center justify-center shadow-md z-10" style={{ background: config.color }}>
-            <Icon size={10} className="text-white" />
-          </div>
-          <div className="absolute bottom-0 left-0 right-0 px-2 pb-1.5 pt-3 z-10">
-            <p className="text-white text-[10px] font-semibold truncate leading-tight drop-shadow-md">{activity.title}</p>
-            {cardHeight >= 65 && (
-              <p className="text-white/65 text-[9px] mt-0.5 truncate">{activity.startTime} – {activity.endTime}</p>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 });
@@ -520,12 +524,11 @@ DropZone.displayName = 'DropZone';
 // ─── Day Header ─────────────────────────────────────────────
 
 const DraggableDayHeader = memo(({
-  day, dayMeta, onSwapDays, activityCount, isSelected, onSelectDay,
+  day, dayMeta, onSwapDays, isSelected, onSelectDay,
 }: {
   day: number;
   dayMeta: { dayLabel: string; dateLabel: string; theme: string } | undefined;
   onSwapDays: (d1: number, d2: number) => void;
-  activityCount: number;
   isSelected: boolean;
   onSelectDay: (day: number) => void;
 }) => {
@@ -557,14 +560,6 @@ const DraggableDayHeader = memo(({
         <div className={`text-sm font-bold mt-0.5 leading-none ${isSelected ? 'text-gray-900' : 'text-gray-500'}`}>
           {dayMeta?.dayLabel ?? `Day ${day + 1}`}
         </div>
-        {dayMeta?.theme && (
-          <div className={`text-[9px] mt-0.5 font-medium ${isSelected ? '' : 'text-gray-400'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>{dayMeta.theme}</div>
-        )}
-        <div className="flex items-center justify-center gap-0.5 mt-1">
-          {activityCount > 0 ? Array.from({ length: Math.min(activityCount, 5) }).map((_, i) => (
-            <div key={i} className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: isSelected ? NAVY : '#d1d5db' }} />
-          )) : <span className="text-[8px] text-gray-300">--</span>}
-        </div>
       </div>
     </div>
   );
@@ -582,7 +577,7 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
   const { activities, setActivities } = useItineraryContext();
   const [selectedActivity, setSelectedActivity] = useState<CalendarActivity | null>(null);
   const [showLeftPanel, setShowLeftPanel] = useState(false);
-  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set(['cal-disney']));
+  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
   const [collaborators] = useState<CollaboratorPresence[]>(MOCK_COLLABORATORS);
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
 
@@ -605,11 +600,6 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
     return activities.filter((a) => a.onCalendar && !a.parentId);
   }, [activities]);
 
-  const activityCountPerDay = useMemo(() => {
-    const counts: Record<number, number> = {};
-    calendarActivities.forEach((a) => { counts[a.day] = (counts[a.day] || 0) + 1; });
-    return counts;
-  }, [calendarActivities]);
 
   const filteredDiscoverPlaces = useMemo(() => {
     return DISCOVER_PLACES.filter((p) => {
@@ -667,6 +657,49 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
     const dm = minute === 0 ? '00' : minute < 10 ? `0${minute}` : String(minute);
     return `${dh}:${dm} ${period}`;
   }, []);
+
+  const handleAddSubActivity = useCallback((parentId: string) => {
+    const parent = activities.find((a) => a.id === parentId);
+    if (!parent) return;
+
+    const children = getChildren(parentId, activities);
+    const usedHours = new Set<number>();
+    children.forEach((c) => {
+      for (let h = Math.floor(c.startHour); h < Math.ceil(c.startHour + c.duration); h++) usedHours.add(h);
+    });
+
+    // Find first available hour within parent's range
+    const parentEnd = parent.startHour + parent.duration;
+    let startHour = Math.ceil(parent.startHour);
+    for (let h = startHour; h < parentEnd - 1; h++) {
+      if (!usedHours.has(h)) { startHour = h; break; }
+    }
+
+    const end = startHour + 1;
+    const newActivity: CalendarActivity = {
+      id: `cal-sub-${Date.now()}`,
+      title: 'New Activity',
+      type: 'sightseeing',
+      day: parent.day,
+      startHour,
+      duration: 1,
+      startTime: formatTime(startHour, 0),
+      endTime: formatTime(Math.floor(end), (end % 1) * 60),
+      color: getConfig('sightseeing').color,
+      onCalendar: true,
+      parentId,
+    };
+
+    // Make sure parent is expanded (remove from collapsed set)
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      next.delete(parentId);
+      return next;
+    });
+
+    setActivities((prev) => [...prev, newActivity]);
+    setSelectedActivity(newActivity);
+  }, [activities, formatTime]);
 
   const handleDrop = useCallback((activityId: string, newDay: number, newStartHour: number, fromDiscover?: boolean, place?: DiscoverPlace) => {
     if (fromDiscover && place) {
@@ -758,10 +791,10 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
 
   return (
     <DndProvider backend={HTML5Backend}>
-      <div className="w-full h-[calc(100vh-220px)] min-h-[600px] flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white relative">
+      <div className="w-full h-full min-h-[600px] flex flex-col overflow-hidden bg-white relative">
 
-        {/* ── Minimal Toolbar ──────────────────────────────────── */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-100 flex-shrink-0 bg-white">
+        {/* ── Toolbar ─────────────────────────────────────────── */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-gray-100 flex-shrink-0 bg-white">
           <div className="flex items-center gap-3">
             <button
               onClick={() => setShowLeftPanel(!showLeftPanel)}
@@ -776,9 +809,7 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
               <span>Discover {destination}</span>
             </button>
           </div>
-
           <div className="flex items-center gap-3">
-            {/* Collaborator avatars — subtle */}
             <div className="flex -space-x-1.5">
               {collaborators.filter((c) => c.isOnline).map((c) => (
                 <div
@@ -790,10 +821,6 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
                   {c.avatarInitial}
                 </div>
               ))}
-            </div>
-            <div className="hidden md:flex items-center gap-1.5 text-[10px] text-gray-400">
-              <StickyNote size={10} />
-              <span>Double-click to add note</span>
             </div>
             <div className="text-[11px] text-gray-400 font-medium">
               {calendarActivities.length} planned
@@ -910,7 +937,6 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
                       <DraggableDayHeader
                         key={i} day={i} dayMeta={dayMetas[i]}
                         onSwapDays={handleSwapDays}
-                        activityCount={activityCountPerDay[i] || 0}
                         isSelected={selectedDay === null || selectedDay === i}
                         onSelectDay={handleSelectDay}
                       />
@@ -964,6 +990,7 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
                         totalDays={totalDays}
                         expandedParents={expandedParents}
                         onToggleExpand={handleToggleExpand}
+                        onAddSubActivity={handleAddSubActivity}
                         collaborators={collaborators}
                         isDimmed={selectedDay !== null && selectedDay !== activity.day}
                       />
@@ -1043,6 +1070,36 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
                         </div>
                       );
                     })}
+
+                    {/* ── Collaborator cursors (Figma-style) ── */}
+                    {collaborators.filter((c) => c.isOnline && c.cursor && c.userId !== 'user-1').map((c) => {
+                      const cDayWidth = 100 / totalDays;
+                      const cursorLeft = c.cursor!.day * cDayWidth;
+                      const cursorTop = (c.cursor!.hour - 7) * HOUR_HEIGHT;
+                      const isDimmedCursor = selectedDay !== null && selectedDay !== c.cursor!.day;
+                      return (
+                        <div
+                          key={`cursor-${c.userId}`}
+                          className="absolute z-[8] pointer-events-none"
+                          style={{
+                            left: `calc(${cursorLeft}% + 10px)`,
+                            top: `${cursorTop}px`,
+                            opacity: isDimmedCursor ? 0.2 : 1,
+                            transition: 'left 0.7s cubic-bezier(.4,0,.2,1), top 0.7s cubic-bezier(.4,0,.2,1), opacity 0.3s',
+                          }}
+                        >
+                          <svg width="12" height="16" viewBox="0 0 12 16" className="drop-shadow-md" style={{ filter: `drop-shadow(0 1px 2px ${c.color}40)` }}>
+                            <path d="M0 0L12 9L6.5 9L4 16L0 0Z" fill={c.color} stroke="white" strokeWidth="1" />
+                          </svg>
+                          <div
+                            className="absolute top-3 left-2 px-1.5 py-[2px] rounded-md text-[8px] font-bold text-white whitespace-nowrap shadow-sm"
+                            style={{ background: c.color }}
+                          >
+                            {c.name}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               </div>
@@ -1114,7 +1171,7 @@ export function CalendarView({ destination = 'Paris' }: CalendarViewProps) {
                           const cfg = getConfig(child.type);
                           const CIcon = cfg.icon;
                           return (
-                            <div key={child.id} className="flex items-center gap-2 p-2 rounded-lg border-l-[3px]" style={{ borderColor: cfg.color, background: cfg.bgGradient }}>
+                            <div key={child.id} className="flex items-center gap-2 p-2 rounded-lg" style={{ background: cfg.bgGradient }}>
                               <div className={`w-5 h-5 rounded flex items-center justify-center flex-shrink-0 ${cfg.dotColor}`}>
                                 <CIcon size={9} className="text-white" />
                               </div>

--- a/apps/web/components/itinerary/CompactActivityCard.tsx
+++ b/apps/web/components/itinerary/CompactActivityCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Heart, Clock, MapPin, Star, ChevronLeft, ChevronRight, CalendarCheck } from 'lucide-react';
-import { getActivityTypeColor } from '@travyl/shared';
+import { getActivityTypeColor, Navy } from '@travyl/shared';
 import type { ActivityViewModel } from '@travyl/shared';
 
 interface CompactActivityCardProps {
@@ -52,20 +52,15 @@ export function CompactActivityCard({
             onError={() => setImgError(true)}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <MapPin size={28} style={{ color: typeColor.primary + '30' }} />
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ background: `linear-gradient(135deg, ${Navy.DEFAULT}, #2563eb)` }}
+          >
+            <MapPin size={28} className="text-white/30" />
           </div>
         )}
 
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
-
-        {/* Type badge */}
-        <span
-          className="absolute top-2 left-2 text-[10px] font-semibold px-2 py-0.5 rounded-lg text-white"
-          style={{ backgroundColor: typeColor.primary + 'cc' }}
-        >
-          {activity.category}
-        </span>
 
         {/* Favorite button */}
         <button
@@ -159,13 +154,6 @@ export function CompactActivityCard({
           <p className="text-[10px] text-gray-600 mt-1 line-clamp-2 leading-relaxed">{activity.notes}</p>
         )}
 
-        {/* Tags */}
-        <div className="flex flex-wrap gap-1 mt-1.5">
-          <span className="px-2 py-0.5 rounded-md text-[9px] bg-gray-100 border border-gray-200 text-gray-500">{activity.category}</span>
-          {activity.costDisplay && (
-            <span className="px-2 py-0.5 rounded-md text-[9px] bg-gray-100 border border-gray-200 text-gray-500">{activity.costDisplay}</span>
-          )}
-        </div>
 
         {/* Booked info bar */}
         {activity.startTime && (

--- a/apps/web/components/itinerary/ListActivityCard.tsx
+++ b/apps/web/components/itinerary/ListActivityCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Heart, Clock, Star, Image as ImageIcon } from 'lucide-react';
-import { getActivityTypeColor } from '@travyl/shared';
+import { Heart, Clock, Star, MapPin } from 'lucide-react';
+import { getActivityTypeColor, Navy } from '@travyl/shared';
 import type { ActivityViewModel } from '@travyl/shared';
 
 interface ListActivityCardProps {
@@ -41,8 +41,11 @@ export function ListActivityCard({
             onError={() => setImgError(true)}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <ImageIcon size={14} style={{ color: typeColor.primary + '40' }} />
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ background: `linear-gradient(135deg, ${Navy.DEFAULT}, #2563eb)` }}
+          >
+            <MapPin size={14} className="text-white/30" />
           </div>
         )}
       </div>
@@ -51,12 +54,6 @@ export function ListActivityCard({
       <div className="flex-1 min-w-0">
         <h3 className="text-[13px] font-semibold text-gray-900 line-clamp-1">{activity.name}</h3>
         <div className="flex items-center gap-2.5 mt-0.5 text-[11px] text-gray-500">
-          <span
-            className="font-medium"
-            style={{ color: typeColor.primary }}
-          >
-            {activity.category}
-          </span>
           {activity.startTime && (
             <span className="flex items-center gap-0.5">
               <Clock size={9} className="text-gray-400" />

--- a/apps/web/components/itinerary/MinimalActivityCard.tsx
+++ b/apps/web/components/itinerary/MinimalActivityCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Heart, Clock, Star, Image as ImageIcon } from 'lucide-react';
-import { getActivityTypeColor } from '@travyl/shared';
+import { Heart, Clock, Star, MapPin } from 'lucide-react';
+import { getActivityTypeColor, Navy } from '@travyl/shared';
 import type { ActivityViewModel } from '@travyl/shared';
 
 interface MinimalActivityCardProps {
@@ -41,22 +41,17 @@ export function MinimalActivityCard({
             onError={() => setImgError(true)}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <ImageIcon size={20} style={{ color: typeColor.primary + '40' }} />
+          <div
+            className="w-full h-full flex items-center justify-center"
+            style={{ background: `linear-gradient(135deg, ${Navy.DEFAULT}, #2563eb)` }}
+          >
+            <MapPin size={20} className="text-white/30" />
           </div>
         )}
       </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-0.5">
-          <span
-            className="text-[9px] font-semibold px-1.5 py-0.5 rounded"
-            style={{ backgroundColor: typeColor.bg, color: typeColor.primary }}
-          >
-            {activity.category}
-          </span>
-        </div>
         <h3 className="text-sm font-semibold text-gray-900 line-clamp-1">{activity.name}</h3>
         <div className="flex items-center gap-3 mt-1 text-xs text-gray-500">
           {activity.timeDisplay && (

--- a/apps/web/components/itinerary/SplitScreenModal.tsx
+++ b/apps/web/components/itinerary/SplitScreenModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { motion } from 'motion/react';
 import {
   X, ChevronLeft, ChevronRight, Search, SlidersHorizontal,
   Heart, Share2, Star, MapPin, Clock, Check, XCircle,
@@ -652,13 +653,24 @@ export function SplitScreenModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.25 }}
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
 
       {/* Modal */}
       <div className="relative w-full h-full md:w-[90vw] md:max-w-7xl md:h-[90vh] md:rounded-2xl bg-white shadow-2xl overflow-hidden flex flex-col md:flex-row">
 
         {/* ── Left Panel: Content ── */}
-        <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        <motion.div
+          initial={{ opacity: 0, x: -120, rotate: -2 }}
+          animate={{ opacity: 1, x: 0, rotate: 0 }}
+          transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+          className="flex-1 flex flex-col min-w-0 overflow-hidden"
+        >
 
           {/* Header */}
           <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 shrink-0">
@@ -764,12 +776,17 @@ export function SplitScreenModal({
               {currentItem.isBooked ? 'View Booking' : 'Book Now'}
             </button>
           </div>
-        </div>
+        </motion.div>
 
         {/* ── Right Panel: Map (desktop only) ── */}
-        <div className="hidden md:block w-[380px] shrink-0 border-l border-gray-200 p-3">
+        <motion.div
+          initial={{ opacity: 0, x: 120, rotate: 2 }}
+          animate={{ opacity: 1, x: 0, rotate: 0 }}
+          transition={{ duration: 0.7, delay: 0.1, ease: [0.22, 1, 0.36, 1] }}
+          className="hidden md:block w-[380px] shrink-0 border-l border-gray-200 p-3"
+        >
           <MapPanel item={currentItem} />
-        </div>
+        </motion.div>
       </div>
     </div>
   );

--- a/apps/web/components/itinerary/TimeGroupSection.tsx
+++ b/apps/web/components/itinerary/TimeGroupSection.tsx
@@ -92,13 +92,14 @@ export function TimeGroupSection({ group, onActivityClick, onAddActivity, cardSt
       >
         <div className={`mt-2.5 ${cardStyle === 'pin' ? 'grid grid-cols-2 gap-2.5' : 'space-y-2.5'}`}>
           {group.activities.map((activity, i) => (
-            <ActivityCardRenderer
-              key={activity.id}
-              activity={activity}
-              cardStyle={cardStyle}
-              index={i}
-              onClick={() => onActivityClick?.(activity.id)}
-            />
+            <div key={activity.id} data-activity-id={activity.id}>
+              <ActivityCardRenderer
+                activity={activity}
+                cardStyle={cardStyle}
+                index={i}
+                onClick={() => onActivityClick?.(activity.id)}
+              />
+            </div>
           ))}
 
           {/* Add Activity button */}


### PR DESCRIPTION
## Summary
- Parent block cards: colored header strip with image
- Blocks expanded by default (toggle to collapse)
- Add sub-activity button per parent block
- Updated activity card styling for consistency across all variants

## Test plan
- [ ] Parent blocks show header strip with image
- [ ] Expand/collapse toggle works
- [ ] Add sub-activity button appears
- [ ] All activity card variants render correctly