### PR TITLE
fix: resolve corrupted files and remaining build errors

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Navbar from "@/components/navbar";
 
 export default function MainLayout({
@@ -7,7 +8,9 @@ export default function MainLayout({
 }) {
   return (
     <>
-      <Navbar />
+      <Suspense>
+        <Navbar />
+      </Suspense>
       <main className="pt-11">{children}</main>
     </>
   );

--- a/apps/web/app/(main)/trips/page.tsx
+++ b/apps/web/app/(main)/trips/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useTrips, MOCK_TRIPS } from '@travyl/shared';
@@ -70,6 +70,25 @@ function SkeletonCard() {
 }
 
 export default function MyTripsPage() {
+  return (
+    <Suspense fallback={
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">My Trips</h1>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    }>
+      <MyTripsContent />
+    </Suspense>
+  );
+}
+
+function MyTripsContent() {
   const searchParams = useSearchParams();
   const statusParam = (searchParams.get('status') as StatusFilter) || 'all';
   const searchQuery = searchParams.get('search') || '';

--- a/apps/web/components/home/TagUs.tsx
+++ b/apps/web/components/home/TagUs.tsx
@@ -1,73 +1,104 @@
 "use client";
 
 import { motion } from "motion/react";
-import {
-  useMosaicTiles,
-  TILE_CATEGORY_GRADIENTS,
-  TileCategoryColors,
-  EASE_OUT_EXPO
-} from "@travyl/shared";
-import type { TileCategory, MosaicTile } from "@travyl/shared";
+import { Camera } from "lucide-react";
+import { SOCIAL_HASHTAGS, SOCIAL_LINKS, CATEGORY_GRADIENT_CYCLE, EASE_OUT_EXPO, useTagUsDestinations } from "@travyl/shared";
 
-const PLACEHOLDER_TILES: MosaicTile[] = [
-  { id: 'p-1', name: 'Santorini, Greece', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1570077188670-e3a8d69ac5ff?w=800&fit=crop', gridSpan: [3, 2] },
-  { id: 'p-2', name: 'Bali, Indonesia', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1539367628448-4bc5c9d171c8?w=800&fit=crop', gridSpan: [3, 1] },
-  { id: 'p-3', name: 'Eiffel Tower, Paris', category: 'attraction', tagline: '', image_url: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-4', name: 'Cappadocia, Turkey', category: 'experience', tagline: '', image_url: 'https://images.unsplash.com/photo-1641128324972-af3212f0f6bd?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-5', name: 'Fine Dining, Italy', category: 'dining', tagline: '', image_url: 'https://images.unsplash.com/photo-1428515613728-6b4607e44363?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-6', name: 'Maldives', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1514282401047-d79a71a590e8?w=800&fit=crop', gridSpan: [2, 2] },
-  { id: 'p-7', name: 'Machu Picchu, Peru', category: 'attraction', tagline: '', image_url: 'https://images.unsplash.com/photo-1587595431973-160d0d163abd?w=600&fit=crop', gridSpan: [2, 1]},
-  { id: 'p-8', name: 'Northern Lights, Iceland', category: 'experience', tagline: '', image_url: 'https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=600&fit=crop', gridSpan: [2, 1] }
-  { id: 'p-9', name: 'Tokyo, Japan', category: 'dining', tagline: '', image_url: 'https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=600&fit=crop', gridSpan: [2, 1] }
-  { id: 'p-10', name: 'Kyoto, Japan', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1493976040374-85c8e12f0c0e?w=600&fit=crop', gridSpan: [2, 1] },
-];
-
-const PLACEholderTiles: MosaicTile[] = PlaceholderTiles;
-
-  const { data: dbTiles, isLoading } => useMosaicTiles();
-  const tiles = dbTiles?.length ? dbTiles?.placeholders
-    ? <div className="flex-1 overflow-hidden md:flex" items-center gap-6 mb-1"
-              <div className="w-7 h-7 rounded-full bg-[#1e3a5f] flex items-center justify-center"          <PaperPlane size={14} className="text-white- rotate-[8deg]" />
-        </div>
-      </div>
-
-      {/* Quick chips */}
-      <div className="flex flex-wrap gap-1.5 mb-4">
-        {[
-          'https://images.unsplash.com/photo-1534308983496-4fabb1a015ee?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1503614282401047-d79a71a590e8?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1519681393784-d120267933ba?w=600&fit=crop',
-        ]
-      </motion.div>
-    );
+function SocialIcon({ platform }: { platform: string }) {
+  const props = { width: 20, height: 20, viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const, className: 'text-foreground' };
+  switch (platform) {
+    case 'twitter':
+    case 'x':
+      return <svg {...props}><path d="M4 4l11.733 16H20L8.267 4z" /><path d="M4 20l6.768-6.768M15.232 10.232L20 4" /></svg>;
+    case 'facebook':
+      return <svg {...props}><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" /></svg>;
+    case 'tiktok':
+      return <svg {...props}><path d="M9 12a4 4 0 1 0 4 4V4a5 5 0 0 0 5 5" /></svg>;
+    default: // instagram
+      return <svg {...props}><rect x="2" y="2" width="20" height="20" rx="5" /><circle cx="12" cy="12" r="5" /><circle cx="17.5" cy="6.5" r="1.5" fill="currentColor" stroke="none" /></svg>;
   }
 }
 
-export function TravelMosaic() {
-  const { data: dbTiles, isLoading } = useMosaicTiles()
-  const tiles = dbTiles?.length ? dbTiles?.placeholders) ? <div className="flex-1 overflow-hidden md:flex" items-center gap-6 mb-1"
-              <div className="w-7 h-7 rounded-full bg-[#1e3a5f] flex items-center justify-center"          <PaperPlane size={14} className="text-white -rotate-[8deg]" />
-        </div>
-      </div>
+export function TagUs() {
+  const destinations = useTagUsDestinations();
 
-      {/* Desktop: 6-col grid */}
-      <div
-        className="hidden md:grid grid-cols-6 auto-rows-[120px] gap-3"
-        styles={{ gridAutoFlow: "dense" }}
-      >
-        {tiles.map((tile, i) => {
-          const grad = TILECategoryGradients[tile.category as TileCategory];
-          const color = TILECategoryColors[tile.category as TileCategory]
-          ? (
-          const grad = TILECategoryColors[tile.category]
-            : else {
-              const grad = TileCategoryGradients[tile.category]
-              ? undefined
-            }
+  return (
+    <section className="py-16 px-6">
+      <div className="max-w-6xl mx-auto text-center">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, ease: EASE_OUT_EXPO }}
+          className="text-2xl md:text-3xl font-bold text-foreground mb-8"
+        >
+          Tag us on your <span className="font-extrabold">Next Trip</span>
+        </motion.h2>
+
+        {/* Photo placeholders */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          {CATEGORY_GRADIENT_CYCLE.map((grad, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.4, delay: i * 0.08, ease: EASE_OUT_EXPO }}
+              whileHover={{ scale: 1.03 }}
+              className="aspect-square rounded-2xl relative overflow-hidden cursor-pointer group"
+              style={{
+                background: `linear-gradient(135deg, ${grad.from}, ${grad.to})`,
+              }}
+            >
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
+                <Camera size={28} className="text-white/40 group-hover:text-white/60 transition-colors" />
+                <span className="text-white/50 text-xs font-medium group-hover:text-white/70 transition-colors">
+                  {destinations[i]}
+                </span>
+              </div>
+              <div className="absolute bottom-3 left-3">
+                <span className="text-white/30 text-xs font-medium">
+                  @travyl
+                </span>
+              </div>
+            </motion.div>
+          ))}
         </div>
+
+        {/* Social icons */}
+        <motion.div
+          initial={{ opacity: 0, y: 15 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4, delay: 0.3, ease: EASE_OUT_EXPO }}
+          className="flex items-center justify-center gap-4 mb-4"
+        >
+          {SOCIAL_LINKS.map((link) => (
+            <a
+              key={link.platform}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-10 h-10 rounded-full bg-foreground/10 flex items-center justify-center hover:bg-foreground/20 transition-colors"
+              title={link.platform}
+            >
+              <SocialIcon platform={link.platform} />
+            </a>
+          ))}
+        </motion.div>
+
+        {/* Hashtags */}
+        <motion.p
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4, delay: 0.4, ease: EASE_OUT_EXPO }}
+          className="text-sm text-muted-foreground"
+        >
+          {SOCIAL_HASHTAGS.join(" ")}
+        </motion.p>
       </div>
-    );
-  }
+    </section>
+  );
 }
-

--- a/apps/web/components/home/TravelMosaic.tsx
+++ b/apps/web/components/home/TravelMosaic.tsx
@@ -3,102 +3,130 @@
 import { motion } from "motion/react";
 import {
   useMosaicTiles,
-  TILE_CATEGORY_GRADIENTS
-  TILECategoryColors,
+  TILE_CATEGORY_GRADIENTS,
+  TILE_CATEGORY_COLORS,
   EASE_OUT_EXPO,
 } from "@travyl/shared";
 import type { TileCategory, MosaicTile } from "@travyl/shared";
 
 const PLACEHOLDER_TILES: MosaicTile[] = [
-  { id: 'p-1', name: 'Santorini, Greece', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1570077188670-e3a8d69ac5ff?w=800&fit=crop', gridSpan: [3, 2] },
-  { id: 'p-2', name: 'Bali, Indonesia', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1539367628448-4bc5c9d171c8?w=800&fit=crop', gridSpan: [3, 1] },
-  { id: 'p-3', name: 'Eiffel Tower, Paris', category: 'attraction', tagline: '', image_url: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-4', name: 'Cappadocia, Turkey', category: 'experience', tagline: '', image_url: 'https://images.unsplash.com/photo-1641128324972-af3212f0f6bd?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-5', name: 'Fine Dining, Italy', category: 'dining', tagline: '', image_url: 'https://images.unsplash.com/photo-1428515613728-6b4607e44363?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-6', name: 'Maldives', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1514282401047-d79a71a590e8?w=800&fit=crop', gridSpan: [2, 2] },
-  { id: 'p-7', name: 'Machu Picchu, Peru', category: 'attraction', tagline: '', image_url: 'https://images.unsplash.com/photo-1587595431973-160d0d163abd?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-8', name: 'Northern Lights, Iceland', category: 'experience', tagline: '', image_url: 'https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-9', name: 'Tokyo, Japan', category: 'dining', tagline: '', image_url: 'https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=600&fit=crop', gridSpan: [2, 1] },
-  { id: 'p-10', name: 'Kyoto, Japan', category: 'destination', tagline: '', image_url: 'https://images.unsplash.com/photo-1493976040374-85c8e12f0c0e?w=600&fit=crop', gridSpan: [2, 1] },
+  { id: 'p-1', name: '', category: 'destination', tagline: '', image_url: null, gridSpan: [3, 2] },
+  { id: 'p-2', name: '', category: 'destination', tagline: '', image_url: null, gridSpan: [3, 2] },
+  { id: 'p-3', name: '', category: 'attraction', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-4', name: '', category: 'experience', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-5', name: '', category: 'dining', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-6', name: '', category: 'destination', tagline: '', image_url: null, gridSpan: [2, 2] },
+  { id: 'p-7', name: '', category: 'attraction', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-8', name: '', category: 'experience', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-9', name: '', category: 'dining', tagline: '', image_url: null, gridSpan: [2, 1] },
+  { id: 'p-10', name: '', category: 'destination', tagline: '', image_url: null, gridSpan: [2, 1] },
 ];
 
-const PLACEHolderTILES: MosaicTile[] = PLACEHolder_Tiles;
-
-  const { data: dbTiles, isLoading: => = useMosaicTiles();
-  const tiles = dbTiles?.length ? dbTiles?. placeholders
-    ? <div className="flex-1 overflow-hidden md:flex" items-center gap-6 mb-1"
-              <div className="w-7 h-7 rounded-full bg-[#1e3a5f] flex items-center justify-center"          <PaperPlane size={14} className="text-white -rotate-[8deg]" />
-        </div>
-      </div>
-
-      {/* Quick chips */}
-      <div className="flex flex-wrap gap-1.5 mb-4">
-        {[
-          'https://images.unsplash.com/photo-1534308983496-4fabb1a015ee?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1503614282401047-d79a71a590e8?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1519681393784-d120267933ba?w=600&fit=crop',
-          'https://images.unsplash.com/photo-1519681393784-d120267933ba?w=600&fit=crop',
-        ],
-      </motion.div>
-    );
-  }
-};
-
 export function TravelMosaic() {
-  const { data: dbTiles, isLoading } => useMosaicTiles();
-  const tiles = dbTiles?.length ? dbTiles?.placeholders) ? <div className="flex-1 overflow-hidden md:flex" items-center gap-6 mb-1"
-              <div className="w-7 h-7 rounded-full bg-[#1e3a5f] flex items-center justify-center"          <PaperPlane size={14} className="text-white -rotate-[8deg]" />
+  const { data: dbTiles, isLoading } = useMosaicTiles();
+  const tiles = dbTiles?.length ? dbTiles : PLACEHOLDER_TILES;
+
+  return (
+    <section className="py-16 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground text-center mb-10">
+          Moments That <em>Move You</em>
+        </h2>
+
+        {/* Desktop: 6-col grid */}
+        <div
+          className="hidden md:grid grid-cols-6 auto-rows-[120px] gap-3"
+          style={{ gridAutoFlow: "dense" }}
+        >
+          {tiles.map((tile, i) => {
+            const grad = TILE_CATEGORY_GRADIENTS[tile.category as TileCategory];
+            const color = TILE_CATEGORY_COLORS[tile.category as TileCategory];
+            return (
+              <motion.div
+                key={tile.id}
+                initial={{ opacity: 0, scale: 0.9 }}
+                whileInView={{ opacity: 1, scale: 1 }}
+                viewport={{ once: true, margin: "-30px" }}
+                transition={{ duration: 0.4, delay: i * 0.04, ease: EASE_OUT_EXPO }}
+                whileHover={{ scale: 1.03 }}
+                className="rounded-xl overflow-hidden relative cursor-pointer group"
+                style={{
+                  gridColumn: `span ${tile.gridSpan[0]}`,
+                  gridRow: `span ${tile.gridSpan[1]}`,
+                  background: tile.image_url
+                    ? undefined
+                    : `linear-gradient(135deg, ${grad.from}, ${grad.to})`,
+                }}
+              >
+                {tile.image_url && (
+                  <img
+                    src={tile.image_url}
+                    alt={tile.name}
+                    className="absolute inset-0 w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                  />
+                )}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-black/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+                <div className="relative h-full flex flex-col justify-end p-4 group-hover:-translate-y-0.5 transition-transform duration-300">
+                  <div className="flex items-center gap-1.5 mb-1">
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{ backgroundColor: color.hex }}
+                    />
+                    <span className="text-white/70 text-xs">{color.label}</span>
+                  </div>
+                  <h3 className="text-white font-bold text-base leading-tight">
+                    {tile.name}
+                  </h3>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        {/* Mobile: 2-col grid */}
+        <div className="grid md:hidden grid-cols-2 gap-3">
+          {tiles.slice(0, 8).map((tile, i) => {
+            const grad = TILE_CATEGORY_GRADIENTS[tile.category as TileCategory];
+            const color = TILE_CATEGORY_COLORS[tile.category as TileCategory];
+            return (
+              <motion.div
+                key={tile.id}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.3, delay: i * 0.06, ease: EASE_OUT_EXPO }}
+                className={`rounded-xl overflow-hidden relative ${
+                  i === 0 ? "col-span-2 h-48" : "h-36"
+                }`}
+                style={{
+                  background: tile.image_url
+                    ? undefined
+                    : `linear-gradient(135deg, ${grad.from}, ${grad.to})`,
+                }}
+              >
+                {tile.image_url && (
+                  <img
+                    src={tile.image_url}
+                    alt={tile.name}
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                )}
+                <div className="h-full flex flex-col justify-end p-4">
+                  <div className="flex items-center gap-1.5 mb-1">
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{ backgroundColor: color.hex }}
+                    />
+                    <span className="text-white/70 text-xs">{color.label}</span>
+                  </div>
+                  <h3 className="text-white font-bold text-sm">{tile.name}</h3>
+                </div>
+              </motion.div>
+            );
+          })}
         </div>
       </div>
-
-      {/* Desktop: 6-col grid */}
-      <div
-        className="hidden md:grid grid-cols-6 auto-rows-[120px] gap-3"
-        style={{ gridAutoFlow: "dense" }}
-      >
-        {tiles.map((tile, i) => {
-          const grad = TILECategory_GRadients[tile.category as TileCategory];
-          const color = TILECategoryColors[tile.category as TileCategory]
-          ? (
-          const grad = TILECategoryColors[tile.category]
-            : else {
-              const grad = TILECategoryColors[tile.category]
-            ? (
-          const grad = tile.image_url
-            ? undefined
-            : else {
-              <div className="w-7 h-56 md:h-56 cursor-pointer group-hover:h-48 md:h-36 group-hover:scale-110 transition-transform duration-700"
-              onError={(e) => {
-                (e.target as HTMLImageElement). style.display = 'none';
-              }}
-            />
-          </div        </div>
-      </div>
-
-      {/* Mobile: 2-col grid */}
-      <div
-        className="grid md:hidden grid-cols-2 gap-3"
-        styles={{ gridAutoFlow: "dense" }}
-      >
-        {tiles.slice(0, 8). map((tile, i) => {
-          const grad = TILECategory_GRadients[tile.category as TileCategory];
-          const color = TILECategoryColors[tile.category as TileCategory]
-          ? (
-          const grad = TILECategoryColors[tile.category]
-            : else {
-              const grad = TILECategoryGradients[tile.category]
-              ? undefined
-            : else {
-              const grad = TILECategoryGradients[tile.category]
-            : else {
-              const grad = TILECategoryColors[tile.category]
-            ? {
-              hex: color.hex,
-            : color.label
-          }
-        }
-      </div>
-    );
-  }
+    </section>
+  );
 }

--- a/apps/web/components/trips/RouteMap.tsx
+++ b/apps/web/components/trips/RouteMap.tsx
@@ -1,7 +1,19 @@
 'use client';
 
 import { useMemo } from 'react';
-import type { RouteLocation, TripRoute } from '@travyl/shared';
+
+interface RouteLocation {
+  city: string;
+  iata?: string;
+  lat: number;
+  lng: number;
+}
+
+interface TripRoute {
+  origin: RouteLocation;
+  destinations: RouteLocation[];
+  stops?: RouteLocation[];
+}
 
 interface RouteMapProps {
   route: TripRoute;

--- a/apps/web/components/trips/TripRouteHover.tsx
+++ b/apps/web/components/trips/TripRouteHover.tsx
@@ -2,7 +2,16 @@
 
 import { useMemo } from 'react';
 import { Plane, MapPin, Building2 } from 'lucide-react';
-import type { MockTripCard, RouteLocation } from '@travyl/shared';
+import type { MockTripCard } from '@travyl/shared';
+
+interface RouteLocation {
+  city: string;
+  iata?: string;
+  lat: number;
+  lng: number;
+  continent?: string;
+  country?: string;
+}
 import { RouteMap } from './RouteMap';
 
 interface TripRouteHoverProps {
@@ -35,7 +44,7 @@ function LocationNode({
   isLast: boolean;
   showConnector: boolean;
 }) {
-  const colors = getContinentColor(location.continent);
+  const colors = getContinentColor(location.continent ?? 'default');
 
   return (
     <div className="flex items-start gap-2">
@@ -114,7 +123,7 @@ export function TripRouteHover({ trip }: TripRouteHoverProps) {
   // Get unique continents for the overview
   const continents = useMemo(() => {
     if (!routePoints) return [];
-    const unique = new Set(routePoints.map((p) => p.location.continent));
+    const unique = new Set(routePoints.map((p) => p.location.continent).filter((c): c is string => !!c));
     return Array.from(unique);
   }, [routePoints]);
 

--- a/packages/shared/src/config/mockItineraryData.ts
+++ b/packages/shared/src/config/mockItineraryData.ts
@@ -308,6 +308,9 @@ export const MOCK_TRIP: Trip = {
   is_shared: false,
   share_link_token: null,
   share_link_role: 'viewer',
+  forked_from_trip_id: null,
+  fork_count: 0,
+  is_public: false,
   created_at: '2026-03-01T00:00:00Z',
   updated_at: '2026-03-01T00:00:00Z',
 };

--- a/packages/shared/src/config/mockTripsData.ts
+++ b/packages/shared/src/config/mockTripsData.ts
@@ -2,6 +2,11 @@ import type { Trip } from '../types';
 
 export interface MockTripCard extends Trip {
   image: string;
+  route?: {
+    origin: { city: string; iata?: string; lat: number; lng: number };
+    destinations: Array<{ city: string; iata?: string; lat: number; lng: number }>;
+    stops?: Array<{ city: string; iata?: string; lat: number; lng: number }>;
+  };
 }
 
 export const MOCK_TRIPS: MockTripCard[] = [
@@ -21,6 +26,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: false,
     share_link_token: null,
     share_link_role: 'viewer',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2026-03-01T00:00:00Z',
     updated_at: '2026-03-01T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=800',
@@ -41,6 +49,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: false,
     share_link_token: null,
     share_link_role: 'viewer',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2026-02-15T00:00:00Z',
     updated_at: '2026-02-20T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=800',
@@ -61,6 +72,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: false,
     share_link_token: null,
     share_link_role: 'viewer',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2026-03-02T00:00:00Z',
     updated_at: '2026-03-02T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1570077188670-e3a8d69ac5ff?w=800',
@@ -81,6 +95,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: false,
     share_link_token: null,
     share_link_role: 'viewer',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2026-02-28T00:00:00Z',
     updated_at: '2026-02-28T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1537996194471-e657df975ab4?w=800',
@@ -101,6 +118,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: true,
     share_link_token: null,
     share_link_role: 'editor',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2026-01-10T00:00:00Z',
     updated_at: '2026-03-05T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1583422409516-2895a77efded?w=800',
@@ -121,6 +141,9 @@ export const MOCK_TRIPS: MockTripCard[] = [
     is_shared: false,
     share_link_token: null,
     share_link_role: 'viewer',
+    forked_from_trip_id: null,
+    fork_count: 0,
+    is_public: false,
     created_at: '2025-11-01T00:00:00Z',
     updated_at: '2025-12-29T00:00:00Z',
     image: 'https://images.unsplash.com/photo-1530122037265-a5f1f91d3b99?w=800',


### PR DESCRIPTION
## Summary
- Replace corrupted `TagUs.tsx` and `TravelMosaic.tsx` from bad merge
- Add `Suspense` boundaries for `useSearchParams` in layout and trips page
- Add missing Trip fields (`forked_from_trip_id`, `fork_count`, `is_public`) to mock data
- Define `RouteLocation` types inline in `RouteMap` and `TripRouteHover` components

## Context
PR #96 was merged before the second commit was pushed, so develop still has the corrupted files and type errors. This PR cherry-picks the missing fix.

## Test plan
- [x] `next build` passes cleanly (all 23 routes)
- [x] `expo export --platform ios` passes cleanly