### PR TITLE
feat: Travyl design system theme for calendar dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 
 # Supabase
 supabase/.temp/
+
+.superpowers/

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:is(.dark *));
 
 :root {
   --background: #FFFFFF;
@@ -22,6 +23,7 @@
   --color-border: var(--border);
   --font-sans: 'Satoshi', system-ui, sans-serif;
   --font-mono: var(--font-geist-mono);
+  --font-serif: 'Lustria', Georgia, serif;
 
   /* Trip theme colors — set dynamically by TripThemeProvider */
   --color-trip-base: var(--trip-base, #1e3a5f);

--- a/apps/web/components/calendar/AllDayRow.tsx
+++ b/apps/web/components/calendar/AllDayRow.tsx
@@ -24,7 +24,7 @@ export function AllDayRow({ days, flights = [], hotels = [] }: AllDayRowProps) {
   if (flights.length === 0 && hotels.length === 0) return null
 
   return (
-    <div className="flex border-b border-gray-200 dark:border-gray-700 min-h-[2rem]">
+    <div className="flex border-b border-gray-200 dark:border-[#1e3a5f]/30 min-h-[2rem]">
       {/* Gutter spacer matching TimeGutter width */}
       <div className="flex-shrink-0 w-14" />
 
@@ -39,7 +39,7 @@ export function AllDayRow({ days, flights = [], hotels = [] }: AllDayRowProps) {
           return (
             <div
               key={dayIndex}
-              className="flex-1 min-w-0 border-l border-gray-200 dark:border-gray-700 px-1 py-0.5 flex flex-col gap-0.5"
+              className="flex-1 min-w-0 border-l border-gray-200 dark:border-[#1e3a5f]/20 px-1 py-0.5 flex flex-col gap-0.5"
             >
               {/* Hotel banners */}
               {dayHotels.map((hotel) => {
@@ -50,7 +50,7 @@ export function AllDayRow({ days, flights = [], hotels = [] }: AllDayRowProps) {
                     key={hotel.id}
                     title={hotel.label}
                     className={[
-                      'text-[10px] font-medium px-1 py-0.5 bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 overflow-hidden',
+                      'text-[10px] font-medium px-1 py-0.5 bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 overflow-hidden',
                       isStart && isEnd
                         ? 'rounded'
                         : isStart
@@ -63,7 +63,7 @@ export function AllDayRow({ days, flights = [], hotels = [] }: AllDayRowProps) {
                     {isStart ? (
                       <span className="truncate block">{hotel.label}</span>
                     ) : (
-                      <span className="text-amber-400 dark:text-amber-600">— — —</span>
+                      <span className="text-amber-400 dark:text-amber-700">— — —</span>
                     )}
                   </div>
                 )
@@ -77,8 +77,8 @@ export function AllDayRow({ days, flights = [], hotels = [] }: AllDayRowProps) {
                   className={[
                     'text-[10px] font-medium px-1 py-0.5 rounded truncate',
                     flight.direction === 'arrival'
-                      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300'
-                      : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+                      ? 'bg-[#EFF4FF] text-[#003594] dark:bg-[#003594]/35 dark:text-[#a0c4ff]'
+                      : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300',
                   ].join(' ')}
                 >
                   {flight.direction === 'arrival' ? '→ ' : '← '}

--- a/apps/web/components/calendar/CalendarDashboard.tsx
+++ b/apps/web/components/calendar/CalendarDashboard.tsx
@@ -24,6 +24,8 @@ import { CalendarSkeleton } from './CalendarSkeleton'
 import { CalendarError } from './CalendarError'
 import type { FlightBanner, HotelBanner } from './AllDayRow'
 import type { CalendarActivity } from './types'
+import { useCalendarTheme } from './hooks/useCalendarTheme'
+import { CalendarThemeContext } from './CalendarThemeContext'
 
 // ─── Date helpers ────────────────────────────────────────────
 
@@ -167,6 +169,8 @@ export function CalendarDashboard() {
     onMoveActivity: moveActivity,
   })
 
+  const { theme, toggleTheme } = useCalendarTheme()
+
   // Sync view mode to presence
   useEffect(() => {
     setCurrentView(viewMode)
@@ -247,7 +251,8 @@ export function CalendarDashboard() {
   const visibleDays = viewMode === 'week' ? TRIP_DAYS : [TRIP_DAYS[selectedDayIndex]]
 
   return (
-    <div className="flex h-screen overflow-hidden bg-[#0f1117] text-white">
+    <CalendarThemeContext.Provider value={{ isDark: theme === 'dark' }}>
+    <div className={'flex h-screen overflow-hidden bg-gray-50 dark:bg-[#0a1520] text-gray-900 dark:text-[#f5efe8]' + (theme === 'dark' ? ' dark' : '')}>
       {/* Sidebar */}
       <TripSidebar
         activeNav={activeNav}
@@ -274,6 +279,8 @@ export function CalendarDashboard() {
           connectionStatus={connectionStatus}
           collaborators={collaborators}
           onShare={() => {}}
+          theme={theme}
+          onToggleTheme={toggleTheme}
         />
 
         {/* All-day row: flight + hotel banners */}
@@ -398,5 +405,6 @@ export function CalendarDashboard() {
         )}
       </div>
     </div>
+    </CalendarThemeContext.Provider>
   )
 }

--- a/apps/web/components/calendar/CalendarError.tsx
+++ b/apps/web/components/calendar/CalendarError.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { STORAGE_KEY } from './hooks/useCalendarTheme'
 
 interface CalendarErrorProps {
   message: string
@@ -6,9 +7,10 @@ interface CalendarErrorProps {
 }
 
 export function CalendarError({ message, onBack }: CalendarErrorProps) {
+  // Rendered outside CalendarDashboard — read localStorage directly for initial theme (intentionally non-reactive)
   const isDark =
     typeof window !== 'undefined' &&
-    localStorage.getItem('travyl-calendar-theme') === 'dark'
+    localStorage.getItem(STORAGE_KEY) === 'dark'
 
   return (
     <div

--- a/apps/web/components/calendar/CalendarError.tsx
+++ b/apps/web/components/calendar/CalendarError.tsx
@@ -6,8 +6,17 @@ interface CalendarErrorProps {
 }
 
 export function CalendarError({ message, onBack }: CalendarErrorProps) {
+  const isDark =
+    typeof window !== 'undefined' &&
+    localStorage.getItem('travyl-calendar-theme') === 'dark'
+
   return (
-    <div className="flex h-screen items-center justify-center bg-[#0f1117] text-white">
+    <div
+      className={
+        'flex h-screen items-center justify-center bg-gray-50 dark:bg-[#0a1520] text-gray-900 dark:text-[#f5efe8]' +
+        (isDark ? ' dark' : '')
+      }
+    >
       <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
         <svg
           width="48"
@@ -25,11 +34,11 @@ export function CalendarError({ message, onBack }: CalendarErrorProps) {
             strokeLinecap="round"
           />
         </svg>
-        <p className="text-sm text-gray-300">{message}</p>
+        <p className="text-sm text-gray-600 dark:text-gray-300">{message}</p>
         {onBack && (
           <button
             onClick={onBack}
-            className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 transition-colors text-sm font-medium"
+            className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 transition-colors text-sm font-medium text-gray-700 dark:text-white"
           >
             Go back
           </button>

--- a/apps/web/components/calendar/CalendarHeader.tsx
+++ b/apps/web/components/calendar/CalendarHeader.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { NavArrowLeft, Plus, ShareAndroid, MoreHoriz } from 'iconoir-react'
 import type { ViewMode, UserAwareness } from './types'
+import { ThemeToggle } from './ThemeToggle'
+import type { CalendarTheme } from './hooks/useCalendarTheme'
 
 interface CalendarHeaderProps {
   tripName: string
@@ -12,6 +14,8 @@ interface CalendarHeaderProps {
   connectionStatus: 'connected' | 'reconnecting' | 'disconnected'
   collaborators: UserAwareness[]
   onShare: () => void
+  theme: CalendarTheme
+  onToggleTheme: () => void
 }
 
 export function CalendarHeader({
@@ -24,6 +28,8 @@ export function CalendarHeader({
   connectionStatus,
   collaborators,
   onShare,
+  theme,
+  onToggleTheme,
 }: CalendarHeaderProps) {
   return (
     <div className="flex flex-col shrink-0">
@@ -38,32 +44,32 @@ export function CalendarHeader({
       )}
 
       {/* Single-row header */}
-      <div className="flex items-center gap-3 border-b border-white/10 bg-white/5 px-4 py-3">
+      <div className="flex items-center gap-3 border-b border-gray-200 dark:border-[#1e3a5f]/30 bg-white dark:bg-[#0f1a28] px-4 py-3">
         {/* Back button */}
         <button
           onClick={onBack}
           aria-label="Back"
-          className="flex items-center justify-center h-8 w-8 rounded-lg text-gray-400 hover:bg-white/10 hover:text-white transition-colors shrink-0"
+          className="flex items-center justify-center h-8 w-8 rounded-lg text-gray-400 dark:text-[#4a7ab5] hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white transition-colors shrink-0"
         >
           <NavArrowLeft width={16} height={16} aria-hidden="true" />
         </button>
 
         {/* Trip name + date range */}
         <div className="flex flex-col min-w-0 shrink-0">
-          <span className="truncate text-[14px] font-semibold text-white leading-tight">
+          <span className="truncate text-[15px] font-serif font-normal text-[#1e3a5f] dark:text-[#f5efe8] leading-tight">
             {tripName}
           </span>
-          <span className="text-[10px] text-gray-400 leading-tight">{dateRange}</span>
+          <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5] leading-tight">{dateRange}</span>
         </div>
 
         {/* Vertical divider */}
-        <div className="w-px h-6 bg-white/10 shrink-0" />
+        <div className="w-px h-6 bg-gray-200 dark:bg-[#1e3a5f]/30 shrink-0" />
 
         {/* Week / Day segmented toggle */}
         <div
           role="group"
           aria-label="View mode"
-          className="flex rounded-lg overflow-hidden border border-white/10 text-sm shrink-0"
+          className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-[#1e3a5f]/30 text-sm shrink-0"
         >
           {(['week', 'day'] as ViewMode[]).map((mode) => (
             <button
@@ -73,8 +79,8 @@ export function CalendarHeader({
               className={[
                 'px-3 py-1.5 capitalize transition-colors',
                 viewMode === mode
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-400 hover:bg-white/10 hover:text-white',
+                  ? 'bg-[#003594] text-white'
+                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white',
               ].join(' ')}
             >
               {mode}
@@ -85,7 +91,7 @@ export function CalendarHeader({
         {/* + New Activity outlined button */}
         <button
           onClick={onAddEvent}
-          className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-sm font-medium text-gray-400 hover:bg-white/10 hover:text-white transition-colors shrink-0"
+          className="flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/30 px-3 py-1.5 text-sm font-medium text-gray-500 dark:text-[#4a7ab5] hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white transition-colors shrink-0"
         >
           <Plus width={14} height={14} aria-hidden="true" />
           New Activity
@@ -94,6 +100,9 @@ export function CalendarHeader({
         {/* Spacer */}
         <div className="flex-1" />
 
+        {/* Theme toggle */}
+        <ThemeToggle theme={theme} onToggle={onToggleTheme} />
+
         {/* Collaborator avatars — inline, overlapping */}
         {collaborators.length > 0 && (
           <div className="flex items-center shrink-0" style={{ marginRight: '4px' }}>
@@ -101,7 +110,7 @@ export function CalendarHeader({
               <div
                 key={user.userId}
                 title={user.name}
-                className="relative flex items-center justify-center h-7 w-7 rounded-full text-[11px] font-semibold text-white select-none ring-2 ring-[#1a1a2e]"
+                className="relative flex items-center justify-center h-7 w-7 rounded-full text-[11px] font-semibold text-white select-none ring-2 ring-white dark:ring-[#0a1520]"
                 style={{
                   backgroundColor: user.color,
                   opacity: user.isOnline ? 1 : 0.45,
@@ -113,7 +122,7 @@ export function CalendarHeader({
                 {/* Online/offline dot */}
                 <span
                   className={[
-                    'absolute bottom-0 right-0 h-2 w-2 rounded-full ring-1 ring-[#1a1a2e]',
+                    'absolute bottom-0 right-0 h-2 w-2 rounded-full ring-1 ring-white dark:ring-[#0a1520]',
                     user.isOnline ? 'bg-green-500' : 'bg-gray-500',
                   ].join(' ')}
                 />
@@ -125,7 +134,7 @@ export function CalendarHeader({
         {/* Share button */}
         <button
           onClick={onShare}
-          className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 transition-colors shrink-0"
+          className="flex items-center gap-1.5 rounded-lg bg-[#F59E0B] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#D97706] transition-colors shrink-0"
         >
           <ShareAndroid width={14} height={14} aria-hidden="true" />
           Share
@@ -134,7 +143,7 @@ export function CalendarHeader({
         {/* More menu */}
         <button
           aria-label="More options"
-          className="flex items-center justify-center h-8 w-8 rounded-lg text-gray-400 hover:bg-white/10 hover:text-white transition-colors shrink-0"
+          className="flex items-center justify-center h-8 w-8 rounded-lg text-gray-400 dark:text-[#4a7ab5] hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white transition-colors shrink-0"
         >
           <MoreHoriz width={16} height={16} aria-hidden="true" />
         </button>

--- a/apps/web/components/calendar/CalendarSkeleton.tsx
+++ b/apps/web/components/calendar/CalendarSkeleton.tsx
@@ -1,47 +1,57 @@
 'use client'
 
 export function CalendarSkeleton() {
+  // Rendered outside CalendarDashboard — read localStorage directly for initial theme
+  const isDark =
+    typeof window !== 'undefined' &&
+    localStorage.getItem('travyl-calendar-theme') === 'dark'
+
   return (
-    <div className="flex h-screen overflow-hidden bg-[#0f1117] text-white animate-pulse">
+    <div
+      className={
+        'flex h-screen overflow-hidden animate-pulse bg-gray-50 dark:bg-[#0a1520]' +
+        (isDark ? ' dark' : '')
+      }
+    >
       {/* Sidebar placeholder */}
-      <div className="w-60 flex-shrink-0 bg-gray-800/50 border-r border-gray-700/50" />
+      <div className="w-60 flex-shrink-0 bg-white dark:bg-[#0f1a28] border-r border-gray-200 dark:border-[#1e3a5f]/30" />
 
       {/* Main column */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
         {/* Header placeholder */}
-        <div className="h-14 bg-gray-800/50 border-b border-gray-700/50 flex items-center px-4 gap-4">
-          <div className="h-5 w-40 rounded bg-gray-700/60" />
-          <div className="ml-auto h-5 w-24 rounded bg-gray-700/60" />
+        <div className="h-14 bg-white dark:bg-[#0f1a28] border-b border-gray-200 dark:border-[#1e3a5f]/30 flex items-center px-4 gap-4">
+          <div className="h-5 w-40 rounded bg-gray-200 dark:bg-[#1e3a5f]/40" />
+          <div className="ml-auto h-5 w-24 rounded bg-gray-200 dark:bg-[#1e3a5f]/40" />
         </div>
 
         {/* All-day row placeholder */}
-        <div className="h-10 bg-gray-800/30 border-b border-gray-700/50" />
+        <div className="h-10 bg-gray-50 dark:bg-[#0a1520] border-b border-gray-200 dark:border-[#1e3a5f]/30" />
 
         {/* Grid placeholder — 5 columns */}
         <div className="flex flex-1 min-h-0 overflow-hidden">
           {/* Time gutter placeholder */}
-          <div className="w-16 flex-shrink-0 bg-gray-800/30 border-r border-gray-700/50" />
+          <div className="w-16 flex-shrink-0 bg-gray-50 dark:bg-[#0a1520] border-r border-gray-200 dark:border-[#1e3a5f]/30" />
 
           {/* Day columns */}
           <div className="flex flex-1 min-w-0">
             {Array.from({ length: 5 }).map((_, i) => (
               <div
                 key={i}
-                className="flex flex-col flex-1 min-w-0 border-l border-gray-700/50"
+                className="flex flex-col flex-1 min-w-0 border-l border-gray-200 dark:border-[#1e3a5f]/30"
               >
                 {/* Column header */}
-                <div className="h-7 border-b border-gray-700/50 flex items-center justify-center">
-                  <div className="h-3 w-16 rounded bg-gray-700/60" />
+                <div className="h-7 border-b border-gray-200 dark:border-[#1e3a5f]/30 flex items-center justify-center">
+                  <div className="h-3 w-16 rounded bg-gray-200 dark:bg-[#1e3a5f]/40" />
                 </div>
 
                 {/* Event placeholders */}
                 <div className="relative flex-1 p-1 space-y-2">
                   <div
-                    className="rounded bg-gray-700/40 mx-1"
+                    className="rounded bg-gray-200 dark:bg-[#1e3a5f]/40 mx-1"
                     style={{ height: 48, marginTop: 60 }}
                   />
                   <div
-                    className="rounded bg-gray-700/40 mx-1"
+                    className="rounded bg-gray-200 dark:bg-[#1e3a5f]/40 mx-1"
                     style={{ height: 36, marginTop: 20 }}
                   />
                 </div>

--- a/apps/web/components/calendar/CalendarSkeleton.tsx
+++ b/apps/web/components/calendar/CalendarSkeleton.tsx
@@ -1,10 +1,11 @@
 'use client'
+import { STORAGE_KEY } from './hooks/useCalendarTheme'
 
 export function CalendarSkeleton() {
-  // Rendered outside CalendarDashboard — read localStorage directly for initial theme
+  // Rendered outside CalendarDashboard — read localStorage directly for initial theme (intentionally non-reactive)
   const isDark =
     typeof window !== 'undefined' &&
-    localStorage.getItem('travyl-calendar-theme') === 'dark'
+    localStorage.getItem(STORAGE_KEY) === 'dark'
 
   return (
     <div

--- a/apps/web/components/calendar/CalendarThemeContext.tsx
+++ b/apps/web/components/calendar/CalendarThemeContext.tsx
@@ -7,6 +7,7 @@ interface CalendarThemeContextValue {
 export const CalendarThemeContext = createContext<CalendarThemeContextValue>({
   isDark: false,
 })
+CalendarThemeContext.displayName = 'CalendarThemeContext'
 
 export function useCalendarThemeContext(): CalendarThemeContextValue {
   return useContext(CalendarThemeContext)

--- a/apps/web/components/calendar/CalendarThemeContext.tsx
+++ b/apps/web/components/calendar/CalendarThemeContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+interface CalendarThemeContextValue {
+  isDark: boolean
+}
+
+export const CalendarThemeContext = createContext<CalendarThemeContextValue>({
+  isDark: false,
+})
+
+export function useCalendarThemeContext(): CalendarThemeContextValue {
+  return useContext(CalendarThemeContext)
+}

--- a/apps/web/components/calendar/DayColumn.tsx
+++ b/apps/web/components/calendar/DayColumn.tsx
@@ -101,9 +101,9 @@ export function DayColumn({
       {/* Day header */}
       <div
         className={[
-          'text-center text-xs font-medium py-1 border-b border-gray-200 dark:border-gray-700 select-none',
+          'text-center text-xs font-medium py-1 border-b border-gray-200 dark:border-[#1e3a5f]/30 text-gray-500 dark:text-[#4a7ab5] select-none',
           onClickDayHeader
-            ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors'
+            ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/25 transition-colors'
             : '',
         ].join(' ')}
         onClick={onClickDayHeader}
@@ -127,8 +127,8 @@ export function DayColumn({
       <div
         ref={setNodeRef}
         className={[
-          'relative flex-1 border-l border-gray-200 dark:border-gray-700',
-          isOver ? 'bg-blue-50 dark:bg-blue-900/20' : '',
+          'relative flex-1 border-l border-gray-200 dark:border-[#1e3a5f]/20',
+          isOver ? 'bg-[#EFF4FF] dark:bg-[#003594]/15' : '',
         ].join(' ')}
         style={{ height: hourCount * HOUR_HEIGHT }}
         onMouseDown={handleMouseDown}
@@ -138,7 +138,7 @@ export function DayColumn({
         {hours.map((hour) => (
           <div
             key={hour}
-            className="absolute w-full border-t border-gray-100 dark:border-gray-800 pointer-events-none"
+            className="absolute w-full border-t border-gray-100 dark:border-[#1e3a5f]/15 pointer-events-none"
             style={{ top: (hour - timeRange.startHour) * HOUR_HEIGHT }}
           />
         ))}
@@ -147,7 +147,7 @@ export function DayColumn({
         {hours.map((hour) => (
           <div
             key={`half-${hour}`}
-            className="absolute w-full border-t border-dashed border-gray-100 dark:border-gray-800 pointer-events-none opacity-60"
+            className="absolute w-full border-t border-dashed border-gray-100/60 dark:border-[#1e3a5f]/10 pointer-events-none"
             style={{ top: (hour - timeRange.startHour) * HOUR_HEIGHT + HOUR_HEIGHT / 2 }}
           />
         ))}

--- a/apps/web/components/calendar/DetailPanel.tsx
+++ b/apps/web/components/calendar/DetailPanel.tsx
@@ -128,7 +128,7 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                   aria-hidden="true"
                 />
                 <dt className="sr-only">Location</dt>
-                <dd className="text-gray-300 leading-snug">{activity.location}</dd>
+                <dd className="text-gray-600 dark:text-gray-300 leading-snug">{activity.location}</dd>
               </div>
             )}
 

--- a/apps/web/components/calendar/DetailPanel.tsx
+++ b/apps/web/components/calendar/DetailPanel.tsx
@@ -51,7 +51,7 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
           exit={{ x: DETAIL_PANEL_WIDTH, opacity: 0 }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
           style={{ width: DETAIL_PANEL_WIDTH }}
-          className="flex flex-col shrink-0 border-l border-white/10 bg-[#1a1f2e] overflow-y-auto"
+          className="flex flex-col shrink-0 border-l border-gray-200 dark:border-[#1e3a5f]/30 bg-white dark:bg-[#0f1a28] overflow-y-auto"
           aria-label="Activity details"
         >
           {/* Color bar + header */}
@@ -62,7 +62,7 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
 
           <div className="flex items-start justify-between p-4 pb-2">
             <div className="flex flex-col gap-0.5 min-w-0 pr-2">
-              <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              <span className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-[#4a7ab5]">
                 {activity.type}
               </span>
               {isEditingTitle ? (
@@ -78,12 +78,12 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                       setIsEditingTitle(false)
                     }
                   }}
-                  className="bg-transparent border-b border-white/30 focus:border-white/60 outline-none text-base font-semibold text-white leading-snug w-full placeholder-gray-500"
+                  className="bg-transparent border-b border-gray-300 dark:border-white/30 focus:border-gray-500 dark:focus:border-white/60 outline-none text-base font-semibold text-gray-900 dark:text-white leading-snug w-full placeholder-gray-400 dark:placeholder-gray-500"
                   placeholder="Activity name…"
                 />
               ) : (
                 <h2
-                  className="text-base font-semibold text-white leading-snug cursor-text"
+                  className="text-base font-semibold text-gray-900 dark:text-[#f5efe8] leading-snug cursor-text"
                   onClick={() => {
                     setTitleDraft(activity.title)
                     setIsEditingTitle(true)
@@ -96,7 +96,7 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
             <button
               onClick={onClose}
               aria-label="Close detail panel"
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 dark:text-[#4a7ab5] hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-white transition-colors"
             >
               <Xmark width={16} height={16} strokeWidth={1.5} aria-hidden="true" />
             </button>
@@ -110,11 +110,11 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                 width={16}
                 height={16}
                 strokeWidth={1.5}
-                className="shrink-0 text-gray-500"
+                className="shrink-0 text-gray-400 dark:text-[#4a7ab5]"
                 aria-hidden="true"
               />
               <dt className="sr-only">Time</dt>
-              <dd className="text-gray-300">{formatTimeRange(activity)}</dd>
+              <dd className="text-gray-600 dark:text-gray-300">{formatTimeRange(activity)}</dd>
             </div>
 
             {/* Location */}
@@ -124,7 +124,7 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                   width={16}
                   height={16}
                   strokeWidth={1.5}
-                  className="mt-0.5 shrink-0 text-gray-500"
+                  className="mt-0.5 shrink-0 text-gray-400 dark:text-[#4a7ab5]"
                   aria-hidden="true"
                 />
                 <dt className="sr-only">Location</dt>
@@ -139,11 +139,11 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                   width={16}
                   height={16}
                   strokeWidth={1.5}
-                  className="shrink-0 text-gray-500"
+                  className="shrink-0 text-gray-400 dark:text-[#4a7ab5]"
                   aria-hidden="true"
                 />
                 <dt className="sr-only">Price</dt>
-                <dd className="text-gray-300">{activity.price}</dd>
+                <dd className="text-gray-600 dark:text-gray-300">{activity.price}</dd>
               </div>
             )}
 
@@ -159,14 +159,14 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
                   aria-hidden="true"
                 />
                 <dt className="sr-only">Rating</dt>
-                <dd className="text-gray-300">{activity.rating} / 5</dd>
+                <dd className="text-gray-600 dark:text-gray-300">{activity.rating} / 5</dd>
               </div>
             )}
           </dl>
 
           {/* Notes */}
           {activity.notes && (
-            <div className="mx-4 my-2 rounded-lg bg-white/5 p-3 text-sm text-gray-400 leading-relaxed">
+            <div className="mx-4 my-2 rounded-lg bg-gray-50 dark:bg-white/5 p-3 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
               {activity.notes}
             </div>
           )}
@@ -194,15 +194,15 @@ export function DetailPanel({ activity, viewers, onClose, onRemove, onUpdateActi
           <div className="flex-1" />
 
           {/* Actions */}
-          <div className="flex gap-2 border-t border-white/10 p-4">
+          <div className="flex gap-2 border-t border-gray-200 dark:border-[#1e3a5f]/30 p-4">
             <button
-              className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-gray-300 hover:bg-white/10 hover:text-white transition-colors"
+              className="flex-1 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/30 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white transition-colors"
               onClick={onClose}
             >
               Edit
             </button>
             <button
-              className="flex-1 rounded-lg border border-red-500/30 py-2 text-sm text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-colors"
+              className="flex-1 rounded-lg border border-red-200 dark:border-red-500/30 py-2 text-sm text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-300 transition-colors"
               onClick={() => onRemove(activity.id)}
             >
               Remove

--- a/apps/web/components/calendar/EventBlock.tsx
+++ b/apps/web/components/calendar/EventBlock.tsx
@@ -1,9 +1,14 @@
 'use client'
 import { useDraggable } from '@dnd-kit/core'
 import { CSS } from '@dnd-kit/utilities'
-import { getActivityColor } from '@travyl/shared/viewmodels/calendarViewModel'
+import {
+  getActivityColor,
+  getActivityColorDark,
+  getActivityColorDarkBorder,
+} from '@travyl/shared/viewmodels/calendarViewModel'
 import { HOUR_HEIGHT } from './constants'
 import { formatTimeRange } from './utils'
+import { useCalendarThemeContext } from './CalendarThemeContext'
 import type { CalendarActivity, UserAwareness } from './types'
 
 interface EventBlockProps {
@@ -26,8 +31,13 @@ export function EventBlock({
     data: { activity },
   })
 
+  const { isDark } = useCalendarThemeContext()
+
   const color = getActivityColor(activity.type)
   const hasImage = !!(activity.image && activity.duration >= 1)
+
+  const bgColor = isDark ? getActivityColorDark(activity.type) : color
+  const borderColor = isDark ? getActivityColorDarkBorder(activity.type) : `${color}88`
 
   const style: React.CSSProperties = {
     position: 'absolute',
@@ -38,8 +48,8 @@ export function EventBlock({
     transform: CSS.Translate.toString(transform),
     opacity: isDragging ? 0.5 : 1,
     zIndex: isDragging ? 50 : isSelected ? 10 : 1,
-    borderLeft: `3px solid ${color}88`,
-    ...(hasImage ? {} : { backgroundColor: color }),
+    borderLeft: `3px solid ${borderColor}`,
+    ...(hasImage ? {} : { backgroundColor: bgColor }),
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -67,8 +77,7 @@ export function EventBlock({
         'rounded-md cursor-grab active:cursor-grabbing overflow-hidden select-none relative',
         'text-white text-xs',
         'ring-2 ring-transparent',
-        'transition-all duration-150',
-        'hover:-translate-y-px hover:shadow-lg',
+        isDragging ? '' : 'transition-[ring,shadow,opacity] duration-150 hover:-translate-y-px hover:shadow-lg',
         isSelected ? 'ring-white ring-offset-1' : 'hover:ring-white/40',
         'focus:outline-none focus:ring-white focus:ring-offset-1',
       ].join(' ')}

--- a/apps/web/components/calendar/MiniCalendar.tsx
+++ b/apps/web/components/calendar/MiniCalendar.tsx
@@ -56,14 +56,14 @@ export function MiniCalendar({
   return (
     <div className="select-none px-2 py-3">
       {/* Month label */}
-      <p className="mb-2 text-center text-xs font-medium text-gray-400 uppercase tracking-wide">
+      <p className="mb-2 text-center text-xs font-medium text-gray-500 dark:text-[#4a7ab5] uppercase tracking-wide">
         {MONTH_NAMES[month]} {year}
       </p>
 
       {/* Weekday headers */}
       <div className="grid grid-cols-7 mb-1">
         {WEEKDAY_LABELS.map((d) => (
-          <span key={d} className="text-center text-[10px] text-gray-600 font-medium">
+          <span key={d} className="text-center text-[10px] text-gray-400 dark:text-[#4a7ab5] font-medium">
             {d}
           </span>
         ))}
@@ -90,10 +90,10 @@ export function MiniCalendar({
               className={[
                 'flex h-6 w-6 mx-auto items-center justify-center rounded-full text-[11px] transition-colors',
                 isCurrent
-                  ? 'bg-blue-600 text-white font-semibold'
+                  ? 'bg-[#003594] text-white font-semibold'
                   : isInTrip
-                  ? 'text-gray-200 hover:bg-white/10 cursor-pointer'
-                  : 'text-gray-700 cursor-default',
+                  ? 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-[#1e3a5f]/25 cursor-pointer'
+                  : 'text-gray-400 dark:text-[#1e3a5f]/50 cursor-default',
               ].join(' ')}
             >
               {dom}

--- a/apps/web/components/calendar/ThemeToggle.tsx
+++ b/apps/web/components/calendar/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { SunLight, HalfMoon } from 'iconoir-react'
+import type { CalendarTheme } from './hooks/useCalendarTheme'
+
+interface ThemeToggleProps {
+  theme: CalendarTheme
+  onToggle: () => void
+}
+
+export function ThemeToggle({ theme, onToggle }: ThemeToggleProps) {
+  const isDark = theme === 'dark'
+  return (
+    <button
+      onClick={onToggle}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Light mode' : 'Dark mode'}
+      className="flex items-center justify-center h-8 w-8 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white transition-colors shrink-0"
+    >
+      {isDark ? (
+        <SunLight width={18} height={18} strokeWidth={1.5} aria-hidden="true" />
+      ) : (
+        <HalfMoon width={18} height={18} strokeWidth={1.5} aria-hidden="true" />
+      )}
+    </button>
+  )
+}

--- a/apps/web/components/calendar/TimeGutter.tsx
+++ b/apps/web/components/calendar/TimeGutter.tsx
@@ -11,7 +11,7 @@ export function TimeGutter({ timeRange }: TimeGutterProps) {
   return (
     <div className="relative flex-shrink-0 w-14 text-right pr-3">
       {hours.map((hour) => (
-        <div key={hour} className="relative text-xs text-gray-400 select-none" style={{ height: HOUR_HEIGHT }}>
+        <div key={hour} className="relative text-xs text-gray-400 dark:text-[#4a7ab5]/70 select-none" style={{ height: HOUR_HEIGHT }}>
           <span className="absolute -top-2 right-3">{formatHourGutter(hour)}</span>
         </div>
       ))}

--- a/apps/web/components/calendar/TripSidebar.tsx
+++ b/apps/web/components/calendar/TripSidebar.tsx
@@ -83,7 +83,7 @@ export function TripSidebar({
       transition={{ type: 'spring', stiffness: 300, damping: 30 }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="relative flex flex-col shrink-0 overflow-hidden border-r border-white/10 bg-[#141824]"
+      className="relative flex flex-col shrink-0 overflow-hidden border-r border-gray-200 dark:border-[#1e3a5f]/30 bg-white dark:bg-[#0a1520]"
       aria-label="Trip navigation"
     >
       {/* Nav items */}
@@ -98,8 +98,8 @@ export function TripSidebar({
                 className={[
                   'flex w-full items-center gap-3 rounded-lg px-2 py-2 text-sm transition-colors',
                   isActive
-                    ? 'bg-blue-600/20 text-blue-400'
-                    : 'text-gray-400 hover:bg-white/10 hover:text-white',
+                    ? 'bg-[#EFF4FF] text-[#003594] dark:bg-[#003594]/35 dark:text-white'
+                    : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white',
                 ].join(' ')}
               >
                 <span className="shrink-0">{item.icon}</span>
@@ -119,7 +119,7 @@ export function TripSidebar({
 
       {/* Mini calendar (expanded only) */}
       {expanded && (
-        <div className="border-t border-white/10">
+        <div className="border-t border-gray-200 dark:border-[#1e3a5f]/30">
           <MiniCalendar
             tripStartDate={tripStartDate}
             tripDays={tripDays}

--- a/apps/web/components/calendar/hooks/useCalendarTheme.ts
+++ b/apps/web/components/calendar/hooks/useCalendarTheme.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback, useEffect } from 'react'
+
+export type CalendarTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'travyl-calendar-theme'
+
+export function useCalendarTheme() {
+  // Default to 'light' on server; client corrects on mount via useEffect
+  const [theme, setTheme] = useState<CalendarTheme>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark') setTheme('dark')
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next: CalendarTheme = prev === 'light' ? 'dark' : 'light'
+      localStorage.setItem(STORAGE_KEY, next)
+      return next
+    })
+  }, [])
+
+  return { theme, toggleTheme }
+}

--- a/apps/web/components/calendar/hooks/useCalendarTheme.ts
+++ b/apps/web/components/calendar/hooks/useCalendarTheme.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react'
 
 export type CalendarTheme = 'light' | 'dark'
 
-const STORAGE_KEY = 'travyl-calendar-theme'
+export const STORAGE_KEY = 'travyl-calendar-theme'
 
 export function useCalendarTheme() {
   // Default to 'light' on server; client corrects on mount via useEffect

--- a/docs/superpowers/specs/2026-03-16-calendar-theme-design.md
+++ b/docs/superpowers/specs/2026-03-16-calendar-theme-design.md
@@ -1,0 +1,321 @@
+# Calendar Dashboard — Travyl Theme (Light + Dark)
+
+**Date:** 2026-03-16
+**Branch:** feature/tra-192
+**Status:** Spec
+
+---
+
+## Overview
+
+Replace the current generic dark theme on the calendar dashboard with the official Travyl design system tokens. Both light and dark modes are implemented. A manual toggle in the `CalendarHeader` switches modes; the preference persists to `localStorage` (stubbed — real impl will sync to user preferences in Supabase).
+
+The rest of the web app is unaffected. Tailwind's `dark:` variants are scoped to the calendar dashboard root element via a `@custom-variant` directive.
+
+---
+
+## Goals
+
+- Light and dark modes that both use Travyl design tokens (navy, Blue[600], amber, Lustria/Satoshi)
+- Theme toggle button in the calendar header (sun/moon icon)
+- Preference persisted to `localStorage` keyed to `'travyl-calendar-theme'`
+- No regressions on drag-and-drop, event selection, detail panel, or collaborator presence
+
+## Non-Goals
+
+- Syncing theme to Supabase user profile (deferred)
+- Theming any other page or route outside the calendar dashboard
+- Changing the activity-type color palette
+
+---
+
+## Token Mapping
+
+All hardcoded dark hex values are replaced. Base styles target light mode; `dark:` variants override for dark mode.
+
+| Element | Light | Dark |
+|---|---|---|
+| Page / main bg | `bg-gray-50` | `dark:bg-[#0a1520]` |
+| Sidebar bg | `bg-white` | `dark:bg-[#0a1520]` |
+| Header bg | `bg-white` | `dark:bg-[#0f1a28]` |
+| Detail panel bg | `bg-white` | `dark:bg-[#0f1a28]` |
+| Borders | `border-gray-200` | `dark:border-[#1e3a5f]/30` |
+| Primary text | `text-gray-900` | `dark:text-[#f5efe8]` |
+| Secondary text | `text-gray-500` | `dark:text-[#4a7ab5]` |
+| Trip name (Lustria) | `text-[#1e3a5f] font-serif` | `dark:text-[#f5efe8]` |
+| Active nav bg | `bg-[#EFF4FF]` | `dark:bg-[#003594]/35` |
+| Active nav text | `text-[#003594]` | `dark:text-white` |
+| Inactive nav icon | `text-gray-400` | `dark:text-[#4a7ab5]` |
+| View toggle active | `bg-[#003594] text-white` | same |
+| View toggle inactive | `bg-gray-100 text-gray-500` | `dark:bg-[#1e3a5f]/25 dark:text-[#4a7ab5]` |
+| Share button | `bg-[#F59E0B] text-white` | same (amber is constant across modes) |
+| Hour grid lines | `border-gray-100` | `dark:border-[#1e3a5f]/15` |
+| Half-hour lines | `border-gray-100/60` | `dark:border-[#1e3a5f]/10` |
+| Day col header text | `text-gray-500` | `dark:text-[#4a7ab5]` |
+| Drag-over highlight | `bg-[#EFF4FF]` | `dark:bg-[#003594]/15` |
+| Flight banner | `bg-[#EFF4FF] text-[#003594]` | `dark:bg-[#003594]/35 dark:text-[#a0c4ff]` |
+| Hotel banner | `bg-amber-100 text-amber-800` | `dark:bg-amber-900/40 dark:text-amber-200` |
+| Skeleton bg | `bg-gray-50` | `dark:bg-[#0a1520]` |
+| Skeleton surface | `bg-white` | `dark:bg-[#0f1a28]` |
+| Skeleton pulse lines | `bg-gray-200` | `dark:bg-[#1e3a5f]/40` |
+
+**Note on `#0f1a28`:** This is an intermediate navy surface (`#0a1520` → `#0f1a28` → `#1e3a5f`) used for elevated surfaces (header, detail panel) to create visual layering depth in dark mode. It is intentional and not a token gap.
+
+### Event Block Colors Per Mode
+
+Light mode: full-saturation activity color as block background.
+Dark mode: deep-tinted background + bright left border, preserving activity color identity.
+
+| Type | Light bg | Dark bg | Dark border |
+|---|---|---|---|
+| sightseeing | `#003594` | `#1e3a5f` | `#4a7ab5` |
+| dining | `#D97706` | `#78350f` | `#F59E0B` |
+| tour | `#0d9488` | `#134e4a` | `#14b8a6` |
+| cultural | `#7C3AED` | `#4c1d95` | `#8b5cf6` |
+| shopping | `#dc2626` | `#7f1d1d` | `#f87171` |
+| nightlife | `#9333ea` | `#581c87` | `#a78bfa` |
+| outdoor | `#059669` | `#064e3b` | `#10b981` |
+| museum | `#d97706` | `#78350f` | `#fbbf24` |
+| transport | `#2563eb` | `#1e3a5f` | `#60a5fa` |
+| hotel | `#6b7280` | `#374151` | `#9ca3af` |
+| default | `#6b7280` | `#374151` | `#9ca3af` |
+
+Note: `cultural` uses violet (`#7C3AED`) and `nightlife` uses purple (`#9333ea`) — distinct in light mode.
+
+---
+
+## globals.css Changes
+
+Two additions to `apps/web/app/globals.css`:
+
+**1. Register Lustria as `--font-serif` in `@theme`:**
+
+```css
+@theme inline {
+  /* ... existing tokens ... */
+  --font-serif: 'Lustria', Georgia, serif;
+}
+```
+
+**2. Add dark mode custom variant** (Tailwind v4 has no `tailwind.config.ts`):
+
+```css
+@custom-variant dark (&:is(.dark *));
+```
+
+This scopes `dark:` variants to elements that are descendants of a `.dark` ancestor. Adding `class="dark"` to the `CalendarDashboard` root div activates dark mode only within that component tree, leaving all other routes in light mode.
+
+---
+
+## New Files
+
+### `apps/web/components/calendar/hooks/useCalendarTheme.ts`
+
+Manages theme state and localStorage persistence. Uses `useEffect` for localStorage init to avoid SSR hydration mismatch — the server always renders `'light'`, then the client corrects on mount:
+
+```ts
+type Theme = 'light' | 'dark'
+const STORAGE_KEY = 'travyl-calendar-theme'
+
+export function useCalendarTheme() {
+  const [theme, setTheme] = useState<Theme>('light') // server default
+
+  useEffect(() => {
+    // Client-only: read persisted preference after mount
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark') setTheme('dark')
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => {
+      const next = prev === 'light' ? 'dark' : 'light'
+      localStorage.setItem(STORAGE_KEY, next)
+      return next
+    })
+  }, [])
+
+  return { theme, toggleTheme }
+}
+```
+
+The single `useEffect` mount read means users who prefer dark mode will see a brief light flash on initial page load. This is acceptable for the stub phase; the Supabase sync (future) will eliminate the flash by server-rendering the correct theme.
+
+### `apps/web/components/calendar/CalendarThemeContext.tsx`
+
+A React context exposing `isDark: boolean` to deep descendants (avoids prop-drilling through WeekView → DayView → DayColumn → EventBlock):
+
+```ts
+export const CalendarThemeContext = createContext<{ isDark: boolean }>({ isDark: false })
+export const useCalendarThemeContext = () => useContext(CalendarThemeContext)
+```
+
+`CalendarDashboard` wraps its tree in `<CalendarThemeContext.Provider value={{ isDark: theme === 'dark' }}>`.
+
+`EventBlock` reads `isDark` via `useCalendarThemeContext()` to select light or dark event block colors from `calendarViewModel`.
+
+### `apps/web/components/calendar/ThemeToggle.tsx`
+
+A small icon button rendered inside `CalendarHeader`. Shows `SunLight` icon in dark mode (click to go light) and `HalfMoon` in light mode (click to go dark). Uses existing iconoir-react style (`strokeWidth={1.5}`, size 18).
+
+---
+
+## Modified Files
+
+### `apps/web/app/globals.css`
+
+Add `--font-serif` to `@theme inline` block and add the `@custom-variant dark` directive as described above.
+
+### `CalendarDashboard.tsx`
+
+```tsx
+const { theme, toggleTheme } = useCalendarTheme()
+
+return (
+  <CalendarThemeContext.Provider value={{ isDark: theme === 'dark' }}>
+    <div className={`flex h-screen overflow-hidden bg-gray-50 dark:bg-[#0a1520] text-gray-900 dark:text-[#f5efe8] ${theme === 'dark' ? 'dark' : ''}`}>
+      ...
+    </div>
+  </CalendarThemeContext.Provider>
+)
+```
+
+Pass `onToggleTheme={toggleTheme}` and `theme={theme}` to `CalendarHeader`.
+
+### `CalendarHeader.tsx`
+
+Updated prop interface:
+
+```ts
+interface CalendarHeaderProps {
+  // ... existing props ...
+  theme: 'light' | 'dark'
+  onToggleTheme: () => void
+}
+```
+
+- Add `<ThemeToggle theme={theme} onToggle={onToggleTheme} />` between the view toggle group and the share button
+- Change trip name: `<span className="font-serif font-normal text-[#1e3a5f] dark:text-[#f5efe8] text-[15px]">`
+- Replace `bg-white/5` header bg: `bg-white dark:bg-[#0f1a28]`
+- Replace `border-white/10`: `border-gray-200 dark:border-[#1e3a5f]/30`
+- Replace view toggle inactive `text-gray-400 hover:bg-white/10`: `text-gray-500 hover:bg-gray-100 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25`
+- Replace "New Activity" button `border-white/10 text-gray-400`: `border-gray-200 text-gray-500 dark:border-[#1e3a5f]/30 dark:text-[#4a7ab5]`
+- Replace `border-white/10` dividers: `border-gray-200 dark:border-[#1e3a5f]/30`
+- Replace avatar `ring-[#1a1a2e]`: `ring-white dark:ring-[#0a1520]`
+
+### `TripSidebar.tsx`
+
+- `bg-[#141824]` → `bg-white dark:bg-[#0a1520]`
+- `border-white/10` → `border-gray-200 dark:border-[#1e3a5f]/30`
+- Active nav: `bg-blue-600/20 text-blue-400` → `bg-[#EFF4FF] text-[#003594] dark:bg-[#003594]/35 dark:text-white`
+- Inactive nav: `text-gray-400 hover:bg-white/10 hover:text-white` → `text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white`
+
+### `DayColumn.tsx`
+
+- Day header border: `border-gray-200 dark:border-[#1e3a5f]/30`
+- Day header text: `text-gray-500 dark:text-[#4a7ab5]`
+- Day header hover: `hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/25`
+- Droppable grid border: `border-gray-200 dark:border-[#1e3a5f]/20`
+- Drag-over: `bg-[#EFF4FF] dark:bg-[#003594]/15`
+- Hour lines: `border-gray-100 dark:border-[#1e3a5f]/15`
+- Half-hour lines: `border-gray-100/60 dark:border-[#1e3a5f]/10`
+
+### `AllDayRow.tsx`
+
+- Row border: `border-gray-200 dark:border-[#1e3a5f]/30`
+- Cell borders: `border-gray-200 dark:border-[#1e3a5f]/20`
+- Flight arrival: `bg-[#EFF4FF] text-[#003594] dark:bg-[#003594]/35 dark:text-[#a0c4ff]`
+- Flight departure: `bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300`
+- Hotel: `bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200`
+
+### `EventBlock.tsx`
+
+- Remove hardcoded `backgroundColor: color` and `borderLeft: \`3px solid ${color}88\`` inline styles
+- Call `useCalendarThemeContext()` to get `isDark`
+- Select colors: `isDark ? getActivityColorDark(activity.type) : getActivityColor(activity.type)` for background; `isDark ? getActivityColorDarkBorder(activity.type) : \`${getActivityColor(activity.type)}88\`` for border
+- `transition-[ring,shadow,opacity]` already fixed (from drag bug fix); no change needed here
+
+### `packages/shared/src/viewmodels/calendarViewModel.ts`
+
+Add two new exported functions:
+
+```ts
+export function getActivityColorDark(type: ActivityType): string {
+  // Returns deep-tinted bg for dark mode (see token table)
+}
+
+export function getActivityColorDarkBorder(type: ActivityType): string {
+  // Returns bright border accent for dark mode (see token table)
+}
+```
+
+### `DetailPanel.tsx`
+
+- `bg-[#1a1f2e]` → `bg-white dark:bg-[#0f1a28]`
+- `border-white/10` → `border-gray-200 dark:border-[#1e3a5f]/30`
+- Type label: `text-gray-400 dark:text-[#4a7ab5]`
+- Title: `text-gray-900 dark:text-[#f5efe8]`
+- Detail rows text: `text-gray-600 dark:text-gray-300`
+- Detail row icons: `text-gray-400 dark:text-[#4a7ab5]`
+- Notes bg: `bg-gray-50 dark:bg-white/5`
+- Notes text: `text-gray-500 dark:text-gray-400`
+- Hover states: `hover:bg-gray-100 dark:hover:bg-white/10`
+- Remove button border: `border-red-200 dark:border-red-500/30`
+- Remove button text: `text-red-500 dark:text-red-400`
+
+### `TimeGutter.tsx`
+
+- `text-gray-400` → `text-gray-400 dark:text-[#4a7ab5]/70`
+
+### `MiniCalendar.tsx`
+
+- Month label: `text-gray-500 dark:text-[#4a7ab5]`
+- Weekday headers: `text-gray-400 dark:text-[#4a7ab5]`
+- Active day: `bg-[#003594] text-white` (same across modes)
+- In-trip days: `text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-[#1e3a5f]/25`
+- Outside-trip days: `text-gray-400 dark:text-[#1e3a5f]/50` (intentionally de-emphasised; `text-gray-400` passes AA contrast on white)
+
+### `CalendarSkeleton.tsx`
+
+- Main bg: `bg-gray-50 dark:bg-[#0a1520]`
+- Sidebar/header surface: `bg-white dark:bg-[#0f1a28]`
+- Border: `border-gray-200 dark:border-[#1e3a5f]/30`
+- Pulse elements: `bg-gray-200 dark:bg-[#1e3a5f]/40`
+
+### `CalendarError.tsx`
+
+- Bg: `bg-gray-50 dark:bg-[#0a1520]`
+- Message: `text-gray-600 dark:text-gray-300`
+- Retry button: `bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600`
+- Error icon: `text-red-400` (same across modes)
+
+---
+
+## Data Flow
+
+```
+useCalendarTheme()         ← reads/writes localStorage, SSR-safe via useEffect
+       │
+       ▼
+CalendarDashboard          ← applies 'dark' CSS class to root div
+       │                   ← wraps tree in CalendarThemeContext.Provider
+       │
+       ├── CalendarHeader  ← ThemeToggle button; Lustria trip name
+       ├── TripSidebar     ← dark: variants
+       ├── AllDayRow       ← dark: variants
+       ├── WeekView / DayView
+       │     └── DayColumn ← dark: variants
+       │           └── EventBlock ← useCalendarThemeContext() for color selection
+       └── DetailPanel     ← dark: variants
+```
+
+---
+
+## Implementation Order
+
+1. `globals.css` — add `--font-serif` + `@custom-variant dark`
+2. `calendarViewModel.ts` — add `getActivityColorDark` + `getActivityColorDarkBorder`
+3. `useCalendarTheme.ts` + `CalendarThemeContext.tsx` + `ThemeToggle.tsx` — new files
+4. `CalendarDashboard.tsx` — wire theme, apply `dark` class, wrap context
+5. `CalendarHeader.tsx` — add toggle, Lustria font, replace colors
+6. `EventBlock.tsx` — consume context, select colors per mode
+7. Remaining components — `TripSidebar`, `DayColumn`, `AllDayRow`, `DetailPanel`, `TimeGutter`, `MiniCalendar`, `CalendarSkeleton`, `CalendarError`

--- a/packages/shared/src/viewmodels/calendarViewModel.ts
+++ b/packages/shared/src/viewmodels/calendarViewModel.ts
@@ -2,22 +2,59 @@ import type { Activity } from '../types'
 import type { CalendarActivity } from '../types'
 
 const ACTIVITY_COLORS: Record<string, string> = {
-  sightseeing: '#4a7dff',
-  dining:      '#e67e22',
-  tour:        '#1abc9c',
-  cultural:    '#9b59b6',
-  shopping:    '#e74c3c',
-  nightlife:   '#8e44ad',
-  outdoor:     '#2ecc71',
-  museum:      '#f39c12',
-  transport:   '#3498db',
-  hotel:       '#6c7b8a',
+  sightseeing: '#003594',
+  dining:      '#D97706',
+  tour:        '#0d9488',
+  cultural:    '#7C3AED',
+  shopping:    '#dc2626',
+  nightlife:   '#9333ea',
+  outdoor:     '#059669',
+  museum:      '#d97706',
+  transport:   '#2563eb',
+  hotel:       '#6b7280',
 }
 
-const DEFAULT_ACTIVITY_COLOR = '#6b7b9e'
+const DEFAULT_ACTIVITY_COLOR = '#6b7280'
 
 export function getActivityColor(type: string): string {
   return ACTIVITY_COLORS[type] ?? DEFAULT_ACTIVITY_COLOR
+}
+
+const ACTIVITY_COLORS_DARK_BG: Record<string, string> = {
+  sightseeing: '#1e3a5f',
+  dining:      '#78350f',
+  tour:        '#134e4a',
+  cultural:    '#4c1d95',
+  shopping:    '#7f1d1d',
+  nightlife:   '#581c87',
+  outdoor:     '#064e3b',
+  museum:      '#78350f',
+  transport:   '#1e3a5f',
+  hotel:       '#374151',
+}
+
+const ACTIVITY_COLORS_DARK_BORDER: Record<string, string> = {
+  sightseeing: '#4a7ab5',
+  dining:      '#F59E0B',
+  tour:        '#14b8a6',
+  cultural:    '#8b5cf6',
+  shopping:    '#f87171',
+  nightlife:   '#a78bfa',
+  outdoor:     '#10b981',
+  museum:      '#fbbf24',
+  transport:   '#60a5fa',
+  hotel:       '#9ca3af',
+}
+
+const DEFAULT_ACTIVITY_COLOR_DARK_BG = '#374151'
+const DEFAULT_ACTIVITY_COLOR_DARK_BORDER = '#9ca3af'
+
+export function getActivityColorDark(type: string): string {
+  return ACTIVITY_COLORS_DARK_BG[type] ?? DEFAULT_ACTIVITY_COLOR_DARK_BG
+}
+
+export function getActivityColorDarkBorder(type: string): string {
+  return ACTIVITY_COLORS_DARK_BORDER[type] ?? DEFAULT_ACTIVITY_COLOR_DARK_BORDER
 }
 
 function parseTimeToHours(time: string): number {


### PR DESCRIPTION
## Summary
- Replace generic dark theme with full Travyl design system tokens (navy `#003594`/`#1e3a5f`, amber `#F59E0B`, cream `#f5efe8`) across all calendar components
- Add light/dark theme toggle with `localStorage` persistence via `useCalendarTheme` hook and `CalendarThemeContext`
- Use `@custom-variant dark` scoped to `.dark` class on calendar root — independent of system preference

## Components updated
- `CalendarDashboard` — wires theme state, applies `.dark` class to root, provides context
- `CalendarHeader` — Travyl tokens + `ThemeToggle` (sun/moon button)
- `EventBlock` — dark-mode activity colors via context + new `getActivityColorDark` functions
- `DayColumn`, `AllDayRow`, `TimeGutter`, `TripSidebar`, `DetailPanel`, `MiniCalendar` — full token retheme
- `CalendarSkeleton` + `CalendarError` — read `localStorage` directly for pre-hydration theme

## New files
- `hooks/useCalendarTheme.ts` — theme state, toggle, `localStorage` persistence
- `CalendarThemeContext.tsx` — `isDark` context for deep descendants
- `ThemeToggle.tsx` — sun/moon icon button

## Test plan
- [ ] Toggle between light and dark — all components update correctly
- [ ] Reload page — theme persists from `localStorage`
- [ ] Check `CalendarSkeleton` and `CalendarError` render with correct theme before hydration
- [ ] Verify event blocks show correct colors in both modes
- [ ] All 30 shared package tests pass (`npm test --workspace=packages/shared`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)