### PR TITLE
TRA-210: Mobile — Trip overview & itinerary glance view redesign

### DIFF
--- a/apps/mobile/app/trip/[id]/index.tsx
+++ b/apps/mobile/app/trip/[id]/index.tsx
@@ -1,60 +1,43 @@
-import { useState } from 'react';
-import { View, ScrollView, Text, Pressable, Linking } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useRef } from 'react';
+import {
+  View, ScrollView, Text, Pressable, Linking, Image, Share,
+  Dimensions, useColorScheme,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {
-  useItineraryScreen, Amber, Red, Sky, Violet,
+  useItineraryScreen,
   MOCK_WEATHER_FORECAST,
-  MOCK_WEATHER, MOCK_NEWS,
+  MOCK_WEATHER, MOCK_NEWS, MOCK_TRIPS, formatDateRange,
+  MOCK_EXPLORE_ITEMS, NEWS_GRADIENTS,
 } from '@travyl/shared';
-import type { NewsItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { PageTransition, useTabAccent } from './_layout';
-import { SkeletonBlock } from '@/components/ui/SkeletonBlock';
+import { PageTransition } from './_layout';
 
-// ─── Collapsible Section ─────────────────────────────────
-function CollapsibleSection({ title, icon, color, children, defaultOpen = false }: {
-  title: string; icon: string; color: string; children: React.ReactNode; defaultOpen?: boolean;
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const ACCENT_COLOR = '#c8a96a';
+
+// ─── Accent label + serif heading (matches web pattern) ──────
+function SectionHeader({ accent, title }: {
+  accent: string; title: string;
 }) {
   const colors = useThemeColors();
-  const [open, setOpen] = useState(defaultOpen);
   return (
-    <View style={{ backgroundColor: colors.cardBackground, borderRadius: 12, overflow: 'hidden', marginBottom: 10, borderWidth: 1, borderColor: colors.border }}>
-      <Pressable onPress={() => setOpen(!open)} style={{ flexDirection: 'row', alignItems: 'center', gap: 10, padding: 12 }}>
-        <View style={{ width: 32, height: 32, borderRadius: 8, backgroundColor: color + '15', alignItems: 'center', justifyContent: 'center' }}>
-          <FontAwesome name={icon as any} size={14} color={color} />
+    <View style={{ marginBottom: 12 }}>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+        <View>
+          <Text style={{
+            fontSize: 9, fontWeight: '700', letterSpacing: 3,
+            textTransform: 'uppercase', color: ACCENT_COLOR, marginBottom: 4,
+          }}>{accent}</Text>
+          <Text style={{
+            fontSize: 22, fontWeight: '700', fontFamily: 'Lustria-Regular',
+            color: colors.text,
+          }}>{title}</Text>
         </View>
-        <Text style={{ fontSize: 14, fontWeight: '600', color: colors.text, flex: 1 }}>{title}</Text>
-        <FontAwesome name={open ? 'chevron-up' : 'chevron-down'} size={10} color={colors.textTertiary} />
-      </Pressable>
-      {open && <View style={{ paddingHorizontal: 12, paddingBottom: 12 }}>{children}</View>}
+      </View>
     </View>
-  );
-}
-
-// ─── Info Row ────────────────────────────────────────────
-function InfoRow({ icon, iconColor, label, value, onPress }: {
-  icon: string; iconColor: string; label: string; value: string; onPress?: () => void;
-}) {
-  const colors = useThemeColors();
-  return (
-    <Pressable
-      onPress={onPress}
-      style={{
-        flexDirection: 'row', alignItems: 'center',
-        paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: colors.borderLight,
-      }}
-    >
-      <View style={{ width: 28, height: 28, borderRadius: 7, backgroundColor: iconColor + '15', alignItems: 'center', justifyContent: 'center', marginRight: 10 }}>
-        <FontAwesome name={icon as any} size={11} color={iconColor} />
-      </View>
-      <View style={{ flex: 1 }}>
-        <Text style={{ fontSize: 10, color: colors.textTertiary }}>{label}</Text>
-        <Text style={{ fontSize: 12, fontWeight: '500', color: colors.text }}>{value}</Text>
-      </View>
-      {onPress && <FontAwesome name="chevron-right" size={10} color={colors.border} />}
-    </Pressable>
   );
 }
 
@@ -68,214 +51,369 @@ function weatherIcon(condition: string): string {
   return 'cloud';
 }
 
-// ─── News Category Config ────────────────────────────────
-const NEWS_CATEGORY_CONFIG: Record<NewsItem['category'], { icon: string; color: string; bg: string; label: string }> = {
-  event:    { icon: 'star',            color: '#7c3aed', bg: '#f5f3ff', label: 'Event' },
-  advisory: { icon: 'exclamation-triangle', color: '#d97706', bg: '#fffbeb', label: 'Advisory' },
-  news:     { icon: 'newspaper-o',     color: '#2563eb', bg: '#eff6ff', label: 'News' },
-  tip:      { icon: 'lightbulb-o',     color: '#059669', bg: '#ecfdf5', label: 'Tip' },
-};
 
 // ─── Data ────────────────────────────────────────────────
-const TRANSPORT_OPTIONS = [
-  { icon: 'subway', iconColor: '#2563eb', name: 'Metro', description: 'Lines 1-14, RER A-E' },
-  { icon: 'bus', iconColor: '#16a34a', name: 'Bus & Tram', description: '350+ routes, 5:30am-12:30am' },
-  { icon: 'taxi', iconColor: '#7c3aed', name: 'Taxis', description: 'G7, Uber, Bolt available' },
-  { icon: 'bicycle', iconColor: '#d97706', name: 'Bike Share', description: "Velib' — 1,400+ stations" },
+const TRANSPORT_INFO = [
+  { name: 'Métro', text: 'Lines 1, 4 & 7 cover tourist areas' },
+  { name: 'Bus', text: 'Route 69 passes major landmarks' },
+  { name: 'Walking', text: 'Best for Le Marais & Montmartre' },
+  { name: 'Taxi', text: 'Beige cabs / Uber · Airport €50–70' },
+];
+
+const GOOD_TO_KNOW = [
+  'Tipping is included — round up for great service',
+  'Tap water is safe — ask for "une carafe d\'eau"',
+  'Watch for pickpockets at tourist sites and on the Métro',
 ];
 
 const EMERGENCY_INFO = [
-  { label: 'Emergency (EU)', number: '112' },
+  { label: 'All', number: '112' },
   { label: 'Police', number: '17' },
-  { label: 'Ambulance (SAMU)', number: '15' },
-  { label: 'Fire Brigade', number: '18' },
+  { label: 'Medical', number: '15' },
 ];
 
-const DESTINATION_TIPS = [
-  { icon: 'eur', label: 'Currency', value: 'Euro (EUR)' },
-  { icon: 'language', label: 'Language', value: 'French (English in tourist areas)' },
-  { icon: 'clock-o', label: 'Time Zone', value: 'CET (UTC+1)' },
-  { icon: 'money', label: 'Tipping', value: 'Service included; round up' },
-  { icon: 'plug', label: 'Power', value: 'Type C/E plugs, 230V' },
-  { icon: 'tint', label: 'Water', value: 'Tap water is safe' },
-];
-
-const QUICK_LINKS = [
-  { label: 'Google Maps', icon: 'map', url: 'https://maps.google.com/?q=Paris,France' },
-  { label: 'Currency', icon: 'exchange', url: 'https://xe.com' },
-  { label: 'Translate', icon: 'language', url: 'https://translate.google.com/?sl=en&tl=fr' },
-  { label: 'Local Time', icon: 'clock-o', url: 'https://time.is/Paris' },
+const QUICK_FACTS = [
+  { bold: 'EUR €', text: '€1 ≈ $1.08' },
+  { bold: 'French', text: 'English widely spoken' },
+  { bold: 'CET +1', text: '6h ahead of EST' },
+  { bold: 'Type C/E', text: '230V adapter' },
 ];
 
 // ─── Main Screen ─────────────────────────────────────────
 export default function OverviewScreen() {
-  const ACCENT = useTabAccent('index');
   const { id } = useLocalSearchParams<{ id: string }>();
-  const { trip, days, flights, hotels, isLoading } = useItineraryScreen(id);
+  const { trip } = useItineraryScreen(id);
   const colors = useThemeColors();
+  const isDark = useColorScheme() === 'dark';
+  const scrollRef = useRef<ScrollView>(null);
+  const router = useRouter();
 
-  const allActivities = days.flatMap((d) => d.timeGroups.flatMap((g) => g.activities));
   const forecast = MOCK_WEATHER_FORECAST;
+  const weather = MOCK_WEATHER;
+  const news = MOCK_NEWS;
 
-  const totalDays = days.length;
-  const allStats = [
-    { icon: 'calendar' as const, count: totalDays, label: totalDays === 1 ? 'Day' : 'Days' },
-    { icon: 'users' as const, count: trip?.travelers ?? 0, label: (trip?.travelers ?? 0) === 1 ? 'Traveler' : 'Travelers' },
-    { icon: 'plane' as const, count: flights.length, label: flights.length === 1 ? 'Flight' : 'Flights' },
-    { icon: 'building-o' as const, count: hotels.length, label: hotels.length === 1 ? 'Hotel' : 'Hotels' },
-  ];
-  const visibleStats = allStats.filter((s) => s.count > 0);
+  const tripData = MOCK_TRIPS.find((t) => t.id === (trip?.id ?? id));
+  const coverImage = tripData?.image?.replace(/\?w=\d+/, '?w=1200&q=80');
+  const destination = trip?.destination || tripData?.destination || 'Paris, France';
+  const cityName = destination.split(',')[0].trim();
+  const countryName = destination.split(',').slice(1).join(',').trim();
+
+  const dateStr = trip ? formatDateRange(trip.start_date, trip.end_date) : null;
+  const travelersStr = trip ? `${trip.travelers} ${trip.travelers === 1 ? 'traveler' : 'travelers'}` : null;
+
+  const handleShare = async () => {
+    if (!trip) return;
+    try {
+      await Share.share({
+        message: `Check out my trip to ${trip.destination}! ${trip.start_date} – ${trip.end_date}`,
+        title: trip.title ?? `Trip to ${trip.destination}`,
+      });
+    } catch (_) {}
+  };
 
   return (
     <PageTransition>
-    <ScrollView style={{ flex: 1, backgroundColor: colors.background }} contentContainerStyle={{ paddingBottom: 32 }}>
-      <View style={{ padding: 16 }}>
-        {/* ─── Current Weather Card ────────────────────────── */}
-        <View style={{
-          borderRadius: 12, padding: 14, marginBottom: 14,
-          borderWidth: 1, borderColor: '#bae6fd',
-          backgroundColor: '#f0f9ff',
-        }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, flex: 1 }}>
-              <View style={{
-                width: 44, height: 44, borderRadius: 12,
-                backgroundColor: 'rgba(255,255,255,0.8)',
-                alignItems: 'center', justifyContent: 'center',
-              }}>
-                <FontAwesome
-                  name={weatherIcon(MOCK_WEATHER.conditions) as any}
-                  size={20}
-                  color={MOCK_WEATHER.conditions.toLowerCase().includes('cloud') ? '#6b7280' : '#f59e0b'}
-                />
-              </View>
-              <View style={{ flex: 1 }}>
-                <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 4 }}>
-                  <Text style={{ fontSize: 22, fontWeight: '700', color: colors.text }}>{MOCK_WEATHER.high}°</Text>
-                  <Text style={{ fontSize: 13, color: colors.textTertiary }}>/ {MOCK_WEATHER.low}°{MOCK_WEATHER.unit === 'celsius' ? 'C' : 'F'}</Text>
-                </View>
-                <Text style={{ fontSize: 11, color: colors.textSecondary }} numberOfLines={2}>{MOCK_WEATHER.conditions} in {MOCK_WEATHER.destination}</Text>
-              </View>
-            </View>
-          </View>
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
+      {/* ─── Background image bleed ───────────────────────── */}
+      {coverImage && (
+        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 420 }} pointerEvents="none">
+          <Image source={{ uri: coverImage }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+          <LinearGradient
+            colors={[
+              'rgba(0,0,0,0.1)',
+              'rgba(0,0,0,0.25)',
+              isDark ? 'rgba(18,18,20,0.7)' : 'rgba(255,255,255,0.7)',
+              isDark ? '#121214' : colors.background,
+            ]}
+            locations={[0, 0.35, 0.7, 1]}
+            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          />
+        </View>
+      )}
 
-          {/* Inline forecast strip */}
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginTop: 10 }} contentContainerStyle={{ gap: 6 }}>
-            {forecast.map((day) => (
-              <View key={day.day} style={{
-                alignItems: 'center', paddingHorizontal: 10, paddingVertical: 6,
-                borderRadius: 8, backgroundColor: 'rgba(255,255,255,0.6)', minWidth: 52,
-              }}>
-                <Text style={{ fontSize: 10, fontWeight: '600', color: colors.textSecondary }}>{day.day}</Text>
-                <FontAwesome name={weatherIcon(day.condition) as any} size={14} color={Amber[500]} style={{ marginVertical: 3 }} />
-                <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 2 }}>
-                  <Text style={{ fontSize: 11, fontWeight: '600', color: colors.text }}>{day.high}°</Text>
-                  <Text style={{ fontSize: 9, color: colors.textTertiary }}>{day.low}°</Text>
-                </View>
+      {/* ─── Back + action buttons over bleed ─────────────── */}
+      <View style={{
+        position: 'absolute', top: 50, left: 14, right: 14, zIndex: 10,
+        flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center',
+      }} pointerEvents="box-none">
+        <Pressable
+          onPress={() => router.back()}
+          style={{
+            width: 34, height: 34, borderRadius: 17,
+            backgroundColor: 'rgba(0,0,0,0.35)', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <FontAwesome name="chevron-left" size={14} color="#fff" />
+        </Pressable>
+        <View style={{ flexDirection: 'row', gap: 6 }}>
+          <Pressable
+            onPress={handleShare}
+            style={{
+              backgroundColor: 'rgba(255,255,255,0.15)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.25)',
+              borderRadius: 10, width: 34, height: 34, alignItems: 'center', justifyContent: 'center',
+            }}
+          >
+            <FontAwesome name="share" size={13} color="#fff" />
+          </Pressable>
+        </View>
+      </View>
+
+      <ScrollView
+        ref={scrollRef}
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: 40 }}
+        showsVerticalScrollIndicator={false}
+      >
+      {/* ─── Hero text over bleed ─────────────────────────── */}
+      <View style={{ paddingHorizontal: 20, paddingTop: 90, paddingBottom: 8 }}>
+        <Text style={{
+          fontSize: 9, fontWeight: '700', letterSpacing: 3,
+          textTransform: 'uppercase', color: ACCENT_COLOR, marginBottom: 6,
+        }}>
+          {countryName || 'Your Trip Guide'}
+        </Text>
+        <Text style={{
+          fontSize: 32, fontWeight: '800', fontFamily: 'Lustria-Regular',
+          color: '#fff', lineHeight: 36, marginBottom: 8,
+          textShadowColor: 'rgba(0,0,0,0.5)',
+          textShadowOffset: { width: 0, height: 2 },
+          textShadowRadius: 16,
+        }}>
+          {cityName.toUpperCase()}
+        </Text>
+
+        {/* Date + travelers + weather inline */}
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+          {dateStr && <Text style={{ fontSize: 13, fontWeight: '500', color: 'rgba(255,255,255,0.7)' }}>{dateStr}</Text>}
+          {dateStr && travelersStr && <Text style={{ color: 'rgba(255,255,255,0.2)' }}>·</Text>}
+          {travelersStr && <Text style={{ fontSize: 13, fontWeight: '500', color: 'rgba(255,255,255,0.7)' }}>{travelersStr}</Text>}
+          {(dateStr || travelersStr) && <Text style={{ color: 'rgba(255,255,255,0.2)' }}>·</Text>}
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            <FontAwesome name={weatherIcon(weather.conditions) as any} size={13} color="rgba(255,255,255,0.5)" />
+            <Text style={{ fontSize: 13, color: 'rgba(255,255,255,0.7)' }}>{weather.high}° / {weather.low}°</Text>
+          </View>
+        </View>
+      </View>
+
+      {/* ─── Lede + Essentials ────────────────────────────── */}
+      <View style={{ paddingHorizontal: 20, paddingBottom: 8 }}>
+        <Text style={{
+          fontSize: 13, lineHeight: 20, fontFamily: 'Lustria-Regular',
+          color: isDark ? '#e0d8cc' : '#4a3f35', marginBottom: 12,
+          textShadowColor: isDark ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.7)',
+          textShadowOffset: { width: 0, height: 1 },
+          textShadowRadius: 6,
+        }}>
+          Paris never reveals itself all at once. It unfolds — slowly, generously — in the steam
+          rising from a morning café crème, in the light that catches the Seine just before sunset.
+        </Text>
+
+        {/* Quick facts — inline text, matches web */}
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginBottom: 16 }}>
+          {QUICK_FACTS.map((f) => (
+            <Text key={f.bold} style={{ fontSize: 11, color: isDark ? '#9e9689' : '#7a6e63' }}>
+              <Text style={{ fontWeight: '600', color: colors.text }}>{f.bold}</Text> · {f.text}
+            </Text>
+          ))}
+        </View>
+
+        {/* Forecast strip — editorial style */}
+        <View style={{
+          flexDirection: 'row', alignItems: 'center', gap: 12,
+          paddingVertical: 10, borderTopWidth: 1, borderBottomWidth: 1,
+          borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+        }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            <FontAwesome
+              name={weatherIcon(weather.conditions) as any}
+              size={14}
+              color={ACCENT_COLOR}
+            />
+            <Text style={{ fontSize: 13, fontWeight: '700', color: ACCENT_COLOR }}>
+              {weather.high}° / {weather.low}°
+            </Text>
+            <Text style={{ fontSize: 9, color: isDark ? '#7a7268' : '#a39688', marginLeft: -2 }}>Now</Text>
+          </View>
+          <Text style={{ color: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.1)' }}>|</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 14 }}>
+            {forecast.slice(0, 5).map((day) => (
+              <View key={day.day} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <Text style={{ fontSize: 11, fontWeight: '600', color: isDark ? '#9e9689' : '#7a6e63' }}>{day.day}</Text>
+                <Text style={{ fontSize: 13 }}>{day.icon}</Text>
+                <Text style={{ fontSize: 12, fontWeight: '700', color: colors.text }}>{day.high}°</Text>
               </View>
             ))}
           </ScrollView>
         </View>
+      </View>
 
-        {/* ─── Emergency Contacts ─────────────────────────── */}
-        <CollapsibleSection title="Emergency Contacts" icon="phone" color={Red[500]}>
-          <View style={{ flexDirection: 'row', gap: 8, marginBottom: 8 }}>
-            {EMERGENCY_INFO.map((e) => (
-              <Pressable
-                key={e.number}
-                onPress={() => Linking.openURL(`tel:${e.number}`)}
-                style={{ flex: 1, backgroundColor: Red[50], borderRadius: 10, padding: 10, alignItems: 'center' }}
-              >
-                <Text style={{ fontSize: 16, fontWeight: '700', color: Red[600] }}>{e.number}</Text>
-                <Text style={{ fontSize: 9, color: colors.textSecondary, marginTop: 2 }}>{e.label}</Text>
-              </Pressable>
-            ))}
-          </View>
-          <View style={{ backgroundColor: Amber[50], borderRadius: 8, borderWidth: 1, borderColor: Amber[100], padding: 8 }}>
-            <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 6 }}>
-              <FontAwesome name="shield" size={10} color={Amber[600]} style={{ marginTop: 2 }} />
-              <Text style={{ fontSize: 10, color: colors.text, flex: 1, lineHeight: 15 }}>
-                Keep valuables in hotel safe. Use front pockets in crowded areas. Watch for pickpockets at tourist hotspots.
-              </Text>
+      {/* ─── Things to Do — horizontal scroll cards ───────── */}
+      <View style={{ marginTop: 20 }}>
+        <View style={{ paddingHorizontal: 20 }}>
+          <SectionHeader accent="Explore" title="Things to Do" />
+        </View>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ paddingHorizontal: 20, gap: 12 }}
+          decelerationRate="fast"
+          snapToInterval={SCREEN_WIDTH - 60}
+        >
+          {MOCK_EXPLORE_ITEMS.map((item) => (
+            <View key={item.id} style={{
+              width: SCREEN_WIDTH - 60, height: 220, borderRadius: 14, overflow: 'hidden',
+            }}>
+              <Image source={{ uri: item.image }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+              <LinearGradient
+                colors={['transparent', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.8)']}
+                locations={[0, 0.4, 1]}
+                pointerEvents="none"
+                style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}
+              />
+              {/* Category pill */}
+              <View style={{
+                position: 'absolute', top: 10, left: 10,
+                backgroundColor: 'rgba(200,169,106,0.15)', borderWidth: 1,
+                borderColor: 'rgba(200,169,106,0.2)', borderRadius: 12,
+                paddingHorizontal: 10, paddingVertical: 4,
+              }}>
+                <Text style={{
+                  fontSize: 9, fontWeight: '700', letterSpacing: 0.5,
+                  textTransform: 'uppercase', color: ACCENT_COLOR,
+                }}>{item.category}</Text>
+              </View>
+              {/* Bottom text */}
+              <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: 14 }}>
+                <Text style={{
+                  fontSize: 17, fontWeight: '700', color: '#fff',
+                  fontFamily: 'Lustria-Regular', marginBottom: 4,
+                }}>{item.title}</Text>
+                <Text style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', lineHeight: 16 }} numberOfLines={2}>
+                  {item.description}
+                </Text>
+              </View>
             </View>
-          </View>
-        </CollapsibleSection>
-
-        {/* ─── Getting Around ────────────────────────────────── */}
-        <CollapsibleSection title="Getting Around" icon="bus" color={Sky[500]}>
-          {TRANSPORT_OPTIONS.map((t) => (
-            <InfoRow key={t.name} icon={t.icon} iconColor={t.iconColor} label={t.name} value={t.description} />
           ))}
-        </CollapsibleSection>
+        </ScrollView>
+      </View>
 
-        {/* ─── Destination Tips ──────────────────────────────── */}
-        <CollapsibleSection title="Destination Tips" icon="lightbulb-o" color={Violet[500]}>
-          {DESTINATION_TIPS.map((tip) => (
-            <InfoRow key={tip.label} icon={tip.icon} iconColor={Violet[500]} label={tip.label} value={tip.value} />
-          ))}
-        </CollapsibleSection>
+      {/* ─── Quote Divider ────────────────────────────────── */}
+      <View style={{ paddingHorizontal: 32, paddingVertical: 24, alignItems: 'center' }}>
+        <Text style={{
+          fontSize: 15, fontStyle: 'italic', fontFamily: 'Lustria-Regular',
+          textAlign: 'center', color: isDark ? 'rgba(200,192,182,0.5)' : 'rgba(80,65,50,0.5)',
+          lineHeight: 22,
+        }}>
+          &ldquo;Paris is always a good idea.&rdquo;{' '}
+          <Text style={{ fontStyle: 'normal', opacity: 0.5 }}>— Audrey Hepburn</Text>
+        </Text>
+      </View>
 
-        {/* ─── Things to Check Out ───────────────────────────── */}
-        <CollapsibleSection title="Things to Check Out" icon="newspaper-o" color="#2563eb">
-          {MOCK_NEWS.map((item) => {
-            const config = NEWS_CATEGORY_CONFIG[item.category];
+      {/* ─── What's Going On — dark gradient news cards ───── */}
+      <View style={{ paddingHorizontal: 20 }}>
+        <SectionHeader accent="What's Happening" title="What's Going On" />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 10 }}
+          decelerationRate="fast"
+          snapToInterval={SCREEN_WIDTH - 60}
+        >
+          {news.map((item, i) => {
+            const grad = NEWS_GRADIENTS[i % NEWS_GRADIENTS.length];
             return (
               <Pressable
                 key={item.id}
                 onPress={() => item.url && Linking.openURL(item.url)}
-                style={{
-                  flexDirection: 'row', alignItems: 'flex-start', gap: 10,
-                  backgroundColor: config.bg + '40', borderRadius: 10, padding: 10, marginBottom: 6,
-                }}
+                style={{ width: SCREEN_WIDTH - 60, height: 200, borderRadius: 14, overflow: 'hidden' }}
               >
-                <View style={{
-                  width: 32, height: 32, borderRadius: 8,
-                  backgroundColor: config.bg,
-                  alignItems: 'center', justifyContent: 'center',
-                }}>
-                  <FontAwesome name={config.icon as any} size={13} color={config.color} />
-                </View>
-                <View style={{ flex: 1 }}>
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-                    <View style={{ backgroundColor: config.bg, borderRadius: 6, paddingHorizontal: 6, paddingVertical: 2 }}>
-                      <Text style={{ fontSize: 9, fontWeight: '700', color: config.color, textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                        {config.label}
-                      </Text>
-                    </View>
-                    <Text style={{ fontSize: 9, color: colors.textTertiary }}>{item.source}</Text>
-                  </View>
-                  <Text style={{ fontSize: 12, fontWeight: '500', color: colors.text }} numberOfLines={2}>{item.title}</Text>
-                  <Text style={{ fontSize: 10, color: colors.textSecondary, marginTop: 2 }} numberOfLines={2}>{item.snippet}</Text>
-                </View>
-                {item.url && (
-                  <FontAwesome name="external-link" size={10} color={colors.border} style={{ marginTop: 4 }} />
-                )}
+                <LinearGradient
+                  colors={[grad[0], grad[1]]}
+                  start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                  style={{ flex: 1, justifyContent: 'flex-end', padding: 16 }}
+                >
+                  {/* Gold accent line at top */}
+                  <View style={{
+                    position: 'absolute', top: 0, left: 0, right: 0, height: 1,
+                    backgroundColor: 'rgba(200,169,106,0.3)',
+                  }} />
+                  <Text style={{
+                    fontSize: 9, fontWeight: '700', letterSpacing: 1.5,
+                    textTransform: 'uppercase', color: ACCENT_COLOR, marginBottom: 6,
+                  }}>
+                    {item.category}
+                    {item.source ? <Text style={{ opacity: 0.5 }}> · {item.source}</Text> : null}
+                  </Text>
+                  <Text style={{
+                    fontSize: 15, fontWeight: '700', fontFamily: 'Lustria-Regular',
+                    color: 'rgba(255,255,255,0.9)', lineHeight: 20, marginBottom: 6,
+                  }} numberOfLines={2}>{item.title}</Text>
+                  <Text style={{
+                    fontSize: 11, color: 'rgba(255,255,255,0.5)', lineHeight: 16,
+                  }} numberOfLines={2}>{item.snippet}</Text>
+                </LinearGradient>
               </Pressable>
             );
           })}
-        </CollapsibleSection>
+        </ScrollView>
+      </View>
 
-        {/* ─── Quick Links ───────────────────────────────────── */}
-        <CollapsibleSection title="Quick Links" icon="external-link" color={ACCENT}>
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-            {QUICK_LINKS.map((link) => (
-              <Pressable
-                key={link.label}
-                onPress={() => Linking.openURL(link.url)}
-                style={{
-                  flexDirection: 'row', alignItems: 'center', gap: 6,
-                  backgroundColor: ACCENT + '10',
-                  paddingHorizontal: 12, paddingVertical: 8, borderRadius: 10,
-                }}
-              >
-                <FontAwesome name={link.icon as any} size={12} color={ACCENT} />
-                <Text style={{ fontSize: 12, fontWeight: '500', color: ACCENT }}>{link.label}</Text>
-              </Pressable>
-            ))}
-          </View>
-        </CollapsibleSection>
+      {/* ─── Before You Go (essentials footer) ────────────── */}
+      <View style={{
+        marginTop: 28, paddingHorizontal: 20, paddingTop: 20,
+        borderTopWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+      }}>
+        <Text style={{
+          fontSize: 20, fontWeight: '700', fontFamily: 'Lustria-Regular',
+          color: colors.text, marginBottom: 16,
+        }}>Before You Go</Text>
+
+        {/* Getting Around */}
+        <Text style={{
+          fontSize: 9, fontWeight: '700', letterSpacing: 1.5,
+          textTransform: 'uppercase', color: ACCENT_COLOR, marginBottom: 10,
+        }}>Getting Around</Text>
+        {TRANSPORT_INFO.map((t) => (
+          <Text key={t.name} style={{ fontSize: 12, color: isDark ? '#9e9689' : '#7a6e63', marginBottom: 6, lineHeight: 18 }}>
+            <Text style={{ fontWeight: '600', color: colors.text }}>{t.name}</Text> — {t.text}
+          </Text>
+        ))}
+
+        {/* Good to Know */}
+        <Text style={{
+          fontSize: 9, fontWeight: '700', letterSpacing: 1.5,
+          textTransform: 'uppercase', color: ACCENT_COLOR, marginTop: 18, marginBottom: 10,
+        }}>Good to Know</Text>
+        {GOOD_TO_KNOW.map((tip, i) => (
+          <Text key={i} style={{ fontSize: 12, color: isDark ? '#9e9689' : '#7a6e63', marginBottom: 6, lineHeight: 18 }}>
+            {tip}
+          </Text>
+        ))}
+
+        {/* Emergency */}
+        <View style={{
+          flexDirection: 'row', alignItems: 'center', gap: 16,
+          marginTop: 14, paddingTop: 12,
+          borderTopWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+        }}>
+          <Text style={{
+            fontSize: 9, fontWeight: '700', letterSpacing: 1,
+            textTransform: 'uppercase', color: isDark ? '#9e9689' : '#7a6e63',
+          }}>Emergency</Text>
+          {EMERGENCY_INFO.map((e) => (
+            <Pressable
+              key={e.number}
+              onPress={() => Linking.openURL(`tel:${e.number}`)}
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+            >
+              <Text style={{ fontSize: 15, fontWeight: '700', color: 'rgba(239,68,68,0.7)' }}>{e.number}</Text>
+              <Text style={{ fontSize: 9, color: isDark ? '#7a7268' : '#a39688' }}>{e.label}</Text>
+            </Pressable>
+          ))}
+        </View>
       </View>
     </ScrollView>
+    </View>
     </PageTransition>
   );
 }

--- a/apps/mobile/app/trip/[id]/itinerary.tsx
+++ b/apps/mobile/app/trip/[id]/itinerary.tsx
@@ -10,10 +10,12 @@ import {
   MOCK_HOTEL_DETAIL,
   MOCK_DISCOVER_ACTIVITIES,
   MOCK_DESTINATION_COORDS,
+  GLANCE_HERO_IMAGES,
   adjustBrightness,
+  getActivityTypeColor,
+  TIME_OF_DAY_CONFIG,
 } from '@travyl/shared';
 import type { MockFlightDetail, MockHotelDetail, DiscoverItem, ActivityViewModel, ItineraryDayViewModel } from '@travyl/shared';
-import { getActivityTypeColor, TIME_OF_DAY_CONFIG } from '@travyl/shared';
 import MapView, { Marker } from 'react-native-maps';
 import { DaySelector, TimeGroupSection } from '@/components/itinerary';
 import type { MapMarker } from '@/components/itinerary/MapPreview';
@@ -117,22 +119,7 @@ function CollapsibleSection({ title, icon, accent, count, defaultOpen = false, c
 }
 
 // ─── Draggable Map Sheet ─────────────────────────────────
-// Snap points: PEEK (just handle + header), DEFAULT (map visible), EXPANDED (near full screen)
 const SCREEN_H = Dimensions.get('window').height;
-const SHEET_PEEK = 44;        // drag handle + header row
-const SHEET_DEFAULT = 320;    // map + header
-const SHEET_EXPANDED = Math.round(SCREEN_H * 0.75);
-const SNAP_POINTS = [0, SHEET_PEEK, SHEET_DEFAULT, SHEET_EXPANDED];
-
-function snapTo(value: number): number {
-  let best = SNAP_POINTS[0];
-  let bestDist = Math.abs(value - best);
-  for (const p of SNAP_POINTS) {
-    const d = Math.abs(value - p);
-    if (d < bestDist) { best = p; bestDist = d; }
-  }
-  return best;
-}
 
 // Route color palette
 const ROUTE_COLORS = [
@@ -377,7 +364,7 @@ function DayMap({ todayActivities, allActivities, onClose }: {
               shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.15, shadowRadius: 3,
             }}>
               <FontAwesome name="map-marker" size={12} color={ACCENT} />
-              <Text style={{ fontSize: 12, fontWeight: '600', color: '#333' }}>
+              <Text style={{ fontSize: 12, fontWeight: '600', color: colors.text }}>
                 {markers.length} {markers.length === 1 ? 'stop' : 'stops'}
               </Text>
             </View>
@@ -618,12 +605,12 @@ function DayMap({ todayActivities, allActivities, onClose }: {
 
 // ─── MobileCalendarView ─────────────────────────────────────
 
+const HOURS = Array.from({ length: 16 }, (_, i) => i + 6); // 6 AM to 9 PM
+
 function MobileCalendarView({ days, selectedDayIndex }: { days: any[]; selectedDayIndex: number }) {
   const colors = useThemeColors();
   const selectedDay = days[selectedDayIndex];
   if (!selectedDay) return null;
-
-  const HOURS = Array.from({ length: 16 }, (_, i) => i + 6); // 6 AM to 9 PM
 
   // Collect all activities from all time groups
   const allActivities = selectedDay.timeGroups?.flatMap((g: any) => g.activities ?? []) ?? [];
@@ -720,7 +707,6 @@ function SkeletonActivityCard() {
 }
 
 function SkeletonTimeSection({ icon }: { icon: string }) {
-  const colors = useThemeColors();
   return (
     <View style={{ marginBottom: 14 }}>
       <View
@@ -1317,7 +1303,7 @@ function ReminderRow({ icon, text }: { icon: string; text: string }) {
 // ─── Browse/Add Constants ───────────────────────────────────
 
 const ADD_CATEGORIES = ['All', 'Tours', 'Museums', 'Restaurants', 'Sightseeing', 'Nightlife'];
-const TIME_TO_HOUR: Record<string, number> = { morning: 9, afternoon: 13, evening: 19, latenight: 22 };
+
 
 // ─── BrowseActivityPanel ────────────────────────────────────
 
@@ -1536,182 +1522,123 @@ function BrowseActivityPanel({
 
 // ─── Main Screen ────────────────────────────────────────────
 
-// ─── FontAwesome icon mapping for time-of-day ─────────────────
-const TOD_FA_ICONS: Record<string, string> = {
-  sun: 'sun-o',
-  sunset: 'sun-o',
-  moon: 'moon-o',
-  sparkles: 'star',
-};
 
-// ─── FontAwesome icon mapping for activity categories ──────────
-const CAT_FA_ICONS: Record<string, string> = {
-  sightseeing: 'eye',
-  landmark: 'camera',
-  tour: 'compass',
-  dining: 'cutlery',
-  food: 'cutlery',
-  outdoor: 'tree',
-  cultural: 'university',
-  shopping: 'shopping-bag',
-  nightlife: 'music',
-  wellness: 'heartbeat',
-  transport: 'bus',
-};
+// ─── View Toggle (single icon button) ─────────────────────────
+function ViewToggle({ mode, onToggle, accent }: { mode: 'glance' | 'detailed'; onToggle: (m: 'glance' | 'detailed') => void; accent: string }) {
+  const colors = useThemeColors();
+  return (
+    <Pressable
+      onPress={() => onToggle(mode === 'glance' ? 'detailed' : 'glance')}
+      style={{
+        width: 32, height: 32, borderRadius: 8,
+        alignItems: 'center', justifyContent: 'center',
+        backgroundColor: mode === 'glance' ? accent : colors.cardBackground,
+        borderWidth: mode === 'glance' ? 0 : 1,
+        borderColor: colors.border,
+        marginLeft: 4,
+      }}
+    >
+      <FontAwesome
+        name="list-ul"
+        size={13}
+        color={mode === 'glance' ? '#fff' : colors.textSecondary}
+      />
+    </Pressable>
+  );
+}
 
-// ─── Glance Day Card ───────────────────────────────────────────
-function GlanceDayCard({
-  day,
-  isFirst,
-  isLast,
-  arrivalFlight,
-  returnFlight,
-  hotel,
-  accent,
+// ─── Glance View: selected day card with image at bottom ───
+function GlancePager({
+  days, selectedDayIndex, arrivalFlightNumber, returnFlightNumber,
 }: {
-  day: ItineraryDayViewModel;
-  isFirst: boolean;
-  isLast: boolean;
-  arrivalFlight?: MockFlightDetail;
-  returnFlight?: MockFlightDetail;
-  hotel: MockHotelDetail;
-  accent: string;
+  days: ItineraryDayViewModel[];
+  selectedDayIndex: number;
+  arrivalFlightNumber: string | null;
+  returnFlightNumber: string | null;
 }) {
   const colors = useThemeColors();
+  const day = days[selectedDayIndex];
+  if (!day) return null;
+
+  const heroImg = GLANCE_HERO_IMAGES[selectedDayIndex % GLANCE_HERO_IMAGES.length];
+  const isFirstDay = selectedDayIndex === 0;
+  const isLastDay = selectedDayIndex === days.length - 1;
 
   return (
-    <View style={{ borderRadius: 14, borderWidth: 1, borderColor: colors.borderLight, overflow: 'hidden' }}>
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ paddingBottom: 24 }}
+      showsVerticalScrollIndicator={false}
+    >
       {/* Day header */}
-      <View style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        paddingHorizontal: 14,
-        paddingVertical: 10,
-        backgroundColor: accent,
-      }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-          <View style={{
-            width: 28, height: 28, borderRadius: 8,
-            backgroundColor: 'rgba(255,255,255,0.2)',
-            alignItems: 'center', justifyContent: 'center',
-          }}>
-            <Text style={{ fontSize: 12, fontWeight: '700', color: '#fff' }}>{day.dayNumber}</Text>
-          </View>
+      <View style={{ paddingHorizontal: 20, paddingTop: 14, marginBottom: 10 }}>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end' }}>
           <View>
-            <Text style={{ fontSize: 14, fontWeight: '600', color: '#fff' }}>{day.dayLabel}</Text>
-            <Text style={{ fontSize: 11, color: 'rgba(255,255,255,0.7)' }}>{day.dateLabel}</Text>
+            <Text style={{
+              fontSize: 9, fontWeight: '700', letterSpacing: 2.5,
+              textTransform: 'uppercase', color: '#c8a96a', marginBottom: 2,
+            }}>
+              {day.dateLabel}
+            </Text>
+            <Text style={{
+              fontSize: 24, fontWeight: '700', color: colors.text, fontFamily: 'Lustria-Regular',
+            }}>
+              {day.dayLabel}
+            </Text>
           </View>
+          <Text style={{ fontSize: 11, color: colors.textSecondary }}>
+            {day.activityCount} {day.activityCount === 1 ? 'activity' : 'activities'}
+          </Text>
         </View>
-        <Text style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)' }}>
-          {day.activityCount} {day.activityCount === 1 ? 'activity' : 'activities'}
-        </Text>
       </View>
 
-      {/* Day content — compact timeline */}
-      <View style={{ paddingHorizontal: 14, paddingVertical: 10, backgroundColor: colors.surface }}>
-        {/* Arrival flight */}
-        {isFirst && arrivalFlight && (
+      {/* Activity timeline */}
+      <View style={{ paddingHorizontal: 20 }}>
+        {isFirstDay && arrivalFlightNumber && (
           <View style={{
-            flexDirection: 'row', alignItems: 'center', gap: 10,
-            paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: colors.borderLight,
+            flexDirection: 'row', alignItems: 'center', gap: 8,
+            marginBottom: 8, paddingBottom: 8,
+            borderBottomWidth: 1, borderBottomColor: colors.borderLight,
           }}>
-            <FontAwesome name="plane" size={13} color="#16a34a" />
-            <View style={{ flex: 1 }}>
-              <Text style={{ fontSize: 13, fontWeight: '500', color: colors.text }}>
-                Arrive — {arrivalFlight.flightNumber}
-              </Text>
-              <Text style={{ fontSize: 11, color: colors.textTertiary }}>{arrivalFlight.arrivalTime}</Text>
-            </View>
-            <View style={{ backgroundColor: '#f0fdf4', paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 }}>
-              <Text style={{ fontSize: 10, fontWeight: '600', color: '#16a34a' }}>Booked</Text>
-            </View>
+            <FontAwesome name="plane" size={11} color="#4ade80" />
+            <Text style={{ fontSize: 12, fontWeight: '600', color: colors.text }}>
+              Arrive — {arrivalFlightNumber}
+            </Text>
           </View>
         )}
 
-        {/* Hotel check-in */}
-        {isFirst && (
-          <View style={{
-            flexDirection: 'row', alignItems: 'center', gap: 10,
-            paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: colors.borderLight,
-          }}>
-            <FontAwesome name="building-o" size={13} color="#2563eb" />
-            <Text style={{ fontSize: 13, fontWeight: '500', color: colors.text, flex: 1 }}>{hotel.name}</Text>
-            <Text style={{ fontSize: 11, color: colors.textTertiary }}>Check-in</Text>
-          </View>
-        )}
-
-        {/* Time groups */}
-        {day.timeGroups.map((group) => {
+        {day.timeGroups.map((group, gi) => {
           const config = TIME_OF_DAY_CONFIG[group.timeOfDay as keyof typeof TIME_OF_DAY_CONFIG];
-          const faIcon = TOD_FA_ICONS[config.icon] ?? 'sun-o';
-
           return (
-            <View key={group.timeOfDay}>
-              {/* Time-of-day label */}
-              <View style={{
-                flexDirection: 'row', alignItems: 'center', gap: 8,
-                paddingTop: 10, paddingBottom: 4,
+            <View key={group.timeOfDay} style={{ marginBottom: gi < day.timeGroups.length - 1 ? 10 : 0 }}>
+              <Text style={{
+                fontSize: 8, fontWeight: '700', letterSpacing: 2,
+                textTransform: 'uppercase', color: '#c8a96a', marginBottom: 4, opacity: 0.7,
               }}>
-                <FontAwesome name={faIcon as any} size={11} color={accent} />
-                <Text style={{
-                  fontSize: 11, fontWeight: '700', color: accent,
-                  textTransform: 'uppercase', letterSpacing: 1,
-                }}>
-                  {config.label}
-                </Text>
-                <View style={{ flex: 1, height: 1, backgroundColor: colors.borderLight }} />
-              </View>
-
-              {/* Activities */}
+                {config.label}
+              </Text>
               {group.activities.map((activity) => {
                 const catColor = getActivityTypeColor(activity.category);
-                const catIcon = CAT_FA_ICONS[activity.category] ?? 'eye';
-
                 return (
-                  <View
-                    key={activity.id}
-                    style={{
-                      flexDirection: 'row', alignItems: 'center', gap: 8,
-                      paddingVertical: 6, paddingLeft: 4,
-                    }}
-                  >
-                    {/* Category icon */}
-                    <View style={{
-                      width: 24, height: 24, borderRadius: 6,
-                      alignItems: 'center', justifyContent: 'center',
-                      backgroundColor: catColor.bg, borderWidth: 1, borderColor: catColor.border,
+                  <View key={activity.id} style={{
+                    flexDirection: 'row', alignItems: 'center', gap: 8,
+                    paddingVertical: 4,
+                  }}>
+                    <Text style={{
+                      fontSize: 10, color: colors.textTertiary, width: 52,
+                      fontVariant: ['tabular-nums'],
                     }}>
-                      <FontAwesome name={catIcon as any} size={10} color={catColor.primary} />
-                    </View>
-
-                    {/* Name + location */}
-                    <View style={{ flex: 1, minWidth: 0 }}>
-                      <Text numberOfLines={1} style={{ fontSize: 13, fontWeight: '500', color: colors.text }}>
-                        {activity.name}
-                      </Text>
-                      {activity.locationName && (
-                        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 3, marginTop: 1 }}>
-                          <FontAwesome name="map-marker" size={9} color={colors.textTertiary} />
-                          <Text numberOfLines={1} style={{ fontSize: 11, color: colors.textTertiary }}>
-                            {activity.locationName}
-                          </Text>
-                        </View>
-                      )}
-                    </View>
-
-                    {/* Time + cost */}
-                    <View style={{ alignItems: 'flex-end', gap: 2 }}>
-                      {activity.startTime && (
-                        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 3 }}>
-                          <FontAwesome name="clock-o" size={9} color={colors.textTertiary} />
-                          <Text style={{ fontSize: 11, color: colors.textTertiary }}>{activity.startTime}</Text>
-                        </View>
-                      )}
-                      {activity.costDisplay && (
-                        <Text style={{ fontSize: 11, fontWeight: '500', color: colors.textSecondary }}>{activity.costDisplay}</Text>
-                      )}
-                    </View>
+                      {activity.startTime || '—'}
+                    </Text>
+                    <View style={{
+                      width: 5, height: 5, borderRadius: 2.5,
+                      backgroundColor: catColor.primary,
+                    }} />
+                    <Text numberOfLines={1} style={{
+                      fontSize: 13, color: colors.text, flex: 1, fontWeight: '500',
+                    }}>
+                      {activity.name}
+                    </Text>
                   </View>
                 );
               })}
@@ -1719,79 +1646,35 @@ function GlanceDayCard({
           );
         })}
 
-        {/* Return flight */}
-        {isLast && returnFlight && (
+        {isLastDay && returnFlightNumber && (
           <View style={{
-            flexDirection: 'row', alignItems: 'center', gap: 10,
-            paddingVertical: 8, borderTopWidth: 1, borderTopColor: colors.borderLight, marginTop: 4,
-          }}>
-            <FontAwesome name="plane" size={13} color="#2563eb" style={{ transform: [{ rotate: '180deg' }] }} />
-            <View style={{ flex: 1 }}>
-              <Text style={{ fontSize: 13, fontWeight: '500', color: colors.text }}>
-                Depart — {returnFlight.flightNumber}
-              </Text>
-              <Text style={{ fontSize: 11, color: colors.textTertiary }}>{returnFlight.departureTime}</Text>
-            </View>
-            <View style={{ backgroundColor: '#f0fdf4', paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 }}>
-              <Text style={{ fontSize: 10, fontWeight: '600', color: '#16a34a' }}>Booked</Text>
-            </View>
-          </View>
-        )}
-
-        {/* Hotel checkout on last day */}
-        {isLast && (
-          <View style={{
-            flexDirection: 'row', alignItems: 'center', gap: 10,
-            paddingVertical: 8, borderTopWidth: 1, borderTopColor: colors.borderLight,
-          }}>
-            <FontAwesome name="building-o" size={13} color="#2563eb" />
-            <Text style={{ fontSize: 13, fontWeight: '500', color: colors.text, flex: 1 }}>{hotel.name}</Text>
-            <Text style={{ fontSize: 11, color: colors.textTertiary }}>Check-out</Text>
-          </View>
-        )}
-
-        {/* Day notes */}
-        {day.notes && (
-          <View style={{
+            flexDirection: 'row', alignItems: 'center', gap: 8,
+            marginTop: 8, paddingTop: 8,
             borderTopWidth: 1, borderTopColor: colors.borderLight,
-            paddingTop: 8, marginTop: 4,
           }}>
-            <Text style={{ fontSize: 12, color: colors.textSecondary, fontStyle: 'italic', lineHeight: 18 }}>
-              {day.notes}
+            <FontAwesome name="plane" size={11} color="#60a5fa" style={{ transform: [{ rotate: '180deg' }] }} />
+            <Text style={{ fontSize: 12, fontWeight: '600', color: colors.text }}>
+              Depart — {returnFlightNumber}
             </Text>
           </View>
         )}
       </View>
-    </View>
-  );
-}
 
-// ─── View Toggle (At a Glance / Detailed) ─────────────────────
-function ViewToggle({ mode, onToggle, accent }: { mode: 'glance' | 'detailed'; onToggle: (m: 'glance' | 'detailed') => void; accent: string }) {
-  return (
-    <View style={{
-      flexDirection: 'row', marginHorizontal: 14, marginTop: 10, marginBottom: 6,
-      borderRadius: 10, backgroundColor: '#f3f4f6', padding: 3,
-    }}>
-      {(['glance', 'detailed'] as const).map((m) => (
-        <Pressable
-          key={m}
-          onPress={() => onToggle(m)}
-          style={{
-            flex: 1, paddingVertical: 7, borderRadius: 8,
-            alignItems: 'center',
-            backgroundColor: mode === m ? accent : 'transparent',
-          }}
-        >
-          <Text style={{
-            fontSize: 12, fontWeight: '600',
-            color: mode === m ? '#fff' : '#6b7280',
-          }}>
-            {m === 'glance' ? 'At a Glance' : 'Detailed'}
+      {/* Destination image card */}
+      <View style={{ marginTop: 16, marginHorizontal: 16, borderRadius: 14, overflow: 'hidden', height: 180 }}>
+        <Image source={{ uri: heroImg }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+        <LinearGradient
+          colors={['transparent', 'rgba(0,0,0,0.5)']}
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '50%' }}
+        />
+        <View style={{ position: 'absolute', bottom: 12, left: 14 }}>
+          <Text style={{ fontSize: 16, fontWeight: '700', color: '#fff', fontFamily: 'Lustria-Regular' }}>
+            {day.dayLabel}
           </Text>
-        </Pressable>
-      ))}
-    </View>
+          <Text style={{ fontSize: 11, color: 'rgba(255,255,255,0.7)' }}>{day.dateLabel}</Text>
+        </View>
+      </View>
+    </ScrollView>
   );
 }
 
@@ -1799,9 +1682,9 @@ export default function ItineraryScreen() {
   const colors = useThemeColors();
   const ACCENT = useTabAccent('itinerary');
   const { id } = useLocalSearchParams<{ id: string }>();
-  const { days, selectedDayIndex, setSelectedDayIndex, selectedDay, isLoading, isEmpty } =
+  const { days, selectedDayIndex, setSelectedDayIndex, selectedDay, flights, isLoading, isEmpty } =
     useItineraryScreen(id);
-  const { calendarOpen, setCalendarOpen, mapOpen, setMapOpen, theme, itineraryColorOverrides } = useContext(TabCtx);
+  const { calendarOpen, mapOpen, setMapOpen, theme, itineraryColorOverrides } = useContext(TabCtx);
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
   const [allCollapsedOverride, setAllCollapsedOverride] = useState<boolean | null>(null);
   const [addingTo, setAddingTo] = useState<string | null>(null);
@@ -1813,6 +1696,8 @@ export default function ItineraryScreen() {
 
   // (Map is now a modal overlay — no need to collapse sections)
 
+  const arrivalFlightNumber = flights[0]?.flightNumber ?? null;
+  const returnFlightNumber = flights[1]?.flightNumber ?? null;
   const arrivalFlight = MOCK_FLIGHT_DETAILS.find((f) => f.type === 'arrival');
   const returnFlight = MOCK_FLIGHT_DETAILS.find((f) => f.type === 'return');
 
@@ -1865,7 +1750,7 @@ export default function ItineraryScreen() {
     setAddSearch('');
   }, []);
 
-  const handleAddItem = useCallback((item: DiscoverItem, timeOfDay: string) => {
+  const handleAddItem = useCallback((_item: DiscoverItem, _timeOfDay: string) => {
     setAddingTo(null);
     setAddSearch('');
     setAddCategory('All');
@@ -1946,8 +1831,32 @@ export default function ItineraryScreen() {
         <View style={{ flex: 1, minWidth: 0 }}>
           <DaySelector days={days} selectedIndex={selectedDayIndex} onSelect={setSelectedDayIndex} accentColor={ACCENT} />
         </View>
-        {/* Collapse All */}
+        {/* Quick-add button */}
         {!calendarOpen && (
+          <Pressable
+            onPress={() => {
+              setViewMode('detailed');
+              setAddingTo('morning');
+              setAddCategory('All');
+              setAddSearch('');
+            }}
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: '#c8a96a' + '25',
+              borderWidth: 1,
+              borderColor: '#c8a96a' + '40',
+              marginLeft: 4,
+            }}
+          >
+            <FontAwesome name="plus" size={13} color="#c8a96a" />
+          </Pressable>
+        )}
+        {/* Collapse All */}
+        {!calendarOpen && viewMode === 'detailed' && (
           <Pressable
             onPress={toggleCollapseAll}
             style={{
@@ -1967,10 +1876,21 @@ export default function ItineraryScreen() {
             />
           </Pressable>
         )}
+        {/* View Toggle — inline next to collapse button */}
+        {!calendarOpen && (
+          <ViewToggle mode={viewMode} onToggle={setViewMode} accent={ACCENT} />
+        )}
       </View>
 
       {calendarOpen ? (
         <MobileCalendarView days={days} selectedDayIndex={selectedDayIndex} />
+      ) : viewMode === 'glance' ? (
+        <GlancePager
+          days={days}
+          selectedDayIndex={selectedDayIndex}
+          arrivalFlightNumber={arrivalFlightNumber}
+          returnFlightNumber={returnFlightNumber}
+        />
       ) : (
       <View style={{ flex: 1, flexDirection: 'column' }}>
         {/* Itinerary content */}

--- a/apps/mobile/components/itinerary/DaySelector.tsx
+++ b/apps/mobile/components/itinerary/DaySelector.tsx
@@ -9,21 +9,26 @@ interface DaySelectorProps {
   accentColor?: string;
 }
 
-const GAP = 6;
-const PADDING_H = 8;
-// Reserve space for the collapse button sitting to the right
-const RIGHT_RESERVE = 40;
+const GAP = 4;
+const PADDING_H = 6;
+const RIGHT_RESERVE = 76;
+
+/** Extract short date like "Mar 10" from full dateLabel like "Tue, Mar 10" */
+function shortDate(dateLabel: string): string {
+  // Remove weekday prefix (e.g. "Tue, Mar 10" → "Mar 10")
+  const parts = dateLabel.split(', ');
+  return parts.length > 1 ? parts.slice(1).join(', ') : dateLabel;
+}
 
 export function DaySelector({ days, selectedIndex, onSelect, accentColor }: DaySelectorProps) {
   const colors = useThemeColors();
   const { width: screenWidth } = useWindowDimensions();
   const accent = accentColor ?? colors.text;
-  // Size pills so 4 fit in the available space
   const available = screenWidth - PADDING_H * 2 - RIGHT_RESERVE;
-  const pillWidth = (available - GAP * 3) / 4;
+  const pillWidth = Math.min((available - GAP * (days.length - 1)) / Math.min(days.length, 6), 58);
 
   return (
-    <View style={{ paddingVertical: 6, paddingHorizontal: 2 }}>
+    <View style={{ paddingVertical: 4, paddingHorizontal: 2 }}>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -35,52 +40,38 @@ export function DaySelector({ days, selectedIndex, onSelect, accentColor }: DayS
             <Pressable
               key={day.id}
               onPress={() => onSelect(index)}
-              style={{
-                width: pillWidth,
-                borderRadius: 8,
-                overflow: 'hidden',
-              }}
+              style={{ width: pillWidth, borderRadius: 7, overflow: 'hidden' }}
             >
-              {selected ? (
-                <View
-                  style={{
-                    paddingVertical: 6,
-                    alignItems: 'center',
-                    borderRadius: 8,
-                    backgroundColor: accent,
+              <View
+                style={{
+                  paddingVertical: 5,
+                  alignItems: 'center',
+                  borderRadius: 7,
+                  backgroundColor: selected ? accent : colors.cardBackground,
+                  borderWidth: selected ? 0 : 1,
+                  borderColor: colors.border,
+                  ...(selected ? {
                     shadowColor: accent,
                     shadowOffset: { width: 0, height: 2 },
                     shadowOpacity: 0.2,
                     shadowRadius: 3,
                     elevation: 3,
-                  }}
-                >
-                  <Text style={{ fontSize: 9, color: 'rgba(255,255,255,0.8)', fontWeight: '500' }}>
-                    {day.dayLabel}
-                  </Text>
-                  <Text style={{ fontSize: 11, fontWeight: '700', color: '#fff', marginTop: 1 }}>
-                    {day.dateLabel}
-                  </Text>
-                </View>
-              ) : (
-                <View
-                  style={{
-                    paddingVertical: 6,
-                    alignItems: 'center',
-                    backgroundColor: colors.cardBackground,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    borderRadius: 8,
-                  }}
-                >
-                  <Text style={{ fontSize: 9, color: colors.textTertiary, fontWeight: '500' }}>
-                    {day.dayLabel}
-                  </Text>
-                  <Text style={{ fontSize: 11, fontWeight: '600', color: colors.text, marginTop: 1 }}>
-                    {day.dateLabel}
-                  </Text>
-                </View>
-              )}
+                  } : {}),
+                }}
+              >
+                <Text style={{
+                  fontSize: 8, fontWeight: '600',
+                  color: selected ? 'rgba(255,255,255,0.8)' : colors.textTertiary,
+                }}>
+                  D{day.dayNumber}
+                </Text>
+                <Text numberOfLines={1} style={{
+                  fontSize: 9, fontWeight: '700', marginTop: 1,
+                  color: selected ? '#fff' : colors.text,
+                }}>
+                  {shortDate(day.dateLabel)}
+                </Text>
+              </View>
             </Pressable>
           );
         })}

--- a/apps/mobile/components/ui/SkeletonBlock.tsx
+++ b/apps/mobile/components/ui/SkeletonBlock.tsx
@@ -9,5 +9,5 @@ export function SkeletonBlock({ width, height, radius = 6, style }: {
   style?: ViewStyle;
 }) {
   const colors = useThemeColors();
-  return <View style={[{ width, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
+  return <View style={[{ width: width as any, height, borderRadius: radius, backgroundColor: colors.skeleton }, style]} />;
 }


### PR DESCRIPTION
## Summary
Mobile itinerary glance view redesign and trip overview updates.

- Itinerary glance view: activities at top, destination image card at bottom
- Magazine styling with gold accent labels, serif day titles
- Quick-add "+" button in header (switches to detailed view with add panel)
- Collapse-all button only shows in detailed view
- Updated DaySelector pill styling
- Trip overview with magazine-style hero

## Test plan
- [ ] Glance view shows activities with times and category dots
- [ ] Destination image renders at bottom of card
- [ ] Day selector pills switch the displayed day
- [ ] Quick-add button switches to detailed view with add panel open
- [ ] Collapse-all button hidden in glance mode