### PR TITLE
feat: replace Lucide Plane icons with PaperPlane component

### DIFF
--- a/apps/web/app/(main)/trips/page.tsx
+++ b/apps/web/app/(main)/trips/page.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useTrips } from '@travyl/shared';
 import type { MockTripCard } from '@travyl/shared';
-import { Plus, Plane } from 'lucide-react';
+import { Plus } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import { Footer, OceanWave } from '@/components/home';
 import { ViewToggle, TripCard, TripListItem, CreateTripModal } from '@/components/trips';
 
@@ -327,7 +328,7 @@ function TripsContent() {
         ) : (
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <div className="w-20 h-20 rounded-full bg-gray-100 flex items-center justify-center mb-4">
-              <Plane size={32} className="text-gray-400" />
+              <PaperPlane size={32} className="text-gray-400" />
             </div>
             <h2 className="text-lg font-semibold text-gray-800 mb-1">No trips yet</h2>
             <p className="text-sm text-gray-500 mb-6 max-w-xs">Start planning your next adventure and it will appear here.</p>

--- a/apps/web/app/(trips-app)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/flights/page.tsx
@@ -3,7 +3,6 @@
 import { use, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
-  Plane,
   Search,
   ChevronDown,
   ChevronUp,
@@ -26,6 +25,7 @@ import {
   Info,
   Plus,
 } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import { useItineraryScreen, useFlights } from '@travyl/shared';
 
 /* ================================================================
@@ -198,7 +198,7 @@ function FlightSearchSection() {
       <button onClick={() => setCollapsed(!collapsed)} className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50/50 transition-colors">
         <div className="flex items-center gap-2.5">
           <div className="w-7 h-7 rounded-lg bg-[#2563eb] flex items-center justify-center">
-            <Plane size={14} className="text-white" />
+            <PaperPlane size={14} className="text-white" />
           </div>
           <div className="text-left">
             <p className="text-sm font-medium text-gray-800">Search Flights</p>
@@ -390,7 +390,7 @@ function BookedFlightCard({ flight }: { flight: typeof BOOKED_FLIGHTS[0] }) {
       {/* Header */}
       <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-4 py-3 text-white" style={{ background: gradient }}>
         <div className="flex items-center gap-2">
-          <Plane size={14} className={isOutbound ? '' : 'rotate-180'} />
+          <PaperPlane size={14} className={isOutbound ? '' : 'rotate-180'} />
           <span className="text-sm font-semibold">{flight.flightNumber}</span>
           <span className="text-xs text-white/70">{flight.date}</span>
         </div>
@@ -413,7 +413,7 @@ function BookedFlightCard({ flight }: { flight: typeof BOOKED_FLIGHTS[0] }) {
             <div className="flex items-center w-full">
               <div className="flex-1 border-t border-dashed border-gray-300" />
               <div className="w-7 h-7 rounded-full flex items-center justify-center mx-1.5" style={{ backgroundColor: '#2563eb' }}>
-                <Plane size={12} className="text-white" />
+                <PaperPlane size={12} className="text-white" />
               </div>
               <div className="flex-1 border-t border-dashed border-gray-300" />
             </div>

--- a/apps/web/app/(trips-app)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/itinerary/page.tsx
@@ -12,9 +12,10 @@ import type { MapLocation } from '@/components/leaflet-map';
 import { ItineraryPinCard } from '@/components/itinerary/ItineraryPinCard';
 import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
 import {
-  ChevronDown, X, Search, Compass, LayoutList, Plane, Map, Plus,
+  ChevronDown, X, Search, Compass, LayoutList, Map, Plus, Calendar,
 } from 'lucide-react';
 import { TIME_OF_DAY_CONFIG, getActivityTypeColor } from '@travyl/shared';
+import { PaperPlane } from '@/components/ui';
 import type { ItineraryDayViewModel } from '@travyl/shared';
 
 // ─── Mock activity coordinates (keyed by activity id) ────────────
@@ -128,7 +129,7 @@ function GlanceView({
                 <div className="flex-1 overflow-y-auto scrollbar-hide">
                   {isFirst && arrivalFlight && (
                     <div className="flex items-center gap-2 mb-1.5 pb-1" style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
-                      <Plane size={10} className="shrink-0" style={{ color: '#4ade80' }} />
+                      <PaperPlane size={10} className="shrink-0" style={{ color: '#4ade80' }} />
                       <span className="text-[10px] font-semibold text-white/80">Arrive — {arrivalFlight.flightNumber}</span>
                       <span className="text-[9px] ml-auto text-white/40">{arrivalFlight.arrivalTime}</span>
                     </div>
@@ -164,7 +165,7 @@ function GlanceView({
 
                   {isLast && returnFlight && (
                     <div className="flex items-center gap-2 mt-1 pt-1" style={{ borderTop: '1px solid rgba(255,255,255,0.08)' }}>
-                      <Plane size={10} className="shrink-0 rotate-180" style={{ color: '#60a5fa' }} />
+                      <PaperPlane size={10} className="shrink-0 rotate-180" style={{ color: '#60a5fa' }} />
                       <span className="text-[10px] font-semibold text-white/80">Depart — {returnFlight.flightNumber}</span>
                       <span className="text-[9px] ml-auto text-white/40">{returnFlight.departureTime}</span>
                     </div>
@@ -444,6 +445,14 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
               >
                 <Plus size={13} style={{ color: 'var(--magazine-accent, #c8a96a)' }} />
               </button>
+              <a
+                href={`/trip/${id}/calendar`}
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
+                style={{ border: '1px solid var(--magazine-border, rgba(0,0,0,0.15))' }}
+                title="Calendar view"
+              >
+                <Calendar size={13} style={{ color: 'var(--magazine-text, var(--muted-foreground))' }} />
+              </a>
               <button
                 onClick={() => setRequestMapOpen((v: boolean) => !v)}
                 className="w-7 h-7 rounded-full flex items-center justify-center transition-all"

--- a/apps/web/components/PostcardDetail.tsx
+++ b/apps/web/components/PostcardDetail.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { X, Star, Calendar, MapPin, Plane, Heart, LayoutGrid, Globe, RotateCcw } from 'lucide-react';
+import { X, Star, Calendar, MapPin, Heart, LayoutGrid, Globe, RotateCcw } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import type { PostcardData } from '@travyl/shared';
 
 interface PostcardDetailProps {
@@ -186,7 +187,7 @@ export function PostcardDetail({ data, onClose }: PostcardDetailProps) {
                         zIndex: 5, boxShadow: '0 1px 4px rgba(0,0,0,0.15)',
                       }}
                     >
-                      <Plane style={{ width: 16, height: 16, color: stamp.text, opacity: 0.7, transform: 'rotate(-20deg)' }} />
+                      <PaperPlane style={{ width: 16, height: 16, color: stamp.text, opacity: 0.7, transform: 'rotate(-20deg)' }} />
                       <span style={{ fontSize: 6, fontWeight: 800, color: stamp.text, marginTop: 2, letterSpacing: '0.5px' }}>AIRMAIL</span>
                       <span style={{ fontSize: 5, color: stamp.text, opacity: 0.6 }}>TRAVYL</span>
                     </motion.div>

--- a/apps/web/components/TravelBoards.tsx
+++ b/apps/web/components/TravelBoards.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Plus, Plane, Clock, MapPin, Sparkles, Compass, Star, Triangle } from "lucide-react";
+import { Plus, Clock, MapPin, Sparkles, Compass, Star, Triangle } from "lucide-react";
+import { PaperPlane } from '@/components/ui';
 import { motion } from "motion/react";
 import { TRAVEL_BOARDS, TRAVEL_DNA, JOURNEY_NUMBERS } from "@travyl/shared";
 import type { TravelBoard } from "@travyl/shared";
@@ -19,7 +20,7 @@ function BoardIcon({ icon, color }: { icon: string; color: string }) {
 function JourneyIcon({ icon, color }: { icon: string; color: string }) {
   const size = 18;
   switch (icon) {
-    case "plane": return <Plane size={size} style={{ color }} />;
+    case "plane": return <PaperPlane size={size} style={{ color }} />;
     case "clock": return <Clock size={size} style={{ color }} />;
     case "map-pin": return <MapPin size={size} style={{ color }} />;
     case "sparkles": return <Sparkles size={size} style={{ color }} />;

--- a/apps/web/components/itinerary/FlightCard.tsx
+++ b/apps/web/components/itinerary/FlightCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plane } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import type { FlightViewModel } from '@travyl/shared';
 
 interface FlightCardProps {
@@ -23,7 +23,7 @@ export function FlightCard({ flight, variant = 'outbound' }: FlightCardProps) {
         }}
       >
         <div className="flex items-center gap-2">
-          <Plane size={16} className="text-white" style={isReturn ? { transform: 'rotate(180deg)' } : undefined} />
+          <PaperPlane size={16} className="text-white" style={isReturn ? { transform: 'rotate(180deg)' } : undefined} />
           <div>
             <span className="block text-sm font-medium text-white">
               {isReturn ? 'Return Flight' : 'Outbound Flight'}
@@ -60,7 +60,7 @@ export function FlightCard({ flight, variant = 'outbound' }: FlightCardProps) {
             <div className="flex items-center w-full">
               <div className="flex-1 border-t border-dashed border-gray-300" />
               <div className="w-7 h-7 rounded-full bg-[#0ea5e9] flex items-center justify-center mx-1">
-                <Plane size={12} className="text-white" />
+                <PaperPlane size={12} className="text-white" />
               </div>
               <div className="flex-1 border-t border-dashed border-gray-300" />
             </div>

--- a/apps/web/components/itinerary/FlightSearchSection.tsx
+++ b/apps/web/components/itinerary/FlightSearchSection.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useEffect } from 'react';
 import {
-  Plane,
   Search,
   ChevronDown,
   ChevronUp,
@@ -13,6 +12,7 @@ import {
   Minus,
   RotateCcw,
 } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import type { PopularAirport } from '@travyl/shared';
 
 /* ── Constants ──────────────────────────────────────────────── */
@@ -291,7 +291,7 @@ export function FlightSearchSection() {
       >
         <div className="flex items-center gap-3">
           <div className="w-9 h-9 rounded-xl bg-blue-50 flex items-center justify-center">
-            <Plane size={18} className="text-blue-600" />
+            <PaperPlane size={18} className="text-blue-600" />
           </div>
           <div className="text-left">
             <span className="block text-sm font-semibold text-gray-900">Search Flights</span>

--- a/apps/web/components/itinerary/FlightSection.tsx
+++ b/apps/web/components/itinerary/FlightSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { Plane, ChevronDown, Check } from 'lucide-react';
+import { ChevronDown, Check } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import type { MockFlightDetail } from '@travyl/shared';
 
 interface FlightSectionProps {
@@ -40,7 +41,7 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
       >
         <div className="flex items-center justify-between text-white">
           <div className="flex items-center gap-2">
-            <Plane size={18} />
+            <PaperPlane size={18} />
             <div className="text-left">
               <div className="flex items-center gap-2">
                 <p className="text-sm">{label}</p>
@@ -88,7 +89,7 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
                 <div className="relative w-full">
                   <div className="border-t border-dashed border-gray-300 w-full" />
                   <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full p-1" style={{ backgroundColor: 'var(--trip-base)' }}>
-                    <Plane size={12} className="text-white" />
+                    <PaperPlane size={12} className="text-white" />
                   </div>
                 </div>
                 <p className="text-xs text-gray-500 mt-2">{flight.duration}</p>
@@ -180,7 +181,7 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
                   </>
                 ) : (
                   <>
-                    <Plane size={14} />
+                    <PaperPlane size={14} />
                     Book Flight
                   </>
                 )}

--- a/apps/web/components/trips/CreateTripModal.tsx
+++ b/apps/web/components/trips/CreateTripModal.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
-import { X, Plane, MapPin } from 'lucide-react'
+import { X, MapPin } from 'lucide-react'
+import { PaperPlane } from '@/components/ui'
 import { useAuthStore } from '@travyl/shared'
 import { supabase } from '@travyl/shared'
 
@@ -179,7 +180,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 rounded-full bg-[#1e3a5f] flex items-center justify-center">
-              <Plane size={14} className="text-white -rotate-12" />
+              <PaperPlane size={14} className="text-white -rotate-12" />
             </div>
             <h2 id="create-trip-title" className="text-lg font-bold text-[#1e3a5f]">Plan a Trip</h2>
           </div>

--- a/apps/web/components/trips/TripRouteHover.tsx
+++ b/apps/web/components/trips/TripRouteHover.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useMemo } from 'react';
-import { Plane, MapPin, Building2 } from 'lucide-react';
+import { MapPin, Building2 } from 'lucide-react';
+import { PaperPlane } from '@/components/ui';
 import type { MockTripCard, RouteLocation } from '@travyl/shared';
 import { RouteMap } from './RouteMap';
 
@@ -79,7 +80,7 @@ function FlightConnector() {
     <div className="flex items-center gap-1 px-2 py-1.5 ml-1">
       <div className="w-0.5 h-4 bg-slate-700" />
       <div className="flex items-center gap-1 px-2 py-0.5 bg-slate-800/80 rounded-full border border-slate-700/50">
-        <Plane size={10} className="text-blue-400 rotate-90" />
+        <PaperPlane size={10} className="text-blue-400 rotate-90" />
         <span className="text-[10px] text-slate-300 font-medium">flight</span>
       </div>
       <div className="flex-1 h-px bg-gradient-to-r from-slate-600 to-transparent" />
@@ -139,7 +140,7 @@ export function TripRouteHover({ trip }: TripRouteHoverProps) {
       {/* Route Header */}
       <div className="mb-3 pb-2 border-b border-gray-100">
         <div className="flex items-center gap-2 mb-1.5">
-          <Plane size={14} className="text-[#1e3a5f]" />
+          <PaperPlane size={14} className="text-[#1e3a5f]" />
           <span className="text-sm font-semibold text-gray-800">Trip Route</span>
         </div>
 

--- a/apps/web/components/ui/PaperPlane.tsx
+++ b/apps/web/components/ui/PaperPlane.tsx
@@ -1,0 +1,24 @@
+import { PAPER_PLANE_VIEWBOX, PAPER_PLANE_PATHS } from '@travyl/shared';
+
+interface PaperPlaneProps {
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function PaperPlane({ size = 16, className, style }: PaperPlaneProps) {
+  return (
+    <svg
+      viewBox={PAPER_PLANE_VIEWBOX}
+      width={size}
+      height={size}
+      className={className}
+      style={style}
+      fill="currentColor"
+    >
+      {PAPER_PLANE_PATHS.map((d, i) => (
+        <path key={i} d={d} />
+      ))}
+    </svg>
+  );
+}

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { GlassPill } from "./GlassPill";
+export { PaperPlane } from "./PaperPlane";
 export { Skeleton } from "./Skeleton";


### PR DESCRIPTION
## Summary
- Replace all Lucide Plane icons with custom PaperPlane SVG component for brand consistency

## Test plan
- [ ] Verify PaperPlane renders correctly across all usages