### PR TITLE
feat: remove mock data dependencies (TRA-260)

### DIFF
--- a/apps/mobile/app/(tabs)/favorites/index.tsx
+++ b/apps/mobile/app/(tabs)/favorites/index.tsx
@@ -10,14 +10,15 @@ import {
 } from 'react-native';
 import { Image } from 'expo-image';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { Navy, groupPlacesByCollection, type PlaceItem } from '@travyl/shared';
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
+import { Navy, groupPlacesByCollection, TextStyles, FontSize, FontFamily, type PlaceItem } from '@travyl/shared';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { ExplorePreview } from '@/components/home/ExplorePreview';
 import { OceanWave, Footer } from '@/components/home';
 import PlaceDetailModal from '@/components/places/PlaceDetailModal';
 import { CardStackCarousel } from '@/components/places/CardStackCarousel';
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const PLACES: PlaceItem[] = [];
 const PAD = 16;
 const GAP = 8;
 const STACK_CARD_W = SCREEN_WIDTH * 0.72;
@@ -143,17 +144,17 @@ const GridPlaceCard = memo(function GridPlaceCard({
         <View style={{ paddingHorizontal: 10, paddingTop: 8, paddingBottom: 10 }}>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 2 }}>
             <FontAwesome name="map-marker" size={9} color={colors.textTertiary} style={{ marginRight: 4 }} />
-            <Text style={{ fontSize: 10, color: colors.textTertiary, flex: 1 }} numberOfLines={1}>{place.tagline}</Text>
+            <Text style={{ ...TextStyles.sm, color: colors.textTertiary, flex: 1 }} numberOfLines={1}>{place.tagline}</Text>
           </View>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 2 }}>
-            <Text style={{ fontSize: 13, fontWeight: '600', color: colors.text, flex: 1 }} numberOfLines={1}>{place.name}</Text>
+            <Text style={{ ...TextStyles.bodyLgEm, color: colors.text, flex: 1 }} numberOfLines={1}>{place.name}</Text>
             <View style={{ flexDirection: 'row', alignItems: 'center', marginLeft: 4 }}>
               <FontAwesome name="star" size={10} color="#fbbf24" style={{ marginRight: 2 }} />
-              <Text style={{ fontSize: 10, fontWeight: '500', color: colors.textSecondary }}>{place.rating}</Text>
+              <Text style={{ ...TextStyles.sm, color: colors.textSecondary }}>{place.rating}</Text>
             </View>
           </View>
           {place.description && (
-            <Text style={{ fontSize: 10, color: colors.textSecondary, lineHeight: 14 }} numberOfLines={2}>{place.description}</Text>
+            <Text style={{ ...TextStyles.sm, color: colors.textSecondary }} numberOfLines={2}>{place.description}</Text>
           )}
           {place.tags && place.tags.length > 0 && (
             <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 4, marginTop: 6 }}>
@@ -162,7 +163,7 @@ const GridPlaceCard = memo(function GridPlaceCard({
                   paddingHorizontal: 6, paddingVertical: 2,
                   backgroundColor: colors.surface, borderRadius: 10,
                 }}>
-                  <Text style={{ fontSize: 9, color: colors.textTertiary }}>{tag}</Text>
+                  <Text style={{ ...TextStyles.xs, color: colors.textTertiary }}>{tag}</Text>
                 </View>
               ))}
             </View>
@@ -178,6 +179,7 @@ const GridPlaceCard = memo(function GridPlaceCard({
 
 export default function FavoritesScreen() {
   const colors = useThemeColors();
+  const insets = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<TabKey>('all');
   const [activeSubcategory, setActiveSubcategory] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -195,13 +197,13 @@ export default function FavoritesScreen() {
 
   // Prefetch images so they're cached when the tab loads
   useEffect(() => {
-    Image.prefetch(MOCK_PLACES.map((p) => p.image));
+    Image.prefetch(PLACES.map((p) => p.image));
   }, []);
 
   const tabFiltered = useMemo(() => {
-    if (activeTab === 'all') return MOCK_PLACES;
-    if (activeTab === 'favorites') return MOCK_PLACES.filter((p) => favorites.includes(p.id));
-    return MOCK_PLACES.filter((p) => p.type === activeTab);
+    if (activeTab === 'all') return PLACES;
+    if (activeTab === 'favorites') return PLACES.filter((p) => favorites.includes(p.id));
+    return PLACES.filter((p) => p.type === activeTab);
   }, [activeTab, favorites]);
 
   const subcategories = useMemo(() => {
@@ -247,16 +249,16 @@ export default function FavoritesScreen() {
 
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 100 }}>
         {/* Header */}
-        <View style={{ paddingHorizontal: PAD, paddingTop: 12, paddingBottom: 4 }}>
+        <View style={{ paddingHorizontal: PAD, paddingTop: insets.top + 8, paddingBottom: 4 }}>
           <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-              <Text style={{ fontSize: 26, fontWeight: '800', color: colors.text }}>Places</Text>
+              <Text style={{ ...TextStyles.headline, color: colors.text }}>Places</Text>
               <View style={{
                 backgroundColor: colors.cardBackground, borderRadius: 10,
                 paddingHorizontal: 8, paddingVertical: 2,
                 borderWidth: 1, borderColor: colors.border,
               }}>
-                <Text style={{ fontSize: 11, fontWeight: '600', color: colors.textTertiary }}>
+                <Text style={{ ...TextStyles.captionEm, color: colors.textTertiary }}>
                   {filteredPlaces.length}
                 </Text>
               </View>
@@ -318,8 +320,7 @@ export default function FavoritesScreen() {
                   style={{ marginRight: 5 }}
                 />
                 <Text style={{
-                  fontSize: 12,
-                  fontWeight: isActive ? '600' : '500',
+                  ...(isActive ? TextStyles.bodyEm : TextStyles.body),
                   color: isActive ? Navy.DEFAULT : colors.textTertiary,
                 }}>
                   {tab.label}
@@ -346,7 +347,7 @@ export default function FavoritesScreen() {
               }}
             >
               <Text style={{
-                fontSize: 11, fontWeight: '600',
+                ...TextStyles.captionEm,
                 color: !activeSubcategory ? '#fff' : colors.textSecondary,
               }}>All</Text>
             </Pressable>
@@ -362,7 +363,7 @@ export default function FavoritesScreen() {
                   }}
                 >
                   <Text style={{
-                    fontSize: 11, fontWeight: '600',
+                    ...TextStyles.captionEm,
                     color: isActive ? '#fff' : colors.textSecondary,
                   }}>{cat}</Text>
                 </Pressable>
@@ -387,7 +388,7 @@ export default function FavoritesScreen() {
               }}
             >
               <FontAwesome name="sort" size={11} color={colors.textTertiary} style={{ marginRight: 6 }} />
-              <Text style={{ fontSize: 12, fontWeight: '500', color: colors.textSecondary }}>
+              <Text style={{ ...TextStyles.body, color: colors.textSecondary }}>
                 {SORT_OPTIONS.find((o) => o.key === sortBy)?.label}
               </Text>
             </Pressable>
@@ -403,7 +404,7 @@ export default function FavoritesScreen() {
                 onChangeText={setSearchQuery}
                 placeholder="Search places..."
                 placeholderTextColor={colors.textTertiary}
-                style={{ flex: 1, fontSize: 12, color: colors.text, marginLeft: 8, paddingVertical: 0 }}
+                style={{ flex: 1, fontSize: FontSize.body, color: colors.text, marginLeft: 8, paddingVertical: 0 }}
               />
               {searchQuery.length > 0 && (
                 <Pressable onPress={() => setSearchQuery('')}>
@@ -420,7 +421,7 @@ export default function FavoritesScreen() {
             {filteredPlaces.length === 0 && (
               <View style={{ alignItems: 'center', paddingTop: 60 }}>
                 <FontAwesome name="search" size={36} color={colors.textTertiary} />
-                <Text style={{ fontSize: 15, color: colors.textTertiary, marginTop: 12 }}>
+                <Text style={{ ...TextStyles.subhead, color: colors.textTertiary, marginTop: 12 }}>
                   {activeTab === 'favorites' ? 'No favorites yet' : 'No places match your search'}
                 </Text>
               </View>
@@ -435,10 +436,10 @@ export default function FavoritesScreen() {
                     borderTopWidth: 1, borderTopColor: colors.border,
                     paddingTop: 16, paddingBottom: 12, marginTop: 8,
                   }}>
-                    <Text style={{ fontSize: 18, fontWeight: '800', color: '#1e3a5f' }}>
+                    <Text style={{ ...TextStyles.title, color: '#1e3a5f' }}>
                       {collection.label}
                     </Text>
-                    <Text style={{ fontSize: 11, color: colors.textTertiary, marginTop: 2 }}>
+                    <Text style={{ ...TextStyles.caption, color: colors.textTertiary, marginTop: 2 }}>
                       {sectionPlaces.length} places
                     </Text>
                   </View>
@@ -469,7 +470,7 @@ export default function FavoritesScreen() {
             {filteredPlaces.length === 0 ? (
               <View style={{ alignItems: 'center', paddingTop: 60 }}>
                 <FontAwesome name="search" size={36} color={colors.textTertiary} />
-                <Text style={{ fontSize: 15, color: colors.textTertiary, marginTop: 12 }}>
+                <Text style={{ ...TextStyles.subhead, color: colors.textTertiary, marginTop: 12 }}>
                   {activeTab === 'favorites' ? 'No favorites yet' : 'No places match your search'}
                 </Text>
               </View>
@@ -505,7 +506,7 @@ export default function FavoritesScreen() {
       {selectedPlace && (
         <PlaceDetailModal
           place={selectedPlace}
-          allPlaces={MOCK_PLACES}
+          allPlaces={PLACES}
           onClose={closeModal}
           favorites={favorites}
           onToggleFav={toggleFavorite}

--- a/apps/mobile/components/home/ExplorePreview.tsx
+++ b/apps/mobile/components/home/ExplorePreview.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useMemo } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useExploreRows, Gray, getCyclicGradient } from '@travyl/shared';
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
 import type { PlaceItem } from '@travyl/shared';
 import { ExploreRow } from './ExploreRow';
 
@@ -34,10 +33,8 @@ export function ExplorePreview({ contextPlace }: { contextPlace?: PlaceItem } = 
   const contextRows = useMemo(() => {
     if (!contextPlace) return null;
     const nearbyIds = contextPlace.nearbyPlaces ?? [];
-    const nearbyItems = MOCK_PLACES.filter((p) => nearbyIds.includes(p.id));
-    const similarItems = MOCK_PLACES.filter(
-      (p) => p.id !== contextPlace.id && p.type === contextPlace.type,
-    ).slice(0, 6);
+    const nearbyItems: PlaceItem[] = [];
+    const similarItems: PlaceItem[] = [];
 
     return [
       ...(nearbyItems.length > 0

--- a/apps/mobile/components/home/GetInspired.tsx
+++ b/apps/mobile/components/home/GetInspired.tsx
@@ -1,11 +1,10 @@
 import { useState, useCallback } from 'react';
 import { View, Text, Dimensions } from 'react-native';
-import { Gray } from '@travyl/shared';
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
+import { Gray, type PlaceItem } from '@travyl/shared';
 import { CardStackCarousel } from '@/components/places/CardStackCarousel';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const INSPIRED_PLACES = MOCK_PLACES.slice(0, 8);
+const INSPIRED_PLACES: PlaceItem[] = [];
 const CARD_W = SCREEN_WIDTH * 0.62;
 const CARD_H = CARD_W * 1.35;
 

--- a/apps/web/app/(main)/places/page.tsx
+++ b/apps/web/app/(main)/places/page.tsx
@@ -20,7 +20,9 @@ import {
 } from 'lucide-react';
 import type { PanInfo } from 'motion/react';
 import { groupPlacesByCollection, useSimilarPlaces } from '@travyl/shared';
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
+import type { PlaceItem as PlaceItemType } from '@travyl/shared';
+
+const MOCK_PLACES: PlaceItemType[] = [];
 import type { PlaceItem } from '@travyl/shared';
 import { PinCard } from '@/components/PinCard';
 import { PlaceDetailOverlay } from '@/components/PlaceDetailOverlay';

--- a/apps/web/app/(trips-app)/trip/[id]/favorites/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/favorites/page.tsx
@@ -6,7 +6,10 @@ import {
   Image as ImageIcon,
 } from 'lucide-react';
 import { useItineraryScreen } from '@travyl/shared';
-import { MOCK_DISCOVER_ACTIVITIES, MOCK_DISCOVER_RESTAURANTS } from '@travyl/shared/src/config/mockItineraryData';
+import type { DiscoverItem as DiscoverItemType } from '@travyl/shared';
+
+const MOCK_DISCOVER_ACTIVITIES: DiscoverItemType[] = [];
+const MOCK_DISCOVER_RESTAURANTS: DiscoverItemType[] = [];
 import type { DiscoverItem } from '@travyl/shared';
 import { SplitScreenModal } from '@/components/itinerary';
 

--- a/apps/web/app/(trips-app)/trip/[id]/info/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/info/page.tsx
@@ -10,7 +10,6 @@ import {
   Phone, ShieldAlert, Ambulance,
 } from 'lucide-react';
 import { useItineraryScreen } from '@travyl/shared';
-import { MOCK_TRIP } from '@travyl/shared/src/config/mockItineraryData';
 
 // ─── Collapsible Section ────────────────────────────────────────
 
@@ -246,16 +245,12 @@ const SAFETY_TIPS = [
 export default function InfoPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { isLoading, trip: liveTrip } = useItineraryScreen(id);
-  const trip = liveTrip ?? MOCK_TRIP;
-
-  const startDate = new Date(trip.start_date + 'T00:00:00');
-  const endDate = new Date(trip.end_date + 'T00:00:00');
-  const duration = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+  const trip = liveTrip;
 
   const formatDate = (d: Date) =>
     d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
 
-  if (isLoading) {
+  if (isLoading || !trip) {
     return (
       <div className="space-y-4">
         <div className="h-32 rounded-xl bg-gray-200 animate-pulse" />
@@ -264,6 +259,10 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
       </div>
     );
   }
+
+  const startDate = new Date(trip.start_date + 'T00:00:00');
+  const endDate = new Date(trip.end_date + 'T00:00:00');
+  const duration = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
 
   return (
     <div className="space-y-3">

--- a/apps/web/app/(trips-app)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/itinerary/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { use, useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useItineraryScreen, MOCK_FLIGHT_DETAILS, MOCK_HOTEL_DETAIL, MOCK_DISCOVER_ACTIVITIES, GLANCE_HERO_IMAGES, MOCK_PLACES, TOD_START_HOURS, QUICK_FILL_CATEGORIES, pickRandomActivity } from '@travyl/shared';
+import { useItineraryScreen, GLANCE_HERO_IMAGES, TOD_START_HOURS, QUICK_FILL_CATEGORIES, pickRandomActivity } from '@travyl/shared';
+import type { MockFlightDetail, PlaceItem } from '@travyl/shared';
 import type { DiscoverItem } from '@travyl/shared';
 import { useItineraryContext } from '@/components/itinerary/ItineraryContext';
 import {
   ItineraryEmpty, TimeGroupSection, SplitScreenModal,
-  FlightSection, HotelSection, CheckoutSection,
+  FlightSection,
 } from '@/components/itinerary';
 import type { MapLocation } from '@/components/leaflet-map';
 import { ItineraryPinCard } from '@/components/itinerary/ItineraryPinCard';
@@ -36,32 +37,6 @@ import { TIME_OF_DAY_CONFIG, getActivityTypeColor } from '@travyl/shared';
 import { PaperPlane } from '@/components/ui';
 import type { ItineraryDayViewModel } from '@travyl/shared';
 
-// ─── Mock activity coordinates (keyed by activity id) ────────────
-const MOCK_ACTIVITY_COORDS: Record<string, { lat: number; lng: number }> = {
-  // Legacy IDs
-  'mock-a1': { lat: 48.8584, lng: 2.2945 },
-  'mock-a2': { lat: 48.8590, lng: 2.2930 },
-  'mock-a3': { lat: 48.8510, lng: 2.3360 },
-  'mock-a4': { lat: 48.8606, lng: 2.3376 },
-  'mock-a5': { lat: 48.8584, lng: 2.2945 },
-  'mock-a6': { lat: 48.8867, lng: 2.3431 },
-  'mock-a7': { lat: 48.8049, lng: 2.1204 },
-  'mock-a8': { lat: 48.8048, lng: 2.1172 },
-  'mock-a9': { lat: 48.8698, lng: 2.3075 },
-  // Calendar activity IDs
-  'cal-1':  { lat: 48.8584, lng: 2.2945 },  // Eiffel Tower
-  'cal-2':  { lat: 48.8566, lng: 2.3622 },  // Le Marais
-  'cal-3':  { lat: 48.8606, lng: 2.3376 },  // Louvre Museum
-  'cal-4':  { lat: 48.8867, lng: 2.3431 },  // Montmartre
-  'cal-5':  { lat: 48.8530, lng: 2.3499 },  // Le Foodist (cooking class)
-  'cal-6':  { lat: 48.8510, lng: 2.3360 },  // Le Comptoir, Saint-Germain
-  'cal-7':  { lat: 48.8049, lng: 2.1204 },  // Versailles
-  'cal-8':  { lat: 48.8566, lng: 2.3425 },  // Seine River Cruise, Pont Neuf
-  'cal-9':  { lat: 48.8600, lng: 2.3266 },  // Musée d'Orsay
-  'cal-10': { lat: 48.8462, lng: 2.3372 },  // Luxembourg Gardens
-  'cal-11': { lat: 48.8510, lng: 2.3230 },  // Le Bon Marché
-  'cal-12': { lat: 48.8584, lng: 2.2945 },  // Le Jules Verne (Eiffel Tower)
-};
 
 
 import { Skeleton } from '@/components/ui';
@@ -106,9 +81,7 @@ function GlanceSearchInput({ query, onChange, onClose, onSelect }: {
   onClose: () => void;
   onSelect: (place: import('@travyl/shared').PlaceItem) => void;
 }) {
-  const results = query.length > 1
-    ? MOCK_PLACES.filter((p) => p.name.toLowerCase().includes(query.toLowerCase())).slice(0, 3)
-    : [];
+  const results: import('@travyl/shared').PlaceItem[] = []; // TODO: wire up real place search API
   return (
     <div className="mt-1">
       <div className="relative">
@@ -163,8 +136,8 @@ function GlanceView({
   days: ItineraryDayViewModel[];
   selectedDayIndex: number;
   onSelectDay: (i: number) => void;
-  arrivalFlight?: typeof MOCK_FLIGHT_DETAILS[number];
-  returnFlight?: typeof MOCK_FLIGHT_DETAILS[number];
+  arrivalFlight?: MockFlightDetail;
+  returnFlight?: MockFlightDetail;
   onActivityClick?: (activityId: string) => void;
   addActivity?: (activity: import('@travyl/shared').CalendarActivity) => void;
   removeActivity?: (id: string) => void;
@@ -531,11 +504,11 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
   const [browseIndex, setBrowseIndex] = useState<number | null>(null);
   const [favorites, setFavorites] = useState<string[]>([]);
 
-  const arrivalFlight = MOCK_FLIGHT_DETAILS.find((f) => f.type === 'arrival');
-  const returnFlight = MOCK_FLIGHT_DETAILS.find((f) => f.type === 'return');
+  const arrivalFlight: MockFlightDetail | undefined = undefined; // TODO: wire up real flight data
+  const returnFlight: MockFlightDetail | undefined = undefined; // TODO: wire up real flight data
 
   const filteredDiscoverItems = useMemo(() => {
-    let items = MOCK_DISCOVER_ACTIVITIES;
+    let items: DiscoverItem[] = []; // TODO: wire up real discover/suggestions API
     if (addSearch) {
       const q = addSearch.toLowerCase();
       items = items.filter((i) =>
@@ -593,25 +566,20 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
     for (const day of days) {
       for (const group of day.timeGroups) {
         for (const a of group.activities) {
-          // Try to find matching discover activity for richer data (images, etc.)
-          const discover = MOCK_DISCOVER_ACTIVITIES.find((d) =>
-            d.name.toLowerCase() === a.name.toLowerCase() ||
-            d.id === a.id,
-          );
           items.push({
             id: a.id,
             name: a.name,
-            location: a.locationName || discover?.location || 'Paris, France',
-            description: a.notes || discover?.description || `${a.category} activity`,
-            images: discover?.images || [],
-            rating: discover?.rating || 4.5,
+            location: a.locationName || '',
+            description: a.notes || `${a.category} activity`,
+            images: [],
+            rating: 0,
             tags: [a.category, group.timeOfDay, a.costDisplay || ''].filter(Boolean),
-            price: a.costDisplay || discover?.price || undefined,
+            price: a.costDisplay || undefined,
             category: a.category,
             isBooked: true,
             bookedDay: day.dayNumber,
             bookedTime: a.startTime || undefined,
-            bookingUrl: a.bookingUrl || discover?.bookingUrl || undefined,
+            bookingUrl: a.bookingUrl || undefined,
           });
         }
       }
@@ -620,19 +588,8 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
   }, [days]);
 
   const mapLocations: MapLocation[] = useMemo(() => {
-    if (!selectedDay) return [];
-    return selectedDay.timeGroups.flatMap((g) =>
-      g.activities
-        .filter((a) => MOCK_ACTIVITY_COORDS[a.id])
-        .map((a) => ({
-          id: a.id,
-          lat: MOCK_ACTIVITY_COORDS[a.id].lat,
-          lng: MOCK_ACTIVITY_COORDS[a.id].lng,
-          name: a.name,
-          color: getActivityTypeColor(a.category).primary,
-          category: a.category,
-        })),
-    );
+    // TODO: wire up real activity coordinates from API
+    return [];
   }, [selectedDay]);
 
   // Push markers to layout map
@@ -799,9 +756,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
           {isFirstDay && arrivalFlight && (
             <FlightSection flight={arrivalFlight} collapsed={allCollapsedOverride ?? undefined} />
           )}
-          {isFirstDay && (
-            <HotelSection hotel={MOCK_HOTEL_DETAIL} label="Check-in · Mar 10" collapsed={allCollapsedOverride ?? undefined} />
-          )}
+          {/* TODO: wire up real hotel check-in data */}
 
           {selectedDay.timeGroups.map((group) => (
             <div key={group.timeOfDay}>
@@ -901,18 +856,11 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
             </div>
           ))}
 
-          {!isFirstDay && !isLastDay && (
-            <HotelSection hotel={MOCK_HOTEL_DETAIL} label={`Night ${selectedDay.dayNumber} · ${selectedDay.dateLabel}`} collapsed={allCollapsedOverride ?? undefined} />
-          )}
+          {/* TODO: wire up real hotel data for non-first/non-last days */}
 
           {isLastDay && (
             <>
-              <CheckoutSection
-                hotelName={MOCK_HOTEL_DETAIL.name}
-                hotelAddress={MOCK_HOTEL_DETAIL.address}
-                checkOutTime={MOCK_HOTEL_DETAIL.checkOutTime}
-                collapsed={allCollapsedOverride ?? undefined}
-              />
+              {/* TODO: wire up real hotel checkout data */}
               {returnFlight && <FlightSection flight={returnFlight} collapsed={allCollapsedOverride ?? undefined} />}
             </>
           )}

--- a/apps/web/app/(trips-app)/trip/[id]/packing/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/packing/page.tsx
@@ -3,8 +3,9 @@
 import { use, useState } from 'react';
 import { Luggage, Sun, Plus, X, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { MOCK_PACKING_LIST, MOCK_TRIP, useItineraryScreen } from '@travyl/shared';
-import type { PackingList } from '@travyl/shared';
+import { useItineraryScreen } from '@travyl/shared';
+
+type PackingList = Record<string, { item: string; packed: boolean }[]>;
 
 import { Skeleton } from '@/components/ui';
 
@@ -45,15 +46,15 @@ function SkeletonPacking() {
 export default function Packing({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
 
-  const [packingList, setPackingList] = useState<PackingList>({ ...MOCK_PACKING_LIST });
+  const [packingList, setPackingList] = useState<PackingList>({});
   const [newItemInputs, setNewItemInputs] = useState<Record<string, string>>({});
   const [isCreatingList, setIsCreatingList] = useState(false);
   const [newListName, setNewListName] = useState('');
 
   const { trip: liveTrip } = useItineraryScreen(id);
-  const trip = liveTrip ?? MOCK_TRIP;
-  const destination = trip.destination ?? '';
-  const currentWeather = trip.trip_context?.weather?.current;
+  const trip = liveTrip;
+  const destination = trip?.destination ?? '';
+  const currentWeather = trip?.trip_context?.weather?.current;
 
   /* derived counts */
   const allItems = Object.values(packingList).flat();

--- a/apps/web/app/(trips-app)/trip/[id]/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState, useEffect, useRef } from 'react';
 import { Plus, ChevronLeft, ChevronRight } from 'lucide-react';
-import { useItineraryScreen, NEWS_COLORS } from '@travyl/shared';
+import { useItineraryScreen } from '@travyl/shared';
 import type { TripContextData } from '@travyl/shared';
 
 // ── Hooks ─────────────────────────────────────────────────────
@@ -47,6 +47,13 @@ function AddToTripButton({ isAdded, onToggle }: { isAdded: boolean; onToggle: ()
     </button>
   );
 }
+
+const NEWS_COLORS: [string, string][] = [
+  ['#1a1a2e', '#16213e'],
+  ['#0f3460', '#1a1a2e'],
+  ['#2c3e50', '#1a1a2e'],
+  ['#1b2838', '#0f3460'],
+];
 
 // ── Sections ─────────────────────────────────────────────────
 

--- a/apps/web/components/PlaceDetailOverlay.tsx
+++ b/apps/web/components/PlaceDetailOverlay.tsx
@@ -12,8 +12,9 @@ import { ExplorePreview } from '@/components/home/ExplorePreview';
 import { Footer } from '@/components/home/Footer';
 import { OceanWave } from '@/components/home/OceanWave';
 import { useSimilarPlaces, Navy } from '@travyl/shared';
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
 import type { PlaceItem } from '@travyl/shared';
+
+const MOCK_PLACES: PlaceItem[] = [];
 
 const LeafletMap = dynamic(() => import('@/components/leaflet-map'), { ssr: false });
 

--- a/apps/web/components/home/GetInspired.tsx
+++ b/apps/web/components/home/GetInspired.tsx
@@ -5,7 +5,9 @@ import { AnimatePresence, motion, type PanInfo } from "motion/react";
 import Image from "next/image";
 import { ChevronLeft, ChevronRight, Heart, Star, MapPin, Repeat, Clock, Globe, Lightbulb } from "lucide-react";
 import { EASE_OUT_EXPO, Navy } from "@travyl/shared";
-import { MOCK_PLACES } from '@travyl/shared/src/config/mockPlacesData';
+import type { PlaceItem as PlaceItemType } from '@travyl/shared';
+
+const MOCK_PLACES: PlaceItemType[] = [];
 import type { PlaceItem } from "@travyl/shared";
 
 const INSPIRED_PLACES = MOCK_PLACES.slice(0, 8);
@@ -208,6 +210,8 @@ export function GetInspired() {
   const [direction, setDirection] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const cards = INSPIRED_PLACES;
+
+  if (cards.length === 0) return null;
 
   // Reset flip when card changes
   useEffect(() => {

--- a/apps/web/components/itinerary/CalendarView.tsx
+++ b/apps/web/components/itinerary/CalendarView.tsx
@@ -15,7 +15,8 @@ import {
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import type { CalendarActivity, CollaboratorPresence } from '@travyl/shared';
-import { MOCK_CALENDAR_ACTIVITIES, MOCK_DAYS, MOCK_COLLABORATORS } from '@travyl/shared/src/config/mockItineraryData';
+const MOCK_COLLABORATORS: CollaboratorPresence[] = [];
+const MOCK_DAYS: { dayLabel: string; dateLabel: string; theme?: string }[] = [];
 import { useItineraryContext } from './ItineraryContext';
 
 // ─── Constants ──────────────────────────────────────────────

--- a/apps/web/components/itinerary/ItineraryContext.tsx
+++ b/apps/web/components/itinerary/ItineraryContext.tsx
@@ -3,7 +3,8 @@
 import { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
 import type { CalendarActivity } from '@travyl/shared';
 import type { ItineraryDayViewModel, ActivityViewModel, TimeGroup } from '@travyl/shared';
-import { MOCK_CALENDAR_ACTIVITIES, MOCK_DAYS } from '@travyl/shared/src/config/mockItineraryData';
+const MOCK_CALENDAR_ACTIVITIES: CalendarActivity[] = [];
+const MOCK_DAYS: { id: string; dayNumber: number; dayLabel: string; dateLabel: string; theme?: string; notes?: string }[] = [];
 import type { MapLocation } from '@/components/leaflet-map';
 
 // ─── Conversion: CalendarActivity[] → ItineraryDayViewModel[] ─────
@@ -78,8 +79,8 @@ function calendarActivitiesToDayViewModels(
       dayNumber: baseDay.dayNumber,
       dayLabel: baseDay.dayLabel,
       dateLabel: baseDay.dateLabel,
-      theme: baseDay.theme,
-      notes: baseDay.notes,
+      theme: baseDay.theme ?? null,
+      notes: baseDay.notes ?? null,
       timeGroups,
       activityCount: allVMs.length,
     };

--- a/packages/shared/src/config/featureFlags.ts
+++ b/packages/shared/src/config/featureFlags.ts
@@ -1,2 +1,2 @@
 /** When true, hooks return mock data instead of fetching from Supabase. */
-export const USE_MOCK_DATA = true;
+export const USE_MOCK_DATA = false;

--- a/packages/shared/src/config/itineraryData.ts
+++ b/packages/shared/src/config/itineraryData.ts
@@ -1,4 +1,3 @@
-import { MOCK_DISCOVER_ACTIVITIES } from './mockItineraryData';
 import type { DiscoverItem } from '../types';
 
 // Navy and TAB_COLORS are now exported from colors.ts via config/index.ts
@@ -124,12 +123,16 @@ export function formatHourToTime(hour: number): string {
   return m === 0 ? `${h12} ${period}` : `${h12}:${String(m).padStart(2, '0')} ${period}`;
 }
 
-export function pickRandomActivity(category: string | null, excludeIds: string[]): DiscoverItem | null {
-  let pool = MOCK_DISCOVER_ACTIVITIES.filter((a) => !excludeIds.includes(a.id));
-  if (category) {
-    const filtered = pool.filter((a) => a.category?.toLowerCase().includes(category));
-    if (filtered.length > 0) pool = filtered;
-  }
-  if (pool.length === 0) return null;
-  return pool[Math.floor(Math.random() * pool.length)];
+export function pickRandomActivity(_category: string | null, _excludeIds: string[]): DiscoverItem | null {
+  // TODO: Replace with real activity data source
+  return null;
 }
+
+// ─── Glance Hero Images ────────────────────────────────────
+export const GLANCE_HERO_IMAGES = [
+  'https://images.unsplash.com/photo-1499856871958-5b9627545d1a?w=1400&q=85',
+  'https://images.unsplash.com/photo-1550340499-a6c60fc8287c?w=1400&q=85',
+  'https://images.unsplash.com/photo-1514933651103-005eec06c04b?w=1400&q=85',
+  'https://images.unsplash.com/photo-1534156355180-a1b40e8282eb?w=1400&q=85',
+  'https://images.unsplash.com/photo-1478391679764-b2d8b3cd1e94?w=1400&q=85',
+];

--- a/packages/shared/src/hooks/useActivityFilters.ts
+++ b/packages/shared/src/hooks/useActivityFilters.ts
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import { MOCK_DISCOVER_ACTIVITIES } from '../config/mockItineraryData';
 import type { DiscoverItem } from '../types';
 import type { ItineraryDayViewModel } from '../viewmodels/itineraryViewModel';
 
@@ -86,7 +85,7 @@ export function buildBookedActivities(days: ItineraryDayViewModel[]): DiscoverIt
 // ─── Hook ─────────────────────────────────────────────────────
 export function useActivityFilters(days: ItineraryDayViewModel[]) {
   const bookedItems = useMemo(() => buildBookedActivities(days), [days]);
-  const discoverItems = MOCK_DISCOVER_ACTIVITIES;
+  const discoverItems: DiscoverItem[] = [];
 
   const [viewMode, setViewMode] = useState<'booked' | 'discover'>('discover');
   const [searchQuery, setSearchQuery] = useState('');

--- a/packages/shared/src/hooks/useExploreRows.ts
+++ b/packages/shared/src/hooks/useExploreRows.ts
@@ -1,17 +1,9 @@
 import { useState, useCallback, useMemo } from 'react';
 import { getCyclicGradient } from '../config/homeData';
 import { useExploreData } from './useExploreData';
-import { MOCK_PLACES } from '../config/mockPlacesData';
 import type { PlaceItem } from '../types';
 
-// Group MOCK_PLACES by type for fallback rows
-const FALLBACK_ROWS = [
-  { title: 'Popular Destinations', items: MOCK_PLACES.filter(p => p.type === 'destination').slice(0, 8) },
-  { title: 'Famous Attractions', items: MOCK_PLACES.filter(p => p.type === 'attraction').slice(0, 8) },
-  { title: 'Top Restaurants', items: MOCK_PLACES.filter(p => p.type === 'restaurant').slice(0, 8) },
-  { title: 'Hot Experiences', items: MOCK_PLACES.filter(p => p.type === 'experience').slice(0, 8) },
-  { title: 'Upcoming Events', items: MOCK_PLACES.filter(p => p.type === 'event').slice(0, 8) },
-];
+const FALLBACK_ROWS: { title: string; items: PlaceItem[] }[] = [];
 
 export function useExploreRows() {
   const { data: rawRows, isLoading } = useExploreData();

--- a/packages/shared/src/hooks/useItineraryScreen.ts
+++ b/packages/shared/src/hooks/useItineraryScreen.ts
@@ -9,8 +9,6 @@ import {
   buildHotelViewModel,
 } from '../viewmodels/itineraryViewModel';
 import { buildBudgetSummary } from '../viewmodels/budgetViewModel';
-import { MOCK_DAYS, MOCK_FLIGHTS, MOCK_HOTELS, MOCK_TRIP, MOCK_BUDGET } from '../config/mockItineraryData';
-import { USE_MOCK_DATA } from '../config/featureFlags';
 
 export function useItineraryScreen(tripId: string | undefined) {
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
@@ -19,22 +17,22 @@ export function useItineraryScreen(tripId: string | undefined) {
   const flightsQuery = useFlights(tripId);
   const hotelsQuery = useHotels(tripId);
 
-  const dayViewModels = useMemo(
+  const days = useMemo(
     () => (daysQuery.data ?? []).map(buildItineraryDayViewModel),
     [daysQuery.data],
   );
 
-  const flightViewModels = useMemo(
+  const flights = useMemo(
     () => (flightsQuery.data ?? []).map(buildFlightViewModel),
     [flightsQuery.data],
   );
 
-  const hotelViewModels = useMemo(
+  const hotels = useMemo(
     () => (hotelsQuery.data ?? []).map(buildHotelViewModel),
     [hotelsQuery.data],
   );
 
-  const budgetSummary = useMemo(
+  const budget = useMemo(
     () => buildBudgetSummary(
       daysQuery.data ?? [],
       flightsQuery.data ?? [],
@@ -49,16 +47,8 @@ export function useItineraryScreen(tripId: string | undefined) {
     (tripQuery.isLoading && !tripQuery.error) ||
     (daysQuery.isLoading && !daysQuery.error);
 
-  // Fall back to mock data when real data is empty and USE_MOCK_DATA is enabled
-  // To disable mock fallbacks: set USE_MOCK_DATA = false in config/featureFlags.ts
-  const hasRealData = dayViewModels.length > 0 || flightViewModels.length > 0 || hotelViewModels.length > 0;
-  const useMock = USE_MOCK_DATA && !isStillLoading && !hasRealData;
-
-  const days = useMock ? MOCK_DAYS : dayViewModels;
-  const flights = useMock ? MOCK_FLIGHTS : flightViewModels;
-  const hotels = useMock ? MOCK_HOTELS : hotelViewModels;
-  const trip = useMock ? MOCK_TRIP : (tripQuery.data ?? null);
-  const budget = useMock ? MOCK_BUDGET : budgetSummary;
+  const trip = tripQuery.data ?? null;
+  const isEmpty = !isStillLoading && days.length === 0 && flights.length === 0 && hotels.length === 0;
 
   const refetch = useCallback(() => {
     tripQuery.refetch();
@@ -79,7 +69,7 @@ export function useItineraryScreen(tripId: string | undefined) {
     isLoading: isStillLoading,
     refetch,
     error: tripQuery.error || daysQuery.error,
-    isEmpty: false, // Never empty — mock data fills in
-    isMockData: useMock,
+    isEmpty,
+    isMockData: false,
   };
 }

--- a/packages/shared/src/hooks/useRestaurantFilters.ts
+++ b/packages/shared/src/hooks/useRestaurantFilters.ts
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import { MOCK_DISCOVER_RESTAURANTS } from '../config/mockItineraryData';
 import type { DiscoverItem } from '../types';
 
 // ─── Constants (shared between web + mobile) ──────────────────
@@ -37,7 +36,7 @@ export const RESTAURANT_SORT_OPTIONS: { key: RestaurantSortOption; label: string
 
 // ─── Hook ─────────────────────────────────────────────────────
 export function useRestaurantFilters() {
-  const allDining = MOCK_DISCOVER_RESTAURANTS;
+  const allDining: DiscoverItem[] = [];
   const bookedItems = allDining.filter((d) => d.isBooked);
   const discoverItems = allDining.filter((d) => !d.isBooked);
 

--- a/packages/shared/src/hooks/useTrips.ts
+++ b/packages/shared/src/hooks/useTrips.ts
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchTrips } from '../services/api';
 import { useAuthStore } from '../stores/authStore';
-import { MOCK_TRIPS } from '../config/mockTripsData';
-import { USE_MOCK_DATA } from '../config/featureFlags';
 
 export function useTrips() {
   const user = useAuthStore((s) => s.user);
   return useQuery({
     queryKey: ['trips'],
-    queryFn: user ? fetchTrips : () => Promise.resolve(MOCK_TRIPS),
-    enabled: !!user || USE_MOCK_DATA,
+    queryFn: fetchTrips,
+    enabled: !!user,
   });
 }

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -408,28 +408,6 @@ export async function updateTripSettings(tripId: string, settings: Record<string
   if (error) throw error;
 }
 
-export async function updateTripDetails(
-  tripId: string,
-  updates: Partial<Pick<Trip, 'title' | 'destination' | 'start_date' | 'end_date' | 'budget' | 'currency' | 'travelers' | 'status'>>
-): Promise<void> {
-  const { error } = await supabase.from('trips').update(updates).eq('id', tripId)
-  if (error) throw error
-}
-
-export async function deleteTrip(tripId: string): Promise<void> {
-  const { error } = await supabase.from('trips').delete().eq('id', tripId)
-  if (error) throw error
-}
-
-export async function leaveTrip(tripId: string, userId: string): Promise<void> {
-  const { error } = await supabase
-    .from('trip_collaborators')
-    .delete()
-    .eq('trip_id', tripId)
-    .eq('user_id', userId)
-  if (error) throw error
-}
-
 // ── Collaborators ──────────────────────────────────────
 
 export async function fetchCollaborators(tripId: string): Promise<TripCollaborator[]> {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -688,6 +688,9 @@ export interface TravelBoard {
 
 // ─── Trip Sharing ────────────────────────────────────────────
 
+// TripVisibility is an alias for Visibility (exported at top of file)
+export type TripVisibility = Visibility
+
 export interface TripNote {
   id: string
   trip_id: string
@@ -719,4 +722,103 @@ export interface EffectivePermission {
   canDelete: boolean
   canInvite: boolean
   canCreateNotes: boolean
+}
+
+// ─── Trip Card / Member Types ──────────────────────────────
+
+export interface TripMember {
+  id: string;
+  name: string;
+  avatar?: string;
+  role: 'owner' | 'editor' | 'viewer';
+}
+
+export interface MockTripCard extends Trip {
+  image: string;
+  images?: string[];
+  route?: TripRoute;
+  members?: TripMember[];
+}
+
+// ─── Flight / Hotel Detail Types ────────────────────────────
+
+export interface MockFlightDetail {
+  id: string;
+  type: 'arrival' | 'return';
+  airline: string;
+  flightNumber: string;
+  originIata: string;
+  originName: string;
+  destIata: string;
+  destName: string;
+  departureTime: string;
+  arrivalTime: string;
+  departureTerminal: string;
+  arrivalTerminal: string;
+  gate: string;
+  boardingTime: string;
+  duration: string;
+  aircraft: string;
+  cabinClass: string;
+  seats: string;
+  baggage: string;
+  meal: string;
+  wifi: boolean;
+  confirmation: string;
+  status: 'On Time' | 'Delayed' | 'Boarding';
+  pricePerTraveler: number;
+  totalPrice: number;
+  currency: string;
+  isBooked: boolean;
+}
+
+export interface MockHotelRoom {
+  id: string;
+  name: string;
+  image: string;
+  images?: string[];
+  amenities: string[];
+  pricePerNight: number;
+  size?: string;
+  beds?: string;
+  maxGuests?: number;
+  isSelected: boolean;
+}
+
+export interface MockHotelGuestRatings {
+  overall: number;
+  label: string;
+  cleanliness: number;
+  staff: number;
+  location: number;
+  comfort: number;
+  value: number;
+  totalRatings: number;
+}
+
+export interface MockHotelDetail {
+  id: string;
+  name: string;
+  address: string;
+  lat: number;
+  lng: number;
+  rating: number;
+  starRating: number;
+  checkInTime: string;
+  checkOutTime: string;
+  checkInDate: string;
+  checkOutDate: string;
+  amenities: string[];
+  images: string[];
+  rooms: MockHotelRoom[];
+  isBooked: boolean;
+  totalPrice: number;
+  currency: string;
+  guestRatings: MockHotelGuestRatings;
+  taxesAndFees: { cityTax: number; serviceFee: number; vat: number };
+  phone: string;
+  email: string;
+  website: string;
+  neighborhood: string;
+  confirmationNumber: string;
 }

--- a/packages/shared/src/viewmodels/budgetViewModel.ts
+++ b/packages/shared/src/viewmodels/budgetViewModel.ts
@@ -1,0 +1,73 @@
+import type { ItineraryDayWithActivities, Flight, Hotel } from '../types';
+import { formatCurrency } from '../utils';
+
+export interface BudgetCategory {
+  label: string;
+  amount: number;
+  formatted: string;
+}
+
+export interface BudgetSummary {
+  total: number;
+  totalFormatted: string;
+  categories: BudgetCategory[];
+  currency: string;
+}
+
+export function buildBudgetSummary(
+  days: ItineraryDayWithActivities[],
+  flights: Flight[],
+  hotels: Hotel[],
+  currency = 'USD',
+): BudgetSummary {
+  // Sum activity costs
+  let activitiesCost = 0;
+  for (const day of days) {
+    for (const activity of day.activities) {
+      if (activity.estimated_cost != null) {
+        activitiesCost += activity.estimated_cost;
+      }
+    }
+  }
+
+  // Sum flight prices
+  let flightsCost = 0;
+  for (const flight of flights) {
+    if (flight.data.price != null) {
+      flightsCost += flight.data.price;
+    }
+  }
+
+  // Sum hotel prices
+  let hotelsCost = 0;
+  for (const hotel of hotels) {
+    if (hotel.data.total_price != null) {
+      hotelsCost += hotel.data.total_price;
+    } else if (hotel.data.price_per_night != null) {
+      const checkIn = new Date(hotel.data.check_in + 'T00:00:00');
+      const checkOut = new Date(hotel.data.check_out + 'T00:00:00');
+      const nights = Math.max(1, Math.round((checkOut.getTime() - checkIn.getTime()) / (1000 * 60 * 60 * 24)));
+      hotelsCost += hotel.data.price_per_night * nights;
+    }
+  }
+
+  const total = activitiesCost + flightsCost + hotelsCost;
+
+  const categories: BudgetCategory[] = [];
+  if (flightsCost > 0) {
+    categories.push({ label: 'Flights', amount: flightsCost, formatted: formatCurrency(flightsCost, currency) });
+  }
+  if (hotelsCost > 0) {
+    categories.push({ label: 'Hotels', amount: hotelsCost, formatted: formatCurrency(hotelsCost, currency) });
+  }
+  if (activitiesCost > 0) {
+    categories.push({ label: 'Activities', amount: activitiesCost, formatted: formatCurrency(activitiesCost, currency) });
+  }
+
+  return {
+    total,
+    totalFormatted: formatCurrency(total, currency),
+    categories,
+    currency,
+  };
+}


### PR DESCRIPTION
## Summary
- Remove mock data barrel exports, set USE_MOCK_DATA=false
- Replace mock references with empty defaults across 23 web and mobile files
- Restore budgetViewModel.ts and fix duplicate api.ts functions from merge
- Keep UI content data (login, profile, travel boards) that pages depend on

## Test plan
- [ ] Web build passes
- [ ] Pages show empty states gracefully (no crashes)
- [ ] Real data from Supabase renders when available