### PR TITLE
fix: SST service secret rename and event bus syntax

### DIFF
--- a/infra/events.ts
+++ b/infra/events.ts
@@ -2,6 +2,7 @@ import { userInteractions } from './storage'
 
 export const bus = new sst.aws.Bus('InteractionBus')
 
-bus.subscribe('services/processInteraction.handler', {
+bus.subscribe('InteractionBusSubscriber', {
+  handler: 'services/processInteraction.handler',
   link: [userInteractions],
 })

--- a/services/backfill-embeddings.ts
+++ b/services/backfill-embeddings.ts
@@ -6,7 +6,7 @@ import { generateEmbedding } from './lib/embeddings'
 export async function backfill() {
   const supabase = createClient(
     Resource.SupabaseUrl.value,
-    Resource.SupabaseSecretKey.value,
+    Resource.SupabaseServiceRoleKey.value,
   )
 
   const { data: trips, error } = await supabase

--- a/services/context-search.ts
+++ b/services/context-search.ts
@@ -16,7 +16,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
     const supabase = createClient(
       Resource.SupabaseUrl.value,
-      Resource.SupabaseSecretKey.value,
+      Resource.SupabaseServiceRoleKey.value,
     )
 
     // Embed the query

--- a/services/index-trip.ts
+++ b/services/index-trip.ts
@@ -20,7 +20,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
     const supabase = createClient(
       Resource.SupabaseUrl.value,
-      Resource.SupabaseSecretKey.value,
+      Resource.SupabaseServiceRoleKey.value,
     )
 
     // Fetch trip

--- a/services/lib/auth.ts
+++ b/services/lib/auth.ts
@@ -9,7 +9,7 @@ export async function validateAuth(authHeader: string | undefined) {
   const token = authHeader.slice(7)
   const supabase = createClient(
     Resource.SupabaseUrl.value,
-    Resource.SupabaseSecretKey.value,
+    Resource.SupabaseServiceRoleKey.value,
   )
 
   const { data, error } = await supabase.auth.getUser(token)

--- a/services/packing-suggest.ts
+++ b/services/packing-suggest.ts
@@ -75,7 +75,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'tripId required' }) }
     }
 
-    const supabase = createClient(Resource.SupabaseUrl.value, Resource.SupabaseSecretKey.value)
+    const supabase = createClient(Resource.SupabaseUrl.value, Resource.SupabaseServiceRoleKey.value)
 
     // Check for existing pending suggestions
     const { data: existing } = await supabase


### PR DESCRIPTION
## Summary
- Rename SupabaseSecretKey → SupabaseServiceRoleKey in all service files
- Fix bus.subscribe syntax for SST v4
- Add AWS SDK dependencies

## Test plan
- [x] `npx sst deploy --stage dev` succeeds
- [x] API live at https://de2373ypta.execute-api.us-east-1.amazonaws.com