### PR TITLE
fix: Amplify build config for Next.js monorepo

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -11,9 +11,8 @@ applications:
           commands:
             - cd apps/web
             - npm run build
-            - bash scripts/amplify-postbuild.sh
       artifacts:
-        baseDirectory: .amplify-hosting
+        baseDirectory: .next
         files:
           - '**/*'
       cache:

--- a/apps/web/scripts/amplify-postbuild.sh
+++ b/apps/web/scripts/amplify-postbuild.sh
@@ -50,10 +50,11 @@ cp .next/app-build-manifest.json .amplify-hosting/compute/default/.next/app-buil
 cp .next/app-path-routes-manifest.json .amplify-hosting/compute/default/.next/app-path-routes-manifest.json 2>/dev/null || true
 cp .next/react-loadable-manifest.json .amplify-hosting/compute/default/.next/react-loadable-manifest.json 2>/dev/null || true
 cp .next/required-server-files.json .amplify-hosting/compute/default/.next/required-server-files.json 2>/dev/null || true
+cp .next/required-server-files.json .amplify-hosting/compute/default/required-server-files.json 2>/dev/null || true
 cp .next/package.json .amplify-hosting/compute/default/.next/package.json 2>/dev/null || true
 
 # Generate deploy-manifest.json
-NEXT_VERSION=$(node -e "console.log(require('./node_modules/next/package.json').version)")
+NEXT_VERSION=$(node -e "console.log(require('next/package.json').version)")
 
 cat > .amplify-hosting/deploy-manifest.json << MANIFEST
 {


### PR DESCRIPTION
## Summary
- Use Amplify native Next.js adapter instead of custom postbuild script
- Fix next/package.json path resolution for monorepo (hoisted node_modules)
- Copy required-server-files.json to both compute locations

## Test plan
- [x] Build passes locally
- [x] Amplify build succeeds on RB24-7/travyl-web