### PR TITLE
fix: remove standalone output for Amplify deploy-manifest

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "standalone",
-transpilePackages: ["@travyl/shared"],
+  transpilePackages: ["@travyl/shared"],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- Removes `output: "standalone"` from `next.config.ts`
- Amplify's Next.js adapter requires default output mode to generate `deploy-manifest.json`
- Standalone mode bypasses this, causing every Amplify build to fail

## Root cause
Three things were broken in Amplify config (all now fixed):
1. **Missing env vars** — `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` were never set → fixed via AWS CLI
2. **Missing monorepo root** — `AMPLIFY_MONOREPO_APP_ROOT=apps/web` was not set → fixed via AWS CLI
3. **Framework not detected** — branches had `framework: null` instead of `"Next.js - SSR"` → fixed via AWS CLI
4. **`output: "standalone"`** — prevents deploy-manifest.json generation → **this PR**

Build 60 on develop passed (BUILD/DEPLOY/VERIFY all SUCCEED) after fixes 1-3. This PR handles fix 4.

## Test plan
- [x] Amplify develop build 60 passed with env var + framework fixes
- [ ] Verify build still passes after merging this config change