### PR TITLE
fix: handle missing env vars during Amplify static prerendering

### DIFF
--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,8 +1,17 @@
 import { createBrowserClient } from '@supabase/ssr'
 
 export function getSupabaseBrowser() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-  )
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+
+  if (!url || !key) {
+    // During static prerendering (build time), env vars may not be available.
+    // Return a placeholder client that will be replaced at runtime.
+    return createBrowserClient(
+      'https://placeholder.supabase.co',
+      'placeholder',
+    )
+  }
+
+  return createBrowserClient(url, key)
 }


### PR DESCRIPTION
## Summary
- `supabase-browser.ts` used non-null assertions (`!`) for `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
- During Amplify's static prerendering (build time), these env vars aren't available, causing the build to crash on `/profile/settings`
- Fix: fall back to a placeholder Supabase client when env vars are missing, matching the pattern already used in `packages/shared/src/services/supabase.ts`

## Test plan
- [ ] Verify Amplify build passes (no more prerender error on `/profile/settings`)
- [ ] Verify app works normally in dev with real env vars