### PR TITLE
fix: context search hybrid — vector + text fallback

### DIFF
--- a/apps/web/hooks/useContextSearch.ts
+++ b/apps/web/hooks/useContextSearch.ts
@@ -47,6 +47,7 @@ export function useContextSearch(query: string) {
     queryFn: () => fetchContextSearch(debouncedQuery),
     enabled,
     staleTime: 30_000,
+    refetchOnMount: 'always',
   })
 
   return {

--- a/services/context-search.ts
+++ b/services/context-search.ts
@@ -19,22 +19,59 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       Resource.SupabaseSecretKey.value,
     )
 
-    // Embed the query
-    const queryEmbedding = await generateEmbedding(query)
+    // Run vector search and text fallback in parallel
+    const [vectorResults, textResults] = await Promise.all([
+      // Vector similarity search
+      (async () => {
+        try {
+          const queryEmbedding = await generateEmbedding(query)
+          const { data, error } = await supabase.rpc('search_trips', {
+            query_embedding: JSON.stringify(queryEmbedding),
+            match_user_id: userId,
+            match_count: 5,
+          })
+          if (error) {
+            console.error('vector search error:', error)
+            return []
+          }
+          return data ?? []
+        } catch (err) {
+          console.error('embedding error:', err)
+          return []
+        }
+      })(),
 
-    // Search via RPC
-    const { data, error } = await supabase.rpc('search_trips', {
-      query_embedding: JSON.stringify(queryEmbedding),
-      match_user_id: userId,
-      match_count: 5,
-    })
+      // Text fallback: ILIKE on title and destination via trip_embeddings metadata
+      supabase
+        .from('trip_embeddings')
+        .select('trip_id, metadata')
+        .eq('user_id', userId)
+        .or(`text_content.ilike.%${query}%`)
+        .limit(5)
+        .then(({ data, error }) => {
+          if (error) {
+            console.error('text search error:', error)
+            return []
+          }
+          return (data ?? []).map((row: any) => ({
+            trip_id: row.trip_id,
+            metadata: row.metadata,
+            score: 0.5, // fixed relevance for text matches
+          }))
+        }),
+    ])
 
-    if (error) {
-      console.error('search error:', error)
-      return { statusCode: 500, body: JSON.stringify({ error: 'Search failed' }) }
+    // Merge and deduplicate — vector results take priority
+    const seen = new Set<string>()
+    const merged = []
+    for (const row of [...vectorResults, ...textResults]) {
+      if (!seen.has(row.trip_id)) {
+        seen.add(row.trip_id)
+        merged.push(row)
+      }
     }
 
-    const results = (data ?? []).map((row: any) => ({
+    const results = merged.slice(0, 5).map((row: any) => ({
       tripId: row.trip_id,
       title: row.metadata.title,
       destination: row.metadata.destination,

--- a/supabase/migrations/20260324000000_search_trips_image_fallback.sql
+++ b/supabase/migrations/20260324000000_search_trips_image_fallback.sql
@@ -1,0 +1,28 @@
+-- supabase/migrations/20260324000000_search_trips_lower_threshold.sql
+-- Lower similarity threshold from 0.4 to 0.15 for short keyword queries
+
+CREATE OR REPLACE FUNCTION search_trips(
+  query_embedding vector(1024),
+  match_user_id uuid,
+  match_count int DEFAULT 5
+)
+RETURNS TABLE (
+  trip_id uuid,
+  metadata jsonb,
+  score float
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    te.trip_id,
+    te.metadata,
+    (1 - (te.embedding <=> query_embedding))::float AS score
+  FROM trip_embeddings te
+  WHERE te.user_id = match_user_id
+    AND (1 - (te.embedding <=> query_embedding)) >= 0.15
+  ORDER BY te.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Context search returned no results for short keyword queries (e.g. "bust", "test2") because the vector similarity threshold of 0.4 was too high for short queries against long text blob embeddings
- Lowered vector similarity threshold from 0.4 to 0.15 (Supabase migration)
- Added parallel ILIKE text fallback search in the Lambda, merged and deduplicated with vector results
- Added `refetchOnMount: 'always'` to `useContextSearch` to prevent stale empty cache from being served

## Test plan
- [ ] Open command palette (Ctrl+K), search for a trip name like "bust" or "test2"
- [ ] Verify trip results appear with Pexels thumbnail images
- [ ] Verify clicking a result navigates to the trip
- [ ] Verify longer natural-language queries still work via vector search