### PR TITLE
feat: settings in spotlight search (TRA-247)

### DIFF
--- a/apps/web/app/(main)/profile/settings/page.tsx
+++ b/apps/web/app/(main)/profile/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-// TODO: Read/write preferences from Zustand store + Supabase user metadata
+import { useSettingsStore, useAuthStore } from '@travyl/shared';
 
 function SectionHeader({ title }: { title: string }) {
   return (
@@ -48,7 +48,6 @@ function SettingsToggle({
   return (
     <div className="flex h-14 items-center justify-between border-b border-border px-4">
       <span className="text-foreground">{label}</span>
-      {/* TODO: Wire up toggle handler */}
       <button
         onClick={onToggle}
         className={`relative h-6 w-11 rounded-full transition-colors ${
@@ -66,6 +65,15 @@ function SettingsToggle({
 }
 
 export default function SettingsPage() {
+  const user = useAuthStore((s) => s.user);
+  const currency = useSettingsStore((s) => s.currency);
+  const distanceUnits = useSettingsStore((s) => s.distanceUnits);
+  const travelStyle = useSettingsStore((s) => s.travelStyle);
+  const pushNotifications = useSettingsStore((s) => s.pushNotifications);
+  const emailNotifications = useSettingsStore((s) => s.emailNotifications);
+  const togglePush = useSettingsStore((s) => s.togglePushNotifications);
+  const toggleEmail = useSettingsStore((s) => s.toggleEmailNotifications);
+
   return (
     <div className="mx-auto max-w-lg px-4 py-8">
       {/* Back to Profile */}
@@ -82,7 +90,7 @@ export default function SettingsPage() {
       <SectionHeader title="Account" />
       <div className="overflow-hidden rounded-xl border border-border">
         {/* TODO: Navigate to email change flow */}
-        <SettingsRow label="Email" value="jane@example.com" onClick={() => {}} />
+        <SettingsRow label="Email" value={user?.email ?? '—'} onClick={() => {}} />
         {/* TODO: Navigate to password change flow */}
         <SettingsRow label="Change Password" onClick={() => {}} />
         {/* TODO: Confirm + call Supabase delete user */}
@@ -93,18 +101,18 @@ export default function SettingsPage() {
       <SectionHeader title="Preferences" />
       <div className="overflow-hidden rounded-xl border border-border">
         {/* TODO: Open currency picker */}
-        <SettingsRow label="Currency" value="USD" onClick={() => {}} />
+        <SettingsRow label="Currency" value={currency} onClick={() => {}} />
         {/* TODO: Open distance unit picker */}
-        <SettingsRow label="Distance Units" value="Miles" onClick={() => {}} />
+        <SettingsRow label="Distance Units" value={distanceUnits === 'miles' ? 'Miles' : 'Kilometers'} onClick={() => {}} />
         {/* TODO: Open travel style picker */}
-        <SettingsRow label="Default Travel Style" value="Balanced" onClick={() => {}} />
+        <SettingsRow label="Default Travel Style" value={travelStyle.charAt(0).toUpperCase() + travelStyle.slice(1)} onClick={() => {}} />
       </div>
 
       {/* Notifications */}
       <SectionHeader title="Notifications" />
       <div className="overflow-hidden rounded-xl border border-border">
-        <SettingsToggle label="Push Notifications" enabled={true} onToggle={() => {}} />
-        <SettingsToggle label="Email Notifications" enabled={false} onToggle={() => {}} />
+        <SettingsToggle label="Push Notifications" enabled={pushNotifications} onToggle={togglePush} />
+        <SettingsToggle label="Email Notifications" enabled={emailNotifications} onToggle={toggleEmail} />
       </div>
 
       {/* About */}

--- a/apps/web/components/GlobalCommandPalette.tsx
+++ b/apps/web/components/GlobalCommandPalette.tsx
@@ -8,6 +8,8 @@ import { useContextSearch } from '@/hooks/useContextSearch'
 import type { ContextSearchResult } from '@/hooks/useContextSearch'
 import { useCalendarCommandsStore } from '@/stores/calendarCommandsStore'
 import type { Command } from './calendar/types'
+import { useSettingsStore, useAuthStore } from '@travyl/shared'
+import type { Currency, DistanceUnits, TravelStyle } from '@travyl/shared'
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -32,7 +34,34 @@ interface CommandItem {
   command: Command
 }
 
-type PaletteItem = NavItem | TripItem | CommandItem
+interface SettingToggleItem {
+  type: 'setting-toggle'
+  id: string
+  label: string
+  keywords: string[]
+  enabled: boolean
+  onToggle: () => void
+}
+
+interface SettingPickerItem {
+  type: 'setting-picker'
+  id: string
+  label: string
+  keywords: string[]
+  currentValue: string
+  options: { value: string; label: string }[]
+  onSelect: (value: string) => void
+}
+
+interface SettingLinkItem {
+  type: 'setting-link'
+  id: string
+  label: string
+  keywords: string[]
+  path: string
+}
+
+type PaletteItem = NavItem | TripItem | CommandItem | SettingToggleItem | SettingPickerItem | SettingLinkItem
 
 interface PaletteGroup {
   key: string
@@ -66,11 +95,25 @@ export function GlobalCommandPalette() {
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [activePicker, setActivePicker] = useState<SettingPickerItem | null>(null)
+  const [savedQuery, setSavedQuery] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
 
   const calendarCommands = useCalendarCommandsStore((s) => s.commands)
   const setPaletteOpen = useCalendarCommandsStore((s) => s.setPaletteOpen)
+
+  const user = useAuthStore((s) => s.user)
+  const currency = useSettingsStore((s) => s.currency)
+  const distanceUnits = useSettingsStore((s) => s.distanceUnits)
+  const travelStyle = useSettingsStore((s) => s.travelStyle)
+  const pushNotifications = useSettingsStore((s) => s.pushNotifications)
+  const emailNotifications = useSettingsStore((s) => s.emailNotifications)
+  const setCurrency = useSettingsStore((s) => s.setCurrency)
+  const setDistanceUnits = useSettingsStore((s) => s.setDistanceUnits)
+  const setTravelStyle = useSettingsStore((s) => s.setTravelStyle)
+  const togglePush = useSettingsStore((s) => s.togglePushNotifications)
+  const toggleEmail = useSettingsStore((s) => s.toggleEmailNotifications)
 
   // Sync palette open state to store so calendar commands can check it
   useEffect(() => { setPaletteOpen(isOpen) }, [isOpen, setPaletteOpen])
@@ -95,9 +138,114 @@ export function GlobalCommandPalette() {
     if (isOpen) {
       setQuery('')
       setHighlightedIndex(0)
+      setActivePicker(null)
+      setSavedQuery('')
       setTimeout(() => inputRef.current?.focus(), 0)
     }
   }, [isOpen])
+
+  // ─── Settings registry ─────────────────────────────────────
+
+  const settingItems = useMemo<(SettingToggleItem | SettingPickerItem | SettingLinkItem)[]>(() => {
+    if (!user) return []
+    return [
+      {
+        type: 'setting-picker' as const,
+        id: 'setting-currency',
+        label: 'Currency',
+        keywords: ['currency', 'money', 'usd', 'eur', 'gbp', 'jpy', 'cad', 'aud', 'mxn'],
+        currentValue: currency,
+        options: [
+          { value: 'USD', label: 'USD — US Dollar' },
+          { value: 'EUR', label: 'EUR — Euro' },
+          { value: 'GBP', label: 'GBP — British Pound' },
+          { value: 'JPY', label: 'JPY — Japanese Yen' },
+          { value: 'CAD', label: 'CAD — Canadian Dollar' },
+          { value: 'AUD', label: 'AUD — Australian Dollar' },
+          { value: 'MXN', label: 'MXN — Mexican Peso' },
+        ],
+        onSelect: (v: string) => setCurrency(v as Currency),
+      },
+      {
+        type: 'setting-picker' as const,
+        id: 'setting-distance',
+        label: 'Distance Units',
+        keywords: ['distance', 'units', 'miles', 'kilometers', 'km'],
+        currentValue: distanceUnits === 'miles' ? 'Miles' : 'Kilometers',
+        options: [
+          { value: 'miles', label: 'Miles' },
+          { value: 'kilometers', label: 'Kilometers' },
+        ],
+        onSelect: (v: string) => setDistanceUnits(v as DistanceUnits),
+      },
+      {
+        type: 'setting-picker' as const,
+        id: 'setting-travel-style',
+        label: 'Travel Style',
+        keywords: ['travel', 'style', 'balanced', 'budget', 'luxury', 'adventure', 'relaxed'],
+        currentValue: travelStyle.charAt(0).toUpperCase() + travelStyle.slice(1),
+        options: [
+          { value: 'balanced', label: 'Balanced' },
+          { value: 'budget', label: 'Budget' },
+          { value: 'luxury', label: 'Luxury' },
+          { value: 'adventure', label: 'Adventure' },
+          { value: 'relaxed', label: 'Relaxed' },
+        ],
+        onSelect: (v: string) => setTravelStyle(v as TravelStyle),
+      },
+      {
+        type: 'setting-toggle' as const,
+        id: 'setting-push',
+        label: 'Push Notifications',
+        keywords: ['push', 'notifications', 'alerts'],
+        enabled: pushNotifications,
+        onToggle: togglePush,
+      },
+      {
+        type: 'setting-toggle' as const,
+        id: 'setting-email-notif',
+        label: 'Email Notifications',
+        keywords: ['email', 'notifications', 'alerts', 'mail'],
+        enabled: emailNotifications,
+        onToggle: toggleEmail,
+      },
+      {
+        type: 'setting-link' as const,
+        id: 'setting-email-account',
+        label: 'Email (Account)',
+        keywords: ['email', 'account'],
+        path: '/profile/settings',
+      },
+      {
+        type: 'setting-link' as const,
+        id: 'setting-password',
+        label: 'Change Password',
+        keywords: ['password', 'security'],
+        path: '/profile/settings',
+      },
+      {
+        type: 'setting-link' as const,
+        id: 'setting-delete-account',
+        label: 'Delete Account',
+        keywords: ['delete', 'account', 'remove'],
+        path: '/profile/settings',
+      },
+      {
+        type: 'setting-link' as const,
+        id: 'setting-terms',
+        label: 'Terms of Service',
+        keywords: ['terms', 'legal'],
+        path: '/profile/settings',
+      },
+      {
+        type: 'setting-link' as const,
+        id: 'setting-privacy',
+        label: 'Privacy Policy',
+        keywords: ['privacy', 'legal', 'policy'],
+        path: '/profile/settings',
+      },
+    ]
+  }, [user, currency, distanceUnits, travelStyle, pushNotifications, emailNotifications, setCurrency, setDistanceUnits, setTravelStyle, togglePush, toggleEmail])
 
   // ─── Build grouped items ─────────────────────────────────
 
@@ -108,6 +256,14 @@ export function GlobalCommandPalette() {
     const filteredNav = NAV_ITEMS.filter((n) => n.label.toLowerCase().includes(q))
     if (filteredNav.length > 0) {
       result.push({ key: 'navigation', label: 'Navigation', items: filteredNav })
+    }
+
+    const filteredSettings = settingItems.filter((s) =>
+      s.label.toLowerCase().includes(q) ||
+      s.keywords.some((kw) => kw.includes(q))
+    )
+    if (filteredSettings.length > 0) {
+      result.push({ key: 'settings', label: 'Settings', items: filteredSettings })
     }
 
     if (tripResults.length > 0) {
@@ -146,7 +302,7 @@ export function GlobalCommandPalette() {
     }
 
     return result
-  }, [query, tripResults, calendarCommands])
+  }, [query, tripResults, calendarCommands, settingItems])
 
   const flatItems = useMemo(() => groups.flatMap((g) => g.items), [groups])
 
@@ -157,15 +313,28 @@ export function GlobalCommandPalette() {
   // ─── Execute item ────────────────────────────────────────
 
   function executeItem(item: PaletteItem) {
-    setIsOpen(false)
     if (item.type === 'navigation') {
+      setIsOpen(false)
       router.push(item.path)
     } else if (item.type === 'trip') {
+      setIsOpen(false)
       router.push(`/trip/${item.data.tripId}`)
     } else if (item.type === 'command') {
+      setIsOpen(false)
       if (item.command.isEnabled) {
         item.command.execute()
       }
+    } else if (item.type === 'setting-toggle') {
+      item.onToggle()
+      // Palette stays open after toggling
+    } else if (item.type === 'setting-picker') {
+      setSavedQuery(query)
+      setQuery('')
+      setActivePicker(item)
+      setHighlightedIndex(0)
+    } else if (item.type === 'setting-link') {
+      setIsOpen(false)
+      router.push(item.path)
     }
   }
 
@@ -178,30 +347,54 @@ export function GlobalCommandPalette() {
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setHighlightedIndex((prev) => {
-        for (let i = prev + 1; i < flatItems.length; i++) {
-          if (!isItemDisabled(flatItems[i])) return i
-        }
-        return prev
-      })
+      if (activePicker) {
+        setHighlightedIndex((prev) => Math.min(prev + 1, activePicker.options.length - 1))
+      } else {
+        setHighlightedIndex((prev) => {
+          for (let i = prev + 1; i < flatItems.length; i++) {
+            if (!isItemDisabled(flatItems[i])) return i
+          }
+          return prev
+        })
+      }
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
-      setHighlightedIndex((prev) => {
-        for (let i = prev - 1; i >= 0; i--) {
-          if (!isItemDisabled(flatItems[i])) return i
-        }
-        return prev
-      })
+      if (activePicker) {
+        setHighlightedIndex((prev) => Math.max(prev - 1, 0))
+      } else {
+        setHighlightedIndex((prev) => {
+          for (let i = prev - 1; i >= 0; i--) {
+            if (!isItemDisabled(flatItems[i])) return i
+          }
+          return prev
+        })
+      }
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      const item = flatItems[highlightedIndex]
-      if (item && !isItemDisabled(item)) {
-        executeItem(item)
+      if (activePicker) {
+        const option = activePicker.options[highlightedIndex]
+        if (option) {
+          activePicker.onSelect(option.value)
+          setActivePicker(null)
+          setQuery(savedQuery)
+          setHighlightedIndex(0)
+        }
+      } else {
+        const item = flatItems[highlightedIndex]
+        if (item && !isItemDisabled(item)) {
+          executeItem(item)
+        }
       }
     } else if (e.key === 'Escape') {
       e.preventDefault()
       e.stopPropagation()
-      setIsOpen(false)
+      if (activePicker) {
+        setActivePicker(null)
+        setQuery(savedQuery)
+        setHighlightedIndex(0)
+      } else {
+        setIsOpen(false)
+      }
     }
   }
 
@@ -231,94 +424,166 @@ export function GlobalCommandPalette() {
             onKeyDown={handleKeyDown}
           >
             <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-[#1e3a5f]/30">
-              <svg
-                width="16" height="16" viewBox="0 0 24 24"
-                fill="none" stroke="currentColor" strokeWidth="2"
-                className="text-gray-400 dark:text-[#4a7ab5] shrink-0"
-              >
-                <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
-              </svg>
-              <input
-                ref={inputRef}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search trips, navigate..."
-                className="flex-1 bg-transparent text-sm text-gray-900 dark:text-[#f5efe8] placeholder-gray-400 dark:placeholder-[#4a7ab5] outline-none"
-              />
+              {activePicker ? (
+                <>
+                  <button
+                    onClick={() => {
+                      setActivePicker(null)
+                      setQuery(savedQuery)
+                      setHighlightedIndex(0)
+                    }}
+                    className="text-gray-400 dark:text-[#4a7ab5] hover:text-gray-600 dark:hover:text-[#f5efe8] shrink-0"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="m15 18-6-6 6-6" />
+                    </svg>
+                  </button>
+                  <span className="text-sm text-gray-900 dark:text-[#f5efe8]">{activePicker.label}</span>
+                </>
+              ) : (
+                <>
+                  <svg
+                    width="16" height="16" viewBox="0 0 24 24"
+                    fill="none" stroke="currentColor" strokeWidth="2"
+                    className="text-gray-400 dark:text-[#4a7ab5] shrink-0"
+                  >
+                    <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
+                  </svg>
+                  <input
+                    ref={inputRef}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search trips, settings, navigate..."
+                    className="flex-1 bg-transparent text-sm text-gray-900 dark:text-[#f5efe8] placeholder-gray-400 dark:placeholder-[#4a7ab5] outline-none"
+                  />
+                </>
+              )}
               <kbd className="text-[10px] text-gray-400 dark:text-[#484f58] bg-gray-100 dark:bg-[#0a1520] border border-gray-200 dark:border-[#1e3a5f]/30 px-1.5 py-0.5 rounded">
                 Esc
               </kbd>
             </div>
 
             <div className="max-h-[360px] overflow-y-auto py-1">
-              {flatItems.length === 0 && !tripSearchLoading && (
-                <div className="px-4 py-8 text-center text-sm text-gray-400 dark:text-[#4a7ab5]">
-                  No results found
-                </div>
-              )}
+              {activePicker ? (
+                activePicker.options.map((option, index) => {
+                  const isSelected = option.value === activePicker.currentValue ||
+                    option.label === activePicker.currentValue
+                  const isHighlighted = index === highlightedIndex
 
-              {tripSearchLoading && query.length >= 3 && tripResults.length === 0 && (
-                <div className="px-4 py-3 text-center text-sm text-gray-400 dark:text-[#4a7ab5]">
-                  Searching trips...
-                </div>
-              )}
+                  return (
+                    <button
+                      key={option.value}
+                      onClick={() => {
+                        activePicker.onSelect(option.value)
+                        setActivePicker(null)
+                        setQuery(savedQuery)
+                        setHighlightedIndex(0)
+                      }}
+                      onMouseEnter={() => setHighlightedIndex(index)}
+                      className={[
+                        'w-full flex items-center justify-between px-4 py-2 text-sm text-left transition-colors',
+                        isHighlighted
+                          ? 'bg-gray-100 dark:bg-[#1e3a5f]/30 text-gray-900 dark:text-[#f5efe8]'
+                          : 'text-gray-700 dark:text-[#cdd9e5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20',
+                      ].join(' ')}
+                    >
+                      <span>{option.label}</span>
+                      {isSelected && (
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                          stroke="currentColor" strokeWidth="2"
+                          className="text-green-500 dark:text-green-400 shrink-0">
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      )}
+                    </button>
+                  )
+                })
+              ) : (
+                <>
+                  {flatItems.length === 0 && !tripSearchLoading && (
+                    <div className="px-4 py-8 text-center text-sm text-gray-400 dark:text-[#4a7ab5]">
+                      No results found
+                    </div>
+                  )}
 
-              {groups.map((group) => (
-                <div key={group.key}>
-                  <div className="px-3 py-1.5 text-[10px] font-medium text-gray-400 dark:text-[#4a7ab5] uppercase tracking-wider">
-                    {group.label}
-                  </div>
-                  {group.items.map((item) => {
-                    const index = flatItems.indexOf(item)
-                    const isHighlighted = index === highlightedIndex
-                    const disabled = isItemDisabled(item)
+                  {tripSearchLoading && query.length >= 3 && tripResults.length === 0 && (
+                    <div className="px-4 py-3 text-center text-sm text-gray-400 dark:text-[#4a7ab5]">
+                      Searching trips...
+                    </div>
+                  )}
 
-                    return (
-                      <button
-                        key={item.id}
-                        disabled={disabled}
-                        onClick={() => {
-                          if (!disabled) executeItem(item)
-                        }}
-                        onMouseEnter={() => {
-                          if (!disabled) setHighlightedIndex(index)
-                        }}
-                        className={[
-                          'w-full flex items-center justify-between px-4 py-2 text-sm text-left transition-colors',
-                          disabled
-                            ? 'text-gray-400 dark:text-[#484f58] cursor-default pointer-events-none'
-                            : isHighlighted
-                              ? 'bg-gray-100 dark:bg-[#1e3a5f]/30 text-gray-900 dark:text-[#f5efe8]'
-                              : 'text-gray-700 dark:text-[#cdd9e5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20',
-                        ].join(' ')}
-                      >
-                        <span className="flex items-center gap-2.5">
-                          {item.type === 'trip' && item.data.imageUrl && (
-                            <img
-                              src={item.data.imageUrl}
-                              alt={item.data.destination}
-                              className="w-[46px] h-[36px] rounded object-cover shrink-0"
-                            />
-                          )}
-                          <span className="flex flex-col min-w-0">
-                            <span>{item.label}</span>
-                            {item.type === 'trip' && (item.data.startDate && item.data.endDate) && (
-                              <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5] truncate">
-                                {item.data.destination} · {formatTripDates(item.data.startDate, item.data.endDate)}
+                  {groups.map((group) => (
+                    <div key={group.key}>
+                      <div className="px-3 py-1.5 text-[10px] font-medium text-gray-400 dark:text-[#4a7ab5] uppercase tracking-wider">
+                        {group.label}
+                      </div>
+                      {group.items.map((item) => {
+                        const index = flatItems.indexOf(item)
+                        const isHighlighted = index === highlightedIndex
+                        const disabled = isItemDisabled(item)
+
+                        return (
+                          <button
+                            key={item.id}
+                            disabled={disabled}
+                            onClick={() => {
+                              if (!disabled) executeItem(item)
+                            }}
+                            onMouseEnter={() => {
+                              if (!disabled) setHighlightedIndex(index)
+                            }}
+                            className={[
+                              'w-full flex items-center justify-between px-4 py-2 text-sm text-left transition-colors',
+                              disabled
+                                ? 'text-gray-400 dark:text-[#484f58] cursor-default pointer-events-none'
+                                : isHighlighted
+                                  ? 'bg-gray-100 dark:bg-[#1e3a5f]/30 text-gray-900 dark:text-[#f5efe8]'
+                                  : 'text-gray-700 dark:text-[#cdd9e5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20',
+                            ].join(' ')}
+                          >
+                            <span className="flex items-center gap-2.5">
+                              {item.type === 'trip' && item.data.imageUrl && (
+                                <img
+                                  src={item.data.imageUrl}
+                                  alt={item.data.destination}
+                                  className="w-[46px] h-[36px] rounded object-cover shrink-0"
+                                />
+                              )}
+                              <span className="flex flex-col min-w-0">
+                                <span>{item.label}</span>
+                                {item.type === 'trip' && (item.data.startDate && item.data.endDate) && (
+                                  <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5] truncate">
+                                    {item.data.destination} · {formatTripDates(item.data.startDate, item.data.endDate)}
+                                  </span>
+                                )}
+                              </span>
+                            </span>
+                            {item.type === 'setting-toggle' && (
+                              <span className={`ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full ${
+                                item.enabled
+                                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                                  : 'bg-gray-100 text-gray-500 dark:bg-[#0a1520] dark:text-[#484f58]'
+                              }`}>
+                                {item.enabled ? 'On' : 'Off'}
                               </span>
                             )}
-                          </span>
-                        </span>
-                        {item.type === 'command' && item.command.shortcut && (
-                          <kbd className="text-[10px] text-gray-400 dark:text-[#484f58] bg-gray-100 dark:bg-[#0a1520] border border-gray-200 dark:border-[#1e3a5f]/30 px-1.5 py-0.5 rounded ml-4 shrink-0">
-                            {item.command.shortcut.display}
-                          </kbd>
-                        )}
-                      </button>
-                    )
-                  })}
-                </div>
-              ))}
+                            {item.type === 'setting-picker' && (
+                              <span className="ml-auto text-[11px] text-gray-400 dark:text-[#4a7ab5]">
+                                {item.currentValue}
+                              </span>
+                            )}
+                            {item.type === 'command' && item.command.shortcut && (
+                              <kbd className="text-[10px] text-gray-400 dark:text-[#484f58] bg-gray-100 dark:bg-[#0a1520] border border-gray-200 dark:border-[#1e3a5f]/30 px-1.5 py-0.5 rounded ml-4 shrink-0">
+                                {item.command.shortcut.display}
+                              </kbd>
+                            )}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  ))}
+                </>
+              )}
             </div>
           </motion.div>
         </motion.div>

--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -2,7 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
-import { useAuthStore, configureSupabase } from '@travyl/shared';
+import { useAuthStore, useSettingsStore, configureSupabase } from '@travyl/shared';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import { GlobalCommandPalette } from './GlobalCommandPalette';
 
@@ -28,6 +28,26 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     const unsubscribe = initialize();
     return unsubscribe;
   }, [initialize]);
+
+  const user = useAuthStore((s) => s.user);
+  const hydrateSettings = useSettingsStore((s) => s.hydrate);
+
+  useEffect(() => {
+    if (!user) {
+      hydrateSettings({});
+      return;
+    }
+    const sb = getSupabaseBrowser();
+    sb.from('profiles')
+      .select('preferences')
+      .eq('id', user.id)
+      .single()
+      .then(({ data }) => {
+        if (data?.preferences) {
+          hydrateSettings(data.preferences as Record<string, unknown>);
+        }
+      });
+  }, [user, hydrateSettings]);
 
   return (
     <QueryClientProvider client={queryClientRef.current}>

--- a/docs/superpowers/specs/2026-03-24-trip-settings-spotlight-search-design.md
+++ b/docs/superpowers/specs/2026-03-24-trip-settings-spotlight-search-design.md
@@ -1,0 +1,127 @@
+# Trip Settings in Spotlight Search — Design Spec
+
+**Date:** 2026-03-24
+**Status:** Approved
+**Linear:** TRA-263
+
+## Goal
+
+Make trip-level settings (theme, tab visibility, status) searchable and actionable from the GlobalCommandPalette (Ctrl+K) when the user is inside a trip route. Link items navigate to the trip settings page for complex operations (sharing, details, danger zone).
+
+## Architecture: Zustand Registration Store
+
+The palette is global (`providers.tsx`) but trip settings only exist inside `/trip/[id]` routes via `TripThemeContext`. Bridge this with a **registration store** — the same pattern used by `calendarCommandsStore`.
+
+New Zustand store `tripSettingsStore` at `apps/web/stores/tripSettingsStore.ts` (web-local, not shared):
+
+```ts
+interface TripSettingsRegistration {
+  tripId: string
+  themeId: string
+  customColor: string | null
+  hiddenTabs: Record<string, boolean>
+  status: Trip['status']
+  canEdit: boolean
+  isOwner: boolean
+  setTripTheme: (id: string, color?: string) => void
+  setTabHidden: (segment: string, hidden: boolean) => void
+  setStatus: (status: Trip['status']) => void
+}
+
+interface TripSettingsStoreState {
+  registration: TripSettingsRegistration | null
+  register: (reg: TripSettingsRegistration) => void
+  unregister: () => void
+}
+```
+
+## Registration Hook
+
+`useTripSettingsRegistration(trip, canEdit, isOwner)` — called from `TripLayoutContent` in `trip-layout-inner.tsx`. Bridges `TripThemeContext` + trip data into the store.
+
+- **When `trip` is null** (still loading): skip registration, do nothing. Registration only happens once trip data is available.
+- On mount/update (when trip is non-null): calls `register()` with current values and action callbacks
+- On unmount: calls `unregister()` to clear the registration
+- `canEdit` and `isOwner` are computed inside the hook using `isTripOwner(trip, userId)` and `canEditTrip(trip, userId)` from `@travyl/shared`
+- `useAuthStore` provides the current user ID
+
+**Action callbacks:**
+- `setTripTheme` and `setTabHidden`: delegate to `TripThemeContext` methods (local state only — same as the existing settings page behavior; persistence happens via the settings page save flow)
+- `setStatus`: calls `updateTripDetails(trip.id, { status })` from `@travyl/shared` to persist to Supabase, then calls `refetch()` from `useItineraryScreen` to update local state
+
+Dependencies: `useTripTheme()` for theme/tabs state and actions, `useItineraryScreen(tripId)` for trip data and `refetch` (already called in `TripLayoutContent`), `useAuthStore` for user ID.
+
+**New imports needed in `TripLayoutContent`:** `useAuthStore`, `isTripOwner`, `canEditTrip` from `@travyl/shared`.
+
+## Palette Integration
+
+### Trip Settings Items
+
+When `registration !== null`, the palette builds a "Trip Settings" group:
+
+**Theme picker** (requires `canEdit`):
+- Label: "Trip Theme"
+- Keywords: theme, colors, appearance
+- Current value: theme name from `TRIP_THEMES[themeId]?.name ?? 'Custom'`
+- Options: Navy, Ocean, Sunset, Rainforest, Lavender Fields, Terracotta, Midnight Sky, Charcoal (from `THEME_ORDER`)
+- Action: `registration.setTripTheme(id)`
+
+**Tab toggles** (requires `canEdit`):
+- One per configurable tab, matching `CONFIGURABLE_TABS` from `TabsSection.tsx`:
+
+| Segment | Label | Keywords |
+|---------|-------|----------|
+| `itinerary` | Itinerary Tab | itinerary, tab, show, hide |
+| `hotels` | Hotels Tab | hotels, tab, show, hide |
+| `flights` | Flights Tab | flights, tab, show, hide |
+| `restaurants` | Restaurants Tab | restaurants, tab, show, hide |
+| `activities` | Explore Tab | explore, activities, tab, show, hide |
+| `packing` | Packing Tab | packing, tab, show, hide |
+| `budget` | Budget Tab | budget, tab, show, hide |
+| `cars` | Car Rental Tab | car, rental, tab, show, hide |
+| `favorites` | Favorites Tab | favorites, tab, show, hide |
+
+- Skips always-on tabs: Overview (`index`), Settings (`settings`)
+- Calendar is not a configurable tab (it's always available and not in `CONFIGURABLE_TABS`)
+- Enabled: `!registration.hiddenTabs[segment]`
+- Action: `registration.setTabHidden(segment, !currentlyHidden)` — toggles sidebar visibility only (route remains accessible via direct URL)
+
+**Status picker** (requires `canEdit`):
+- Label: "Trip Status"
+- Keywords: status, planning, booked, active, completed, abandoned
+- Current value: capitalized `registration.status`
+- Options: Planning, Booked, Active, Completed, Abandoned
+- Action: `registration.setStatus(status)` — persists to Supabase and refetches trip data
+
+**Link items** (always shown when on trip):
+- "Trip Sharing" → `/trip/[id]/settings` (keywords: sharing, share, link, public)
+- "Trip Details" → `/trip/[id]/settings` (keywords: details, title, destination, dates, budget)
+- "Trip Colors" → `/trip/[id]/settings` (keywords: colors, tab colors, itinerary colors, customize)
+- "Delete Trip" → `/trip/[id]/settings` (keywords: delete, remove, archive) — only when `isOwner`
+
+### Group Ordering
+
+Navigation → Settings → Trip Settings → Trips → Commands
+
+The Trip Settings group is inserted after the Settings group and before the Trips group in the `groups` useMemo array.
+
+### Search Matching
+
+Same as profile settings: query matches label OR any keyword (case-insensitive includes). Trip Settings group is always visible when on a trip (filtered by query like all other groups).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/stores/tripSettingsStore.ts` | New — Zustand store with register/unregister + `useTripSettingsRegistration` hook |
+| `apps/web/app/(trips-app)/trip/[id]/trip-layout-inner.tsx` | Modify — Add `useTripSettingsRegistration` call in `TripLayoutContent`, add `useAuthStore`/`isTripOwner`/`canEditTrip` imports |
+| `apps/web/components/GlobalCommandPalette.tsx` | Modify — Import trip settings store, build "Trip Settings" group from registration |
+
+## Out of Scope
+
+- Custom color picker in palette (too complex — use settings page)
+- Tab/itinerary color overrides in palette (color picker UI doesn't fit)
+- Sharing toggles in palette (multi-step flow with URL copy)
+- Trip details editing in palette (form fields)
+- Confirmation dialogs for danger zone actions
+- Persistence of theme/tab changes from palette (matches existing settings page behavior — local state only until explicit save)

--- a/packages/shared/src/stores/index.ts
+++ b/packages/shared/src/stores/index.ts
@@ -1,1 +1,3 @@
 export { useAuthStore } from './authStore';
+export { useSettingsStore } from './settingsStore';
+export type { Currency, DistanceUnits, TravelStyle } from './settingsStore';

--- a/packages/shared/src/stores/settingsStore.ts
+++ b/packages/shared/src/stores/settingsStore.ts
@@ -1,0 +1,120 @@
+// packages/shared/src/stores/settingsStore.ts
+import { create } from 'zustand';
+import { supabase } from '../services/supabase';
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type Currency = 'USD' | 'EUR' | 'GBP' | 'JPY' | 'CAD' | 'AUD' | 'MXN';
+export type DistanceUnits = 'miles' | 'kilometers';
+export type TravelStyle = 'balanced' | 'budget' | 'luxury' | 'adventure' | 'relaxed';
+
+const VALID_CURRENCIES: Currency[] = ['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'MXN'];
+const VALID_DISTANCE_UNITS: DistanceUnits[] = ['miles', 'kilometers'];
+const VALID_TRAVEL_STYLES: TravelStyle[] = ['balanced', 'budget', 'luxury', 'adventure', 'relaxed'];
+
+const DEFAULTS = {
+  currency: 'USD' as Currency,
+  distanceUnits: 'miles' as DistanceUnits,
+  travelStyle: 'balanced' as TravelStyle,
+  pushNotifications: true,
+  emailNotifications: false,
+};
+
+// ─── Validation helpers ───────────────────────────────────────
+
+function validCurrency(v: unknown): Currency {
+  return VALID_CURRENCIES.includes(v as Currency) ? (v as Currency) : DEFAULTS.currency;
+}
+
+function validDistanceUnits(v: unknown): DistanceUnits {
+  return VALID_DISTANCE_UNITS.includes(v as DistanceUnits) ? (v as DistanceUnits) : DEFAULTS.distanceUnits;
+}
+
+function validTravelStyle(v: unknown): TravelStyle {
+  return VALID_TRAVEL_STYLES.includes(v as TravelStyle) ? (v as TravelStyle) : DEFAULTS.travelStyle;
+}
+
+function validBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+// ─── Store ────────────────────────────────────────────────────
+
+interface SettingsState {
+  currency: Currency;
+  distanceUnits: DistanceUnits;
+  travelStyle: TravelStyle;
+  pushNotifications: boolean;
+  emailNotifications: boolean;
+
+  setCurrency: (v: Currency) => void;
+  setDistanceUnits: (v: DistanceUnits) => void;
+  setTravelStyle: (v: TravelStyle) => void;
+  togglePushNotifications: () => void;
+  toggleEmailNotifications: () => void;
+  hydrate: (prefs: Record<string, unknown>) => void;
+}
+
+function persistPreferences(prefs: Record<string, unknown>) {
+  supabase.auth.getUser().then(({ data }) => {
+    if (!data.user) return;
+    supabase
+      .from('profiles')
+      .update({ preferences: prefs })
+      .eq('id', data.user.id)
+      .then(({ error }) => {
+        if (error) console.error('Failed to persist preferences:', error);
+      });
+  });
+}
+
+function getPrefsSnapshot(state: SettingsState): Record<string, unknown> {
+  return {
+    currency: state.currency,
+    distanceUnits: state.distanceUnits,
+    travelStyle: state.travelStyle,
+    pushNotifications: state.pushNotifications,
+    emailNotifications: state.emailNotifications,
+  };
+}
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  ...DEFAULTS,
+
+  setCurrency: (v) => {
+    set({ currency: v });
+    persistPreferences({ ...getPrefsSnapshot(get()), currency: v });
+  },
+
+  setDistanceUnits: (v) => {
+    set({ distanceUnits: v });
+    persistPreferences({ ...getPrefsSnapshot(get()), distanceUnits: v });
+  },
+
+  setTravelStyle: (v) => {
+    set({ travelStyle: v });
+    persistPreferences({ ...getPrefsSnapshot(get()), travelStyle: v });
+  },
+
+  togglePushNotifications: () => {
+    const next = !get().pushNotifications;
+    set({ pushNotifications: next });
+    persistPreferences({ ...getPrefsSnapshot(get()), pushNotifications: next });
+  },
+
+  toggleEmailNotifications: () => {
+    const next = !get().emailNotifications;
+    set({ emailNotifications: next });
+    persistPreferences({ ...getPrefsSnapshot(get()), emailNotifications: next });
+  },
+
+  hydrate: (prefs) => {
+    set({
+      currency: validCurrency(prefs.currency),
+      distanceUnits: validDistanceUnits(prefs.distanceUnits),
+      travelStyle: validTravelStyle(prefs.travelStyle),
+      pushNotifications: validBool(prefs.pushNotifications, DEFAULTS.pushNotifications),
+      emailNotifications: validBool(prefs.emailNotifications, DEFAULTS.emailNotifications),
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- New `settingsStore` (Zustand) for user preferences — currency, distance units, travel style, push/email notifications
- Optimistic writes to `profiles.preferences` jsonb column in Supabase, with validation on hydrate
- Settings hydrate on auth init, reset to defaults on sign-out
- GlobalCommandPalette gains 10 new setting items: 3 pickers (currency, distance, travel style), 2 toggles (push/email notifications), 5 links (email, password, delete account, terms, privacy)
- Picker sub-view with back arrow, option list, checkmark for current selection, full keyboard navigation
- Toggle items show On/Off pill and keep palette open after toggling
- Settings page wired to store reads/actions (no more hardcoded values)
- Group ordering: Navigation → Settings → Trips → Commands

## Test plan
- [ ] Open palette (Ctrl+K), type "currency" — Currency picker appears with current value
- [ ] Click Currency — picker sub-view with back arrow, 7 options, checkmark on selected
- [ ] Select a new currency — exits picker, value persists across page reload
- [ ] Press Escape in picker — exits without changing
- [ ] Type "push" — Push Notifications toggle appears with On/Off pill
- [ ] Click toggle — flips state, palette stays open
- [ ] Type "password" — Change Password link appears, navigates to /profile/settings
- [ ] Sign out and sign back in — settings should restore from DB
- [ ] Go to /profile/settings — values match what was set via palette
- [ ] Toggle notifications on settings page — palette reflects updated state