### PR TITLE
TRA-271: Fix Amplify build — lazy-init Supabase client in API routes

### DIFF
--- a/apps/web/app/api/trips/create/route.ts
+++ b/apps/web/app/api/trips/create/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabase = createClient(supabaseUrl, supabaseKey)
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient(url, key)
+}
 
 const CITY_AIRPORTS: Record<string, string> = {
   'Paris': 'CDG', 'London': 'LHR', 'Tokyo': 'NRT', 'Rome': 'FCO',
@@ -21,6 +23,7 @@ const CITY_AIRPORTS: Record<string, string> = {
 }
 
 export async function POST(req: NextRequest) {
+  const supabase = getSupabase()
   const body = await req.json()
   const { title, destination, start_date, end_date, status, user_id, travelers, budget, currency, trip_context, hotels, flights, itinerary } = body
 

--- a/apps/web/app/api/trips/delete/route.ts
+++ b/apps/web/app/api/trips/delete/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabase = createClient(supabaseUrl, supabaseKey)
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient(url, key)
+}
 
 export async function POST(req: NextRequest) {
+  const supabase = getSupabase()
   const { tripId } = await req.json()
   if (!tripId) return NextResponse.json({ error: 'Missing tripId' }, { status: 400 })
 

--- a/apps/web/app/api/trips/enrich/route.ts
+++ b/apps/web/app/api/trips/enrich/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-// Use service role key if available (bypasses RLS), otherwise fall back to anon key
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabase = createClient(supabaseUrl, supabaseKey)
+// Lazy-init to avoid crashing at build time when env vars aren't set
+function getSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  return createClient(url, key)
+}
 
 const COUNTRY_CUISINE: Record<string, string> = {
   France: 'French', Spain: 'Spanish', Italy: 'Italian', Japan: 'Japanese',
@@ -16,6 +18,7 @@ const COUNTRY_CUISINE: Record<string, string> = {
 }
 
 export async function POST(req: NextRequest) {
+  const supabase = getSupabase()
   const { tripId } = await req.json()
   if (!tripId) return NextResponse.json({ error: 'Missing tripId' }, { status: 400 })
 


### PR DESCRIPTION
## Summary
- `createClient()` at module level crashes during Next.js page data collection when env vars aren't set in Amplify build
- Move to `getSupabase()` helper called inside each handler

## Files changed
- `apps/web/app/api/trips/create/route.ts`
- `apps/web/app/api/trips/delete/route.ts`
- `apps/web/app/api/trips/enrich/route.ts`

## Test plan
- [x] `next build` passes locally
- [ ] Amplify build succeeds