### PR TITLE
TRA-280: Remove auth gates from trip creation — allow anonymous users

### DIFF
--- a/apps/web/app/api/trips/plan/route.ts
+++ b/apps/web/app/api/trips/plan/route.ts
@@ -4,7 +4,7 @@ const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
 
 export async function POST(req: NextRequest) {
   if (!API_URL) {
-    return NextResponse.json({ error: 'API not configured' }, { status: 500 })
+    return NextResponse.json({ error: 'Trip planning API not configured' }, { status: 503 })
   }
 
   const body = await req.json()

--- a/apps/web/components/spotlight/SpotlightTripCreator.tsx
+++ b/apps/web/components/spotlight/SpotlightTripCreator.tsx
@@ -96,22 +96,13 @@ export function SpotlightTripCreator({ prefillDestination, query, onClose, onBac
         return
       }
 
-      if (user) {
-        try {
-          const tripId = await savePlanToSupabase(plan as any)
-          onClose()
-          router.push(`/trip/${tripId}`)
-        } catch {
-          onClose()
-          router.push('/trips')
-        }
-      } else {
-        // Not logged in — store plan and redirect to preview
-        try {
-          sessionStorage.setItem('pendingPlan', JSON.stringify(plan))
-        } catch { /* ignore */ }
+      try {
+        const tripId = await savePlanToSupabase(plan as any)
         onClose()
-        router.push('/trip/preview')
+        router.push(`/trip/${tripId}`)
+      } catch {
+        onClose()
+        router.push('/trips')
       }
     })()
   }, [planner.state.phase, planner.state, user, onClose, router])

--- a/apps/web/components/trips/CreateTripModal.tsx
+++ b/apps/web/components/trips/CreateTripModal.tsx
@@ -176,11 +176,6 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
     setError(null)
     if (!validate()) return
 
-    if (!user?.id) {
-      setError('You must be signed in to create a trip.')
-      return
-    }
-
     setSubmitting(true)
     try {
       const { data, error: insertError } = await supabase
@@ -191,7 +186,8 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
           start_date: startDate,
           end_date: endDate,
           status: 'planning',
-          user_id: user.id,
+          user_id: user?.id || null,
+          visibility: user?.id ? 'private' : 'public',
         })
         .select()
         .single()

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -544,7 +544,6 @@ export async function savePlanToSupabase(
   onProgress?: (stage: string, pct: number) => void
 ): Promise<string> {
   const { data: { user } } = await supabase.auth.getUser()
-  if (!user) throw new Error('You must be logged in to save a trip. Please sign in and try again.')
 
   const ext = plan.extracted
   const dest = ext.destination
@@ -553,7 +552,8 @@ export async function savePlanToSupabase(
 
   // 1. Create trip
   const tripInsert: Record<string, unknown> = {
-    user_id: user.id,
+    user_id: user?.id || null,
+    visibility: user?.id ? 'private' : 'public',
     title: `${dest.city}, ${dest.country}`,
     destination: `${dest.city}, ${dest.country}`,
     start_date: ext.dates.start,
@@ -617,7 +617,7 @@ export async function savePlanToSupabase(
         return {
           trip_id: tripId,
           itinerary_day_id: dayRow.id,
-          user_id: user.id,
+          user_id: user?.id || null,
           activity_name: poi.name,
           activity_type: catMap[poi.subcategory] || catMap[poi.category] || 'other',
           starting_date: day.date,


### PR DESCRIPTION
## Summary
Remove all authentication requirements so any visitor can create a trip without signing up.

## Changes
- **CreateTripModal**: remove `user?.id` check blocking submission; anon trips get `user_id: null`, `visibility: 'public'`
- **savePlanToSupabase**: remove throw when no user; allow anon inserts
- **SpotlightTripCreator**: save directly instead of redirecting anon users to preview page
- **/api/trips/plan**: return 503 instead of 500 when API URL missing

## Test plan
- [x] Anonymous user can create trip from homepage search (tested via Playwright)
- [x] Trip redirects to `/trip/{id}` with full data after creation
- [ ] CreateTripModal works for anon users on /trips page
- [ ] SpotlightSearch trip creation works for anon users

Closes TRA-280