### PR TITLE
Fix(theme): Default to light mode instead of OS dark preference

### DIFF
--- a/apps/mobile/app/+html.tsx
+++ b/apps/mobile/app/+html.tsx
@@ -30,9 +30,4 @@ export default function Root({ children }: { children: React.ReactNode }) {
 const responsiveBackground = `
 body {
   background-color: #fff;
-}
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #000;
-  }
 }`;

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,7 +1,7 @@
 import '../global.css';
 
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
@@ -10,7 +10,6 @@ import { useEffect, useRef } from 'react';
 import 'react-native-reanimated';
 
 import { Text, TextInput } from 'react-native';
-import { useColorScheme } from '@/components/useColorScheme';
 import { useAuthStore } from '@travyl/shared';
 
 // Set Satoshi as the default font for all Text and TextInput components
@@ -84,10 +83,8 @@ export default function RootLayout() {
 }
 
 function RootLayoutNav() {
-  const colorScheme = useColorScheme();
-
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="trip/[id]" options={{ headerShown: false, gestureEnabled: false }} />

--- a/apps/mobile/hooks/useThemeColors.ts
+++ b/apps/mobile/hooks/useThemeColors.ts
@@ -1,8 +1,7 @@
-import { useColorScheme } from 'react-native';
-import { LIGHT_TOKENS, DARK_TOKENS } from '@travyl/shared';
+import { LIGHT_TOKENS } from '@travyl/shared';
 import type { ThemeTokens } from '@travyl/shared';
 
 export function useThemeColors(): ThemeTokens {
-  const scheme = useColorScheme();
-  return scheme === 'dark' ? DARK_TOKENS : LIGHT_TOKENS;
+  // Default to light mode — ignore OS dark mode preference (TRA-272)
+  return LIGHT_TOKENS;
 }

--- a/apps/web/components/DashboardNavbar.tsx
+++ b/apps/web/components/DashboardNavbar.tsx
@@ -35,7 +35,7 @@ export default function DashboardNavbar() {
 
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme')
-    const prefersDark = savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    const prefersDark = savedTheme === 'dark'
     setIsDarkMode(prefersDark)
     document.documentElement.classList.toggle('dark', prefersDark)
   }, [])

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -65,7 +65,7 @@ export default function Navbar() {
 
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme");
-    const prefersDark = savedTheme === "dark" || (!savedTheme && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    const prefersDark = savedTheme === "dark";
     setIsDarkMode(prefersDark);
     document.documentElement.classList.toggle("dark", prefersDark);
   }, []);


### PR DESCRIPTION
## Summary
- Removes `prefers-color-scheme: dark` system detection on first visit across web and mobile
- App now defaults to light mode for all new users regardless of OS setting
- Users who explicitly toggle dark mode via the navbar retain their saved preference

## Changes
- **`apps/web/components/navbar.tsx`** — removed `matchMedia` fallback; only checks localStorage
- **`apps/web/components/DashboardNavbar.tsx`** — same fix (duplicated init logic)
- **`apps/mobile/hooks/useThemeColors.ts`** — always returns `LIGHT_TOKENS`
- **`apps/mobile/app/_layout.tsx`** — always uses `DefaultTheme` (light)
- **`apps/mobile/app/+html.tsx`** — removed `@media (prefers-color-scheme: dark)` CSS

Closes TRA-272

## Test plan
- [ ] Visit app with OS in dark mode — should render light
- [ ] Toggle to dark via navbar — should persist across refresh
- [ ] Clear localStorage `theme` key — should revert to light