### PR TITLE
feat: entity detail pages — /place, /hotel, /activity, /destination (TRA-279)

### DIFF
--- a/apps/web/app/(main)/activity/[id]/ActivityDetailClient.tsx
+++ b/apps/web/app/(main)/activity/[id]/ActivityDetailClient.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import type { ActivityDetail } from '@travyl/shared'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityTips } from '@/components/entity/EntityTips'
+import { EntityAccessibility } from '@/components/entity/EntityAccessibility'
+import { EntityError } from '@/components/entity/EntityError'
+import { ActivityAbout } from '@/components/entity/activity/ActivityAbout'
+import { ActivityDetails } from '@/components/entity/activity/ActivityDetails'
+import { ActivityInclusions } from '@/components/entity/activity/ActivityInclusions'
+
+interface Props {
+  activity: ActivityDetail | null
+}
+
+export function ActivityDetailClient({ activity }: Props) {
+  if (!activity) {
+    return <EntityError type="activity" variant="404" />
+  }
+
+  const images = [activity.imageUrl, ...(activity.imageUrls ?? [])].filter(Boolean) as string[]
+
+  const city = activity.location?.split(',')[0]?.trim() ?? ''
+  const overline = [activity.category.toUpperCase(), city].filter(Boolean).join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Activities', href: '/places' },
+        ]}
+        current={activity.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={activity.name}
+        overline={overline}
+        rating={activity.rating}
+      />
+
+      <EntityActionsBar
+        entityId={activity.id}
+        entityType="activity"
+        entityName={activity.name}
+      />
+
+      <ActivityAbout activity={activity} />
+
+      <ActivityDetails activity={activity} />
+
+      <ActivityInclusions
+        included={activity.included}
+        notIncluded={activity.notIncluded}
+      />
+
+      <EntityTips tips={activity.tips} />
+
+      <EntityAccessibility items={activity.accessibility} />
+
+      {activity.latitude !== 0 && activity.longitude !== 0 && (
+        <EntityMap
+          latitude={activity.latitude}
+          longitude={activity.longitude}
+          address={activity.address}
+          name={activity.name}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(main)/activity/[id]/page.tsx
+++ b/apps/web/app/(main)/activity/[id]/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import type { ActivityDetail } from '@travyl/shared'
+import { ActivityDetailClient } from './ActivityDetailClient'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+async function fetchActivity(id: string): Promise<ActivityDetail | null> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+    const res = await fetch(`${baseUrl}/api/activities/${encodeURIComponent(id)}`, {
+      next: { revalidate: 3600 },
+    })
+    if (res.status === 404) return null
+    if (!res.ok) return null
+    const data = await res.json()
+    return data.activity ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const activity = await fetchActivity(id)
+
+  if (!activity) {
+    return {
+      title: 'Activity Not Found | Travyl',
+    }
+  }
+
+  return {
+    title: `${activity.name} | Travyl`,
+    description: activity.description || `Discover ${activity.name} on Travyl.`,
+    openGraph: {
+      title: activity.name,
+      description: activity.description || `Discover ${activity.name} on Travyl.`,
+      images: activity.imageUrl ? [{ url: activity.imageUrl }] : [],
+      type: 'website',
+    },
+    alternates: {
+      canonical: `/activity/${id}`,
+    },
+  }
+}
+
+export default async function ActivityDetailPage({ params }: Props) {
+  const { id } = await params
+  const activity = await fetchActivity(id)
+
+  return <ActivityDetailClient activity={activity} />
+}

--- a/apps/web/app/(main)/destination/[name]/DestinationDetailClient.tsx
+++ b/apps/web/app/(main)/destination/[name]/DestinationDetailClient.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import type { DestinationDetail } from '@travyl/shared'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { DestinationOverview } from '@/components/entity/destination/DestinationOverview'
+import { DestinationQuickFacts } from '@/components/entity/destination/DestinationQuickFacts'
+import { DestinationTrips } from '@/components/entity/destination/DestinationTrips'
+import { DestinationTopPlaces } from '@/components/entity/destination/DestinationTopPlaces'
+import { DestinationTopActivities } from '@/components/entity/destination/DestinationTopActivities'
+import { DestinationWhereToStay } from '@/components/entity/destination/DestinationWhereToStay'
+
+interface Props {
+  destination: DestinationDetail | null
+}
+
+export function DestinationDetailClient({ destination }: Props) {
+  if (!destination) {
+    return <EntityError type="destination" variant="404" />
+  }
+
+  const images = [
+    destination.image,
+    ...(destination.images ?? []),
+  ].filter(Boolean) as string[]
+
+  const overline = destination.country
+    ? `DESTINATION · ${destination.country}`
+    : 'DESTINATION'
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[{ label: 'Explore', href: '/' }]}
+        current={destination.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={destination.name}
+        overline={overline}
+        fallbackGradient="from-[#1e3a5f] to-[#0f2d4a]"
+      />
+
+      <EntityActionsBar
+        entityId={destination.name.toLowerCase().replace(/\s+/g, '-')}
+        entityType="destination"
+        entityName={destination.name}
+        variant="destination"
+      />
+
+      <DestinationOverview
+        description={destination.description}
+        tags={destination.tags}
+      />
+
+      <DestinationQuickFacts
+        country={destination.country}
+        language={destination.language}
+        currency={destination.currency}
+        timezone={destination.timezone}
+        bestTimeToVisit={destination.bestTimeToVisit}
+        budgetLevel={destination.budgetLevel}
+      />
+
+      <DestinationTrips destinationName={destination.name} />
+
+      <DestinationTopPlaces
+        destinationName={destination.name}
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+      />
+
+      <DestinationTopActivities destinationName={destination.name} />
+
+      <DestinationWhereToStay
+        destinationName={destination.name}
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+      />
+
+      <EntityMap
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+        name={destination.name}
+      />
+    </div>
+  )
+}

--- a/apps/web/app/(main)/destination/[name]/page.tsx
+++ b/apps/web/app/(main)/destination/[name]/page.tsx
@@ -1,361 +1,69 @@
-'use client'
-
-import { use, useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
-import Link from 'next/link'
-import dynamic from 'next/dynamic'
-import { useQuery } from '@tanstack/react-query'
-import { MapPin, Calendar, Plane, Plus, Compass, Globe, ExternalLink } from 'lucide-react'
-import { useTrips, useAuthStore, formatDateRange } from '@travyl/shared'
-import type { Trip } from '@travyl/shared'
-
-const LeafletMap = dynamic(() => import('@/components/leaflet-map'), { ssr: false })
+import type { Metadata } from 'next'
+import type { DestinationDetail } from '@travyl/shared'
+import { DestinationDetailClient } from './DestinationDetailClient'
 
 interface Props {
   params: Promise<{ name: string }>
 }
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface NominatimResult {
-  lat: string
-  lon: string
-  display_name: string
-  address?: {
-    country?: string
-    country_code?: string
-    state?: string
-    county?: string
+async function fetchDestination(name: string): Promise<DestinationDetail | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/destinations/${encodeURIComponent(name)}`,
+      { next: { revalidate: 3600 } }
+    )
+    if (!res.ok) return null
+    return res.json() as Promise<DestinationDetail>
+  } catch {
+    return null
   }
-  boundingbox?: [string, string, string, string]
 }
 
-// ─── Status badge config ──────────────────────────────────────────────────────
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { name } = await params
+  const destination = await fetchDestination(name)
 
-const STATUS_BADGE: Record<string, { label: string; bg: string; text: string }> = {
-  planning: { label: 'Planning', bg: 'bg-blue-100 dark:bg-blue-900/40', text: 'text-blue-700 dark:text-blue-300' },
-  booked: { label: 'Booked', bg: 'bg-emerald-100 dark:bg-emerald-900/40', text: 'text-emerald-700 dark:text-emerald-300' },
-  active: { label: 'Active', bg: 'bg-amber-100 dark:bg-amber-900/40', text: 'text-amber-700 dark:text-amber-300' },
-  completed: { label: 'Completed', bg: 'bg-gray-100 dark:bg-gray-700', text: 'text-gray-600 dark:text-gray-300' },
-  abandoned: { label: 'Cancelled', bg: 'bg-red-100 dark:bg-red-900/40', text: 'text-red-600 dark:text-red-300' },
-}
+  const displayName = destination?.name ?? decodeURIComponent(name).replace(/-/g, ' ')
 
-// ─── Skeleton ─────────────────────────────────────────────────────────────────
+  if (!destination) {
+    return {
+      title: `${displayName} | Travyl`,
+      description: `Explore ${displayName} — discover top attractions, activities, and travel tips.`,
+    }
+  }
 
-function DestinationSkeleton() {
-  return (
-    <div className="min-h-screen bg-white dark:bg-gray-950">
-      {/* Hero skeleton */}
-      <div className="relative min-h-[50vh] bg-gray-200 dark:bg-gray-800 animate-pulse" />
-      {/* Content skeleton */}
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-12 space-y-10">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="h-64 bg-gray-100 dark:bg-gray-800 rounded-2xl animate-pulse" />
-          <div className="space-y-4">
-            {[80, 60, 70, 50].map((w, i) => (
-              <div key={i} className={`h-16 bg-gray-100 dark:bg-gray-800 rounded-xl animate-pulse`} style={{ width: `${w}%` }} />
-            ))}
-          </div>
-        </div>
-        <div className="space-y-4">
-          <div className="h-6 w-48 bg-gray-100 dark:bg-gray-800 rounded animate-pulse" />
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="h-32 bg-gray-100 dark:bg-gray-800 rounded-xl animate-pulse" />
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
+  const title = destination.country
+    ? `${destination.name}, ${destination.country} | Travyl`
+    : `${destination.name} | Travyl`
 
-// ─── Trip card ────────────────────────────────────────────────────────────────
+  const description = destination.description
+    ? destination.description.slice(0, 160)
+    : `Explore ${destination.name} — discover top attractions, activities, and travel tips.`
 
-function DestinationTripCard({ trip }: { trip: Trip }) {
-  const badge = STATUS_BADGE[trip.status] ?? STATUS_BADGE.planning
-  const dateRange = formatDateRange(trip.start_date, trip.end_date)
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  const canonicalUrl = `${baseUrl}/destination/${encodeURIComponent(name)}`
 
-  return (
-    <Link
-      href={`/trip/${trip.id}`}
-      className="group block rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 hover:shadow-lg hover:border-[#1e3a5f]/30 dark:hover:border-blue-500/30 transition-all duration-200"
-    >
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-[#1e3a5f] dark:group-hover:text-blue-400 transition-colors leading-tight line-clamp-2">
-          {trip.title}
-        </h3>
-        <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${badge.bg} ${badge.text}`}>
-          {badge.label}
-        </span>
-      </div>
-
-      <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-3">
-        <MapPin size={13} className="shrink-0" />
-        <span className="line-clamp-1">{trip.destination}</span>
-      </div>
-
-      <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-        <Calendar size={12} className="shrink-0" />
-        <span>{dateRange}</span>
-      </div>
-    </Link>
-  )
-}
-
-// ─── Quick fact card ──────────────────────────────────────────────────────────
-
-function QuickFactCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
-  return (
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
-      <div className="w-9 h-9 rounded-lg bg-[#1e3a5f]/10 dark:bg-blue-500/10 flex items-center justify-center text-[#1e3a5f] dark:text-blue-400 shrink-0">
-        {icon}
-      </div>
-      <div className="min-w-0">
-        <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wide">{label}</p>
-        <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">{value}</p>
-      </div>
-    </div>
-  )
-}
-
-// ─── Main page ────────────────────────────────────────────────────────────────
-
-export default function DestinationPage({ params }: Props) {
-  const { name: rawName } = use(params)
-  const destination = decodeURIComponent(rawName)
-  const router = useRouter()
-  const user = useAuthStore((s) => s.user)
-
-  // ── Cover image ────────────────────────────────────────────────────────────
-  const { data: imageData, isLoading: imageLoading } = useQuery({
-    queryKey: ['destination-image', destination],
-    queryFn: async () => {
-      const res = await fetch(`/api/destination-image?destination=${encodeURIComponent(destination)}`)
-      if (!res.ok) return { url: null }
-      return res.json() as Promise<{ url: string | null }>
+  return {
+    title,
+    description,
+    openGraph: {
+      title: destination.name,
+      description,
+      url: canonicalUrl,
+      type: 'website',
+      ...(destination.image
+        ? { images: [{ url: destination.image, width: 1200, height: 630, alt: destination.name }] }
+        : {}),
     },
-    staleTime: 1000 * 60 * 60, // 1 hour
-  })
-
-  // ── Nominatim location data ────────────────────────────────────────────────
-  const { data: locationData } = useQuery({
-    queryKey: ['nominatim', destination],
-    queryFn: async () => {
-      const res = await fetch(
-        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(destination)}&format=json&limit=1&addressdetails=1`,
-        { headers: { 'Accept-Language': 'en' } }
-      )
-      if (!res.ok) return null
-      const results: NominatimResult[] = await res.json()
-      return results.length > 0 ? results[0] : null
+    alternates: {
+      canonical: canonicalUrl,
     },
-    staleTime: 1000 * 60 * 60 * 24, // 24 hours
-  })
-
-  // ── User's trips ───────────────────────────────────────────────────────────
-  const { data: trips, isLoading: tripsLoading } = useTrips()
-
-  const matchingTrips: Trip[] = (trips ?? []).filter((trip) =>
-    trip.destination.toLowerCase().includes(destination.toLowerCase()) ||
-    destination.toLowerCase().includes(trip.destination.toLowerCase())
-  )
-
-  // ── Derived data ───────────────────────────────────────────────────────────
-  const heroImageUrl = imageData?.url ?? null
-  const lat = locationData ? parseFloat(locationData.lat) : null
-  const lng = locationData ? parseFloat(locationData.lon) : null
-  const country = locationData?.address?.country ?? null
-  const state = locationData?.address?.state ?? null
-  const displayName = locationData?.display_name?.split(',').slice(0, 2).join(',').trim() ?? destination
-
-  // Build quick facts from Nominatim
-  const quickFacts: { icon: React.ReactNode; label: string; value: string }[] = []
-  if (country) quickFacts.push({ icon: <Globe size={16} />, label: 'Country', value: country })
-  if (state) quickFacts.push({ icon: <MapPin size={16} />, label: 'Region', value: state })
-  if (lat !== null && lng !== null) {
-    quickFacts.push({
-      icon: <Compass size={16} />,
-      label: 'Coordinates',
-      value: `${lat.toFixed(2)}° N, ${Math.abs(lng).toFixed(2)}° ${lng >= 0 ? 'E' : 'W'}`,
-    })
   }
+}
 
-  const handlePlanTrip = () => {
-    router.push(`/?destination=${encodeURIComponent(destination)}`)
-  }
-
-  const isPageLoading = imageLoading
-
-  if (isPageLoading) return <DestinationSkeleton />
-
-  return (
-    <div className="min-h-screen bg-white dark:bg-gray-950">
-      {/* ─── Hero ──────────────────────────────────────────────────────────── */}
-      <section className="relative min-h-[50vh] flex items-end overflow-hidden bg-gray-900">
-        {/* Background image or gradient fallback */}
-        {heroImageUrl ? (
-          <div
-            className="absolute inset-0 bg-cover bg-center bg-fixed"
-            style={{ backgroundImage: `url(${heroImageUrl})` }}
-            aria-hidden="true"
-          />
-        ) : (
-          <div
-            className="absolute inset-0"
-            style={{ background: 'linear-gradient(135deg, #1e3a5f 0%, #2d6a9f 50%, #1a2d45 100%)' }}
-            aria-hidden="true"
-          />
-        )}
-
-        {/* Dark gradient overlay */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-black/20" aria-hidden="true" />
-
-        {/* Hero content */}
-        <div className="relative z-10 w-full max-w-5xl mx-auto px-4 sm:px-6 pb-10 pt-24">
-          <div className="flex items-center gap-2 text-white/70 text-sm mb-3">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <span>/</span>
-            <span className="text-white/90">Destination</span>
-            <span>/</span>
-            <span className="text-white">{destination}</span>
-          </div>
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-serif font-normal text-white leading-tight tracking-wide drop-shadow-lg">
-            {destination}
-          </h1>
-          {displayName && displayName !== destination && (
-            <p className="mt-2 text-white/70 text-base font-medium">{displayName}</p>
-          )}
-        </div>
-      </section>
-
-      {/* ─── Main content ──────────────────────────────────────────────────── */}
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-12 space-y-14">
-
-        {/* ── Quick facts + map grid ───────────────────────────────────────── */}
-        {(lat !== null && lng !== null || quickFacts.length > 0) && (
-          <section>
-            <h2 className="text-xl font-serif font-normal text-gray-900 dark:text-white mb-6 tracking-wide flex items-center gap-2">
-              <MapPin size={18} className="text-[#1e3a5f] dark:text-blue-400" />
-              About this Destination
-            </h2>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
-              {/* Map */}
-              {lat !== null && lng !== null && (
-                <div className="rounded-2xl overflow-hidden border border-gray-200 dark:border-gray-700 shadow-sm">
-                  <LeafletMap
-                    lat={lat}
-                    lng={lng}
-                    label={destination}
-                    zoom={10}
-                    height={280}
-                  />
-                </div>
-              )}
-
-              {/* Quick facts */}
-              {quickFacts.length > 0 && (
-                <div className="grid grid-cols-1 gap-3">
-                  {quickFacts.map((fact, i) => (
-                    <QuickFactCard key={i} icon={fact.icon} label={fact.label} value={fact.value} />
-                  ))}
-                  {locationData && (
-                    <a
-                      href={`https://www.openstreetmap.org/search?query=${encodeURIComponent(destination)}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-xs text-[#1e3a5f] dark:text-blue-400 hover:underline mt-1 font-medium"
-                    >
-                      <ExternalLink size={12} />
-                      View on OpenStreetMap
-                    </a>
-                  )}
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-
-        {/* ── Your trips here ──────────────────────────────────────────────── */}
-        {user && (
-          <section>
-            <h2 className="text-xl font-serif font-normal text-gray-900 dark:text-white mb-6 tracking-wide flex items-center gap-2">
-              <Plane size={18} className="text-[#1e3a5f] dark:text-blue-400" />
-              Your Trips to {destination}
-            </h2>
-
-            {tripsLoading ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {[0, 1, 2].map((i) => (
-                  <div key={i} className="h-32 bg-gray-100 dark:bg-gray-800 rounded-xl animate-pulse" />
-                ))}
-              </div>
-            ) : matchingTrips.length > 0 ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {matchingTrips.map((trip) => (
-                  <DestinationTripCard key={trip.id} trip={trip} />
-                ))}
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 p-10 text-center">
-                <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mx-auto mb-3">
-                  <Plane size={20} className="text-gray-400 dark:text-gray-500" />
-                </div>
-                <p className="text-gray-500 dark:text-gray-400 text-sm">No trips to {destination} yet</p>
-                <p className="text-gray-400 dark:text-gray-500 text-xs mt-1">Be the first to plan one!</p>
-              </div>
-            )}
-          </section>
-        )}
-
-        {/* ── Plan a trip CTA ──────────────────────────────────────────────── */}
-        <section className="rounded-3xl bg-gradient-to-br from-[#1e3a5f] to-[#2d6a9f] p-10 text-center relative overflow-hidden">
-          {/* Decorative blobs */}
-          <div className="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/2" aria-hidden="true" />
-          <div className="absolute bottom-0 left-0 w-48 h-48 bg-white/5 rounded-full translate-y-1/2 -translate-x-1/2" aria-hidden="true" />
-
-          <div className="relative z-10">
-            <div className="w-14 h-14 rounded-2xl bg-white/10 backdrop-blur-sm flex items-center justify-center mx-auto mb-5">
-              <Plane size={24} className="text-white" />
-            </div>
-            <h2 className="text-2xl sm:text-3xl font-serif font-normal text-white mb-3 tracking-wide">
-              Plan a Trip to {destination}
-            </h2>
-            <p className="text-white/70 text-sm mb-8 max-w-md mx-auto leading-relaxed">
-              Build your perfect itinerary with day-by-day planning, activity scheduling, and real-time collaboration.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              {user ? (
-                <button
-                  onClick={handlePlanTrip}
-                  className="inline-flex items-center gap-2 px-8 py-3.5 rounded-xl bg-white text-[#1e3a5f] font-semibold text-sm hover:bg-gray-50 transition-colors shadow-lg shadow-black/20"
-                >
-                  <Plus size={16} />
-                  Plan a Trip
-                </button>
-              ) : (
-                <>
-                  <Link
-                    href={`/signup?destination=${encodeURIComponent(destination)}`}
-                    className="inline-flex items-center gap-2 px-8 py-3.5 rounded-xl bg-white text-[#1e3a5f] font-semibold text-sm hover:bg-gray-50 transition-colors shadow-lg shadow-black/20"
-                  >
-                    <Plus size={16} />
-                    Sign up to Plan
-                  </Link>
-                  <Link
-                    href={`/login?destination=${encodeURIComponent(destination)}`}
-                    className="inline-flex items-center gap-2 px-8 py-3.5 rounded-xl bg-white/10 text-white border border-white/30 font-semibold text-sm hover:bg-white/20 transition-colors"
-                  >
-                    Sign in
-                  </Link>
-                </>
-              )}
-            </div>
-          </div>
-        </section>
-      </div>
-    </div>
-  )
+export default async function DestinationPage({ params }: Props) {
+  const { name } = await params
+  const destination = await fetchDestination(name)
+  return <DestinationDetailClient destination={destination} />
 }

--- a/apps/web/app/(main)/hotel/[id]/HotelDetailClient.tsx
+++ b/apps/web/app/(main)/hotel/[id]/HotelDetailClient.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { HotelOverview } from '@/components/entity/hotel/HotelOverview'
+import { HotelStayDetails } from '@/components/entity/hotel/HotelStayDetails'
+import { HotelGuestRatings } from '@/components/entity/hotel/HotelGuestRatings'
+import { HotelRooms } from '@/components/entity/hotel/HotelRooms'
+import { HotelAmenities } from '@/components/entity/hotel/HotelAmenities'
+import type { RoomType } from '@travyl/shared'
+
+interface HotelApiResponse {
+  id: string
+  name: string
+  address?: string | null
+  city?: string | null
+  region?: string | null
+  country?: string | null
+  latitude?: number | null
+  longitude?: number | null
+  rating?: number | null
+  starRating?: number | null
+  phone?: string | null
+  website?: string | null
+  description?: string | null
+  images?: string[]
+  image_url?: string | null
+  categories?: string[]
+  hours?: string | null
+  price?: number | null
+  reviewCount?: number | null
+  // Optional rich data (not returned by Foursquare but may be present from other sources)
+  pricePerNight?: number | null
+  currency?: string | null
+  checkIn?: string | null
+  checkOut?: string | null
+  rooms?: RoomType[]
+  amenityGroups?: { category: string; items: string[] }[]
+  guestRatingCategories?: { label: string; score: number }[]
+}
+
+interface Props {
+  hotel: HotelApiResponse | null
+}
+
+export function HotelDetailClient({ hotel }: Props) {
+  if (!hotel) {
+    return <EntityError type="hotel" variant="404" />
+  }
+
+  const images = [hotel.image_url, ...(hotel.images ?? [])].filter(Boolean) as string[]
+  const dedupedImages = [...new Set(images)]
+
+  const overlineParts = [
+    'HOTEL',
+    hotel.starRating ? `${hotel.starRating}★` : null,
+    hotel.city ?? hotel.region ?? null,
+  ].filter(Boolean)
+  const overline = overlineParts.join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Hotels', href: '/places' },
+        ]}
+        current={hotel.name}
+      />
+
+      <EntityHero
+        images={dedupedImages}
+        title={hotel.name}
+        overline={overline}
+        rating={hotel.rating}
+        reviewCount={hotel.reviewCount ?? undefined}
+        priceLevel={hotel.price}
+      />
+
+      <EntityActionsBar
+        entityId={hotel.id}
+        entityType="hotel"
+        entityName={hotel.name}
+      />
+
+      <HotelOverview
+        description={hotel.description}
+        starRating={hotel.starRating}
+        guestRating={hotel.rating}
+        reviewCount={hotel.reviewCount}
+        tags={hotel.categories}
+      />
+
+      <HotelStayDetails
+        address={hotel.address}
+        pricePerNight={hotel.pricePerNight ?? hotel.price ?? null}
+        currency={hotel.currency}
+        checkIn={hotel.checkIn}
+        checkOut={hotel.checkOut}
+        phone={hotel.phone}
+        website={hotel.website}
+      />
+
+      {hotel.rating != null && (
+        <HotelGuestRatings
+          overall={hotel.rating}
+          reviewCount={hotel.reviewCount}
+          categories={hotel.guestRatingCategories}
+        />
+      )}
+
+      <HotelRooms
+        rooms={hotel.rooms}
+        currency={hotel.currency}
+      />
+
+      <HotelAmenities groups={hotel.amenityGroups} />
+
+      {hotel.latitude != null && hotel.longitude != null && (
+        <EntityMap
+          latitude={hotel.latitude}
+          longitude={hotel.longitude}
+          address={hotel.address}
+          name={hotel.name}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(main)/hotel/[id]/page.tsx
+++ b/apps/web/app/(main)/hotel/[id]/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next'
+import { HotelDetailClient } from './HotelDetailClient'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+interface HotelApiResponse {
+  id: string
+  name: string
+  description?: string | null
+  image_url?: string | null
+  images?: string[]
+  city?: string | null
+  [key: string]: unknown
+}
+
+async function fetchHotel(id: string): Promise<HotelApiResponse | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  try {
+    const res = await fetch(`${baseUrl}/api/hotels/${encodeURIComponent(id)}`, {
+      next: { revalidate: 3600 },
+    })
+    if (!res.ok) return null
+    return res.json() as Promise<HotelApiResponse>
+  } catch {
+    return null
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const hotel = await fetchHotel(id)
+
+  if (!hotel) {
+    return {
+      title: 'Hotel Not Found | Travyl',
+      description: 'This hotel could not be found.',
+    }
+  }
+
+  const description = hotel.description
+    ? hotel.description.slice(0, 160)
+    : `Discover ${hotel.name} on Travyl.`
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  const canonicalUrl = `${baseUrl}/hotel/${id}`
+  const ogImage = hotel.image_url ?? hotel.images?.[0] ?? null
+
+  return {
+    title: `${hotel.name} | Travyl`,
+    description,
+    openGraph: {
+      title: hotel.name,
+      description,
+      url: canonicalUrl,
+      type: 'website',
+      ...(ogImage ? { images: [{ url: ogImage, width: 600, height: 400, alt: hotel.name }] } : {}),
+    },
+    alternates: {
+      canonical: canonicalUrl,
+    },
+  }
+}
+
+export default async function HotelDetailPage({ params }: Props) {
+  const { id } = await params
+  const hotel = await fetchHotel(id)
+  return <HotelDetailClient hotel={hotel} />
+}

--- a/apps/web/app/(main)/place/[id]/PlaceDetailClient.tsx
+++ b/apps/web/app/(main)/place/[id]/PlaceDetailClient.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import type { PlaceItem } from '@travyl/shared'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityTips } from '@/components/entity/EntityTips'
+import { EntityAccessibility } from '@/components/entity/EntityAccessibility'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { PlaceAbout } from '@/components/entity/place/PlaceAbout'
+import { PlaceQuickInfo } from '@/components/entity/place/PlaceQuickInfo'
+
+interface Props {
+  place: PlaceItem | null
+}
+
+export function PlaceDetailClient({ place }: Props) {
+  if (!place) {
+    return <EntityError type="place" variant="404" />
+  }
+
+  // Normalize images: primary image + any extras, deduplicated and filtered
+  const images = [place.image, ...(place.images ?? [])].filter(Boolean) as string[]
+
+  // Build overline: CATEGORY · City
+  const cityFromAddress = place.address
+    ? place.address.split(',').slice(-2, -1)[0]?.trim() ?? null
+    : null
+  const overlineParts = [
+    place.category ? place.category.toUpperCase() : null,
+    cityFromAddress,
+  ].filter(Boolean) as string[]
+  const overline = overlineParts.join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Places', href: '/places' },
+        ]}
+        current={place.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={place.name}
+        overline={overline}
+        rating={place.rating}
+        reviewCount={place.reviewCount}
+        priceLevel={place.priceLevel ?? null}
+      />
+
+      <EntityActionsBar
+        entityId={place.id}
+        entityType="place"
+        entityName={place.name}
+      />
+
+      <PlaceAbout place={place} />
+
+      <PlaceQuickInfo place={place} />
+
+      <EntityTips tips={place.tips} />
+
+      <EntityAccessibility items={place.accessibility} />
+
+      {place.latitude != null && place.longitude != null && (
+        <EntityMap
+          latitude={place.latitude}
+          longitude={place.longitude}
+          address={place.address}
+          name={place.name}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(main)/place/[id]/page.tsx
+++ b/apps/web/app/(main)/place/[id]/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next'
+import type { PlaceItem } from '@travyl/shared'
+import { PlaceDetailClient } from './PlaceDetailClient'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+async function fetchPlace(id: string): Promise<PlaceItem | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  try {
+    const res = await fetch(`${baseUrl}/api/places/${encodeURIComponent(id)}`, {
+      next: { revalidate: 3600 },
+    })
+    if (!res.ok) return null
+    return res.json() as Promise<PlaceItem>
+  } catch {
+    return null
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const place = await fetchPlace(id)
+
+  if (!place) {
+    return {
+      title: 'Place Not Found | Travyl',
+      description: 'This place could not be found.',
+    }
+  }
+
+  const description =
+    place.description
+      ? place.description.slice(0, 160)
+      : place.tagline ?? `Discover ${place.name} on Travyl.`
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  const canonicalUrl = `${baseUrl}/place/${id}`
+
+  return {
+    title: `${place.name} | Travyl`,
+    description,
+    openGraph: {
+      title: place.name,
+      description,
+      url: canonicalUrl,
+      type: 'website',
+      ...(place.image ? { images: [{ url: place.image, width: 600, height: 400, alt: place.name }] } : {}),
+    },
+    alternates: {
+      canonical: canonicalUrl,
+    },
+  }
+}
+
+export default async function PlaceDetailPage({ params }: Props) {
+  const { id } = await params
+  const place = await fetchPlace(id)
+  return <PlaceDetailClient place={place} />
+}

--- a/apps/web/app/(trips-app)/trip/[id]/activities/[activityId]/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/activities/[activityId]/page.tsx
@@ -63,8 +63,11 @@ export default function ActivityDetailPage({
   if (!result) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-6">
-        <EntityBreadcrumb label="Activities" href={`/trip/${tripId}/activities`} />
-        <p className="text-gray-500 dark:text-gray-400">Activity not found.</p>
+        <EntityBreadcrumb
+          items={[{ label: 'Trip', href: `/trip/${tripId}` }]}
+          current="Activity not found"
+        />
+        <p className="text-gray-500 dark:text-gray-400 px-6 py-4">Activity not found.</p>
       </div>
     )
   }
@@ -93,11 +96,20 @@ export default function ActivityDetailPage({
       : null
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-6 pb-24">
-      <EntityBreadcrumb label="Activities" href={`/trip/${tripId}/activities`} />
+    <div className="max-w-3xl mx-auto pb-24">
+      <EntityBreadcrumb
+        items={[{ label: 'Trip', href: `/trip/${tripId}` }, { label: 'Activities', href: `/trip/${tripId}/activities` }]}
+        current={activity.name}
+      />
+
+      <EntityActionsBar
+        entityId={activityId}
+        entityType="activity"
+        entityName={activity.name}
+      />
 
       {/* Overview */}
-      <div className="mb-6">
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
           {activity.name}
         </h1>
@@ -173,19 +185,13 @@ export default function ActivityDetailPage({
 
       {/* Location map */}
       {hasCoordinates && (
-        <EntitySection title="Location">
-          <EntityMap
-            latitude={activity.latitude!}
-            longitude={activity.longitude!}
-            label={activity.location_name ?? activity.name}
-          />
-        </EntitySection>
+        <EntityMap
+          latitude={activity.latitude!}
+          longitude={activity.longitude!}
+          address={activity.location_name}
+          name={activity.name}
+        />
       )}
-
-      <EntityActionsBar
-        onEdit={() => {}}
-        onRemove={() => {}}
-      />
     </div>
   )
 }

--- a/apps/web/app/(trips-app)/trip/[id]/flights/[flightId]/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/flights/[flightId]/page.tsx
@@ -44,9 +44,12 @@ export default function FlightDetailPage({
 
   if (!flight) {
     return (
-      <div className="max-w-3xl mx-auto px-4 py-6">
-        <EntityBreadcrumb label="Flights" href={`/trip/${tripId}/flights`} />
-        <p className="text-gray-500 dark:text-gray-400">Flight not found.</p>
+      <div className="max-w-3xl mx-auto py-6">
+        <EntityBreadcrumb
+          items={[{ label: 'Trip', href: `/trip/${tripId}` }]}
+          current="Flight not found"
+        />
+        <p className="text-gray-500 dark:text-gray-400 px-6 py-4">Flight not found.</p>
       </div>
     )
   }
@@ -62,11 +65,14 @@ export default function FlightDetailPage({
       : null
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-6 pb-24">
-      <EntityBreadcrumb label="Flights" href={`/trip/${tripId}/flights`} />
+    <div className="max-w-3xl mx-auto pb-24">
+      <EntityBreadcrumb
+        items={[{ label: 'Trip', href: `/trip/${tripId}` }, { label: 'Flights', href: `/trip/${tripId}/flights` }]}
+        current={`${data.origin_iata} → ${data.dest_iata}`}
+      />
 
       {/* Hero — full-width gradient banner */}
-      <div className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-blue-600 px-6 py-6 mb-6 relative overflow-hidden">
+      <div className="w-full bg-gradient-to-r from-sky-500 to-blue-600 px-6 py-6 mb-0 relative overflow-hidden">
         {/* Airline + flight number row */}
         <div className="flex items-center justify-between mb-4">
           <span className="text-sm font-medium text-white/90">{data.airline}</span>
@@ -110,6 +116,12 @@ export default function FlightDetailPage({
           </div>
         </div>
       </div>
+
+      <EntityActionsBar
+        entityId={flightId}
+        entityType="activity"
+        entityName={`${data.airline} ${data.flight_number ?? ''} ${data.origin_iata}–${data.dest_iata}`}
+      />
 
       {/* Flight Info */}
       <EntitySection title="Flight Info">
@@ -213,11 +225,6 @@ export default function FlightDetailPage({
           </div>
         </EntitySection>
       )}
-
-      <EntityActionsBar
-        onEdit={() => {}}
-        onRemove={() => {}}
-      />
     </div>
   )
 }

--- a/apps/web/app/(trips-app)/trip/[id]/hotels/[hotelId]/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/hotels/[hotelId]/page.tsx
@@ -39,9 +39,12 @@ export default function HotelDetailPage({
 
   if (!hotel) {
     return (
-      <div className="max-w-3xl mx-auto px-4 py-6">
-        <EntityBreadcrumb label="Hotels" href={`/trip/${tripId}/hotels`} />
-        <p className="text-gray-500 dark:text-gray-400">Hotel not found.</p>
+      <div className="max-w-3xl mx-auto py-6">
+        <EntityBreadcrumb
+          items={[{ label: 'Trip', href: `/trip/${tripId}` }]}
+          current="Hotel not found"
+        />
+        <p className="text-gray-500 dark:text-gray-400 px-6 py-4">Hotel not found.</p>
       </div>
     )
   }
@@ -60,17 +63,27 @@ export default function HotelDetailPage({
     data.latitude !== null && data.longitude !== null
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-6 pb-24">
-      <EntityBreadcrumb label="Hotels" href={`/trip/${tripId}/hotels`} />
+    <div className="max-w-3xl mx-auto pb-24">
+      <EntityBreadcrumb
+        items={[{ label: 'Trip', href: `/trip/${tripId}` }, { label: 'Hotels', href: `/trip/${tripId}/hotels` }]}
+        current={data.name}
+      />
 
-      <EntityHero images={images} alt={data.name} />
+      <EntityHero
+        images={images}
+        title={data.name}
+        overline="Hotel"
+        rating={data.rating ?? null}
+      />
+
+      <EntityActionsBar
+        entityId={hotelId}
+        entityType="hotel"
+        entityName={data.name}
+      />
 
       {/* Overview */}
-      <div className="mt-5 mb-2">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
-          {data.name}
-        </h1>
-
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
         {data.star_rating !== null && (
           <div className="flex items-center gap-0.5 mb-2">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -84,12 +97,6 @@ export default function HotelDetailPage({
               />
             ))}
           </div>
-        )}
-
-        {data.rating !== null && (
-          <span className="inline-block bg-blue-600 text-white text-sm font-semibold px-2 py-0.5 rounded mb-2">
-            {data.rating.toFixed(1)}
-          </span>
         )}
 
         {data.address && (
@@ -162,19 +169,13 @@ export default function HotelDetailPage({
 
       {/* Location */}
       {hasCoordinates && (
-        <EntitySection title="Location">
-          <EntityMap
-            latitude={data.latitude!}
-            longitude={data.longitude!}
-            label={data.name}
-          />
-        </EntitySection>
+        <EntityMap
+          latitude={data.latitude!}
+          longitude={data.longitude!}
+          address={data.address ?? null}
+          name={data.name}
+        />
       )}
-
-      <EntityActionsBar
-        onEdit={() => {}}
-        onRemove={() => {}}
-      />
     </div>
   )
 }

--- a/apps/web/app/(trips-app)/trip/[id]/restaurants/[restaurantId]/page.tsx
+++ b/apps/web/app/(trips-app)/trip/[id]/restaurants/[restaurantId]/page.tsx
@@ -50,9 +50,12 @@ export default function RestaurantDetailPage({
 
   if (!result) {
     return (
-      <div className="max-w-3xl mx-auto px-4 py-6">
-        <EntityBreadcrumb label="Restaurants" href={`/trip/${tripId}/restaurants`} />
-        <p className="text-gray-500 dark:text-gray-400">Restaurant not found.</p>
+      <div className="max-w-3xl mx-auto py-6">
+        <EntityBreadcrumb
+          items={[{ label: 'Trip', href: `/trip/${tripId}` }]}
+          current="Restaurant not found"
+        />
+        <p className="text-gray-500 dark:text-gray-400 px-6 py-4">Restaurant not found.</p>
       </div>
     )
   }
@@ -74,11 +77,20 @@ export default function RestaurantDetailPage({
     activity.category.charAt(0).toUpperCase() + activity.category.slice(1)
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-6 pb-24">
-      <EntityBreadcrumb label="Restaurants" href={`/trip/${tripId}/restaurants`} />
+    <div className="max-w-3xl mx-auto pb-24">
+      <EntityBreadcrumb
+        items={[{ label: 'Trip', href: `/trip/${tripId}` }, { label: 'Restaurants', href: `/trip/${tripId}/restaurants` }]}
+        current={activity.name}
+      />
+
+      <EntityActionsBar
+        entityId={restaurantId}
+        entityType="place"
+        entityName={activity.name}
+      />
 
       {/* Overview */}
-      <div className="mb-6">
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
           {activity.name}
         </h1>
@@ -146,19 +158,13 @@ export default function RestaurantDetailPage({
 
       {/* Location map */}
       {hasCoordinates && (
-        <EntitySection title="Location">
-          <EntityMap
-            latitude={activity.latitude!}
-            longitude={activity.longitude!}
-            label={activity.location_name ?? activity.name}
-          />
-        </EntitySection>
+        <EntityMap
+          latitude={activity.latitude!}
+          longitude={activity.longitude!}
+          address={activity.location_name}
+          name={activity.name}
+        />
       )}
-
-      <EntityActionsBar
-        onEdit={() => {}}
-        onRemove={() => {}}
-      />
     </div>
   )
 }

--- a/apps/web/app/api/activities/[id]/route.ts
+++ b/apps/web/app/api/activities/[id]/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { ActivityDetail } from '@travyl/shared'
+
+const SERPAPI_BASE = 'https://serpapi.com/search.json'
+
+// ─── Route handler ────────────────────────────────────────────
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: rawId } = await params
+  const apiKey = process.env.SERPAPI_KEY
+
+  if (!apiKey) {
+    return NextResponse.json({ error: 'SERPAPI_KEY not configured' }, { status: 500 })
+  }
+
+  // Strip serp- prefix if present
+  const placeId = rawId.startsWith('serp-') ? rawId.slice(5) : rawId
+
+  const url = new URL(SERPAPI_BASE)
+  url.searchParams.set('engine', 'google_maps')
+  url.searchParams.set('place_id', placeId)
+  url.searchParams.set('api_key', apiKey)
+
+  let data: any
+  try {
+    const res = await fetch(url.toString(), { headers: { Accept: 'application/json' } })
+    if (!res.ok) {
+      console.error('[activities] SerpAPI error:', res.status)
+      return NextResponse.json({ error: 'Failed to fetch activity details' }, { status: 500 })
+    }
+    data = await res.json()
+  } catch (err) {
+    console.error('[activities] fetch error:', err)
+    return NextResponse.json({ error: 'Failed to fetch activity details' }, { status: 500 })
+  }
+
+  const place = data.place_results
+  if (!place) {
+    return NextResponse.json({ error: 'Activity not found' }, { status: 404 })
+  }
+
+  const imageUrls = extractImageUrls(place)
+
+  const activity: ActivityDetail = {
+    id: rawId,
+    name: place.title ?? '',
+    category: inferCategory(place.type, 'sightseeing'),
+    imageUrl: imageUrls[0] ?? '',
+    imageUrls,
+    duration: 2,
+    price: mapPrice(place.price),
+    currency: 'USD',
+    rating: place.rating ?? null,
+    location: place.address ?? '',
+    latitude: place.gps_coordinates?.latitude ?? 0,
+    longitude: place.gps_coordinates?.longitude ?? 0,
+    description: place.description ?? '',
+    source: 'ai',
+    relevanceScore: 1,
+    address: place.address ?? undefined,
+    phone: place.phone ?? undefined,
+    website: place.website ?? undefined,
+  }
+
+  return NextResponse.json(
+    { activity },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    },
+  )
+}
+
+// ─── Image helpers ────────────────────────────────────────────
+
+function upscaleThumbnail(url: string): string {
+  if (!url) return url
+  if (/lh\d*\.googleusercontent\.com/.test(url)) {
+    return url.replace(/=([whs]\d+(-[a-zA-Z0-9]+)*)$/, '=w800-h600')
+  }
+  return url
+}
+
+function extractImageUrls(place: any): string[] {
+  const seen = new Set<string>()
+  const urls: string[] = []
+
+  const push = (raw: string) => {
+    if (!raw) return
+    if (raw.includes('encrypted-tbn')) return
+    const upscaled = upscaleThumbnail(raw)
+    if (upscaled && !seen.has(upscaled)) {
+      seen.add(upscaled)
+      urls.push(upscaled)
+    }
+  }
+
+  if (place.thumbnail) push(place.thumbnail)
+
+  for (const p of (place.photos ?? [])) {
+    push(p.original ?? p.url ?? p.thumbnail ?? p.image ?? '')
+  }
+
+  return urls
+}
+
+// ─── Classifiers ─────────────────────────────────────────────
+
+function inferCategory(placeType: string | undefined, fallback: string): string {
+  if (!placeType) return fallback
+  const t = placeType.toLowerCase()
+  if (t.includes('restaurant') || t.includes('cafe') || t.includes('bakery') || t.includes('food') || t.includes('bar')) return 'dining'
+  if (t.includes('museum') || t.includes('gallery') || t.includes('theater') || t.includes('theatre') || t.includes('library')) return 'cultural'
+  if (t.includes('park') || t.includes('garden') || t.includes('beach') || t.includes('trail') || t.includes('nature')) return 'outdoor'
+  if (t.includes('shop') || t.includes('store') || t.includes('mall') || t.includes('market')) return 'shopping'
+  if (t.includes('club') || t.includes('lounge') || t.includes('nightlife')) return 'nightlife'
+  if (t.includes('tour') || t.includes('agency')) return 'tour'
+  if (t.includes('church') || t.includes('temple') || t.includes('monument') || t.includes('landmark') || t.includes('attraction')) return 'sightseeing'
+  return fallback
+}
+
+function mapPrice(price: string | undefined): number | null {
+  if (!price) return null
+  const map: Record<string, number> = { '$': 10, '$$': 25, '$$$': 50, '$$$$': 100 }
+  return map[price] ?? null
+}

--- a/apps/web/app/api/destinations/[name]/route.ts
+++ b/apps/web/app/api/destinations/[name]/route.ts
@@ -1,0 +1,303 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { DestinationDetail } from '@travyl/shared'
+
+// ─── Hardcoded destination metadata ───────────────────────────────────────────
+
+const DESTINATIONS: Record<string, DestinationDetail> = {
+  'paris': {
+    name: 'Paris',
+    country: 'France',
+    description: 'Paris, the City of Light, is renowned for its art, fashion, gastronomy, and culture. Home to iconic landmarks like the Eiffel Tower, the Louvre, and Notre-Dame, it remains one of the most visited cities in the world. Its elegant boulevards, world-class museums, and vibrant café culture make it an endlessly captivating destination.',
+    language: 'French',
+    currency: 'Euro (EUR)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'April – June, September – October',
+    budgetLevel: 3,
+    tags: ['Art & Culture', 'Romance', 'Cuisine', 'Fashion', 'Museums', 'History'],
+    latitude: 48.8566,
+    longitude: 2.3522,
+    image: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=1200&q=80',
+  },
+  'london': {
+    name: 'London',
+    country: 'United Kingdom',
+    description: 'London is a world-class city blending centuries of history with a dynamic modern energy. From the Tower of London and Buckingham Palace to cutting-edge art galleries and a thriving street food scene, there is something for every traveller. Its diverse neighbourhoods, iconic red buses, and the River Thames make it instantly recognisable.',
+    language: 'English',
+    currency: 'British Pound (GBP)',
+    timezone: 'GMT / UTC+0',
+    bestTimeToVisit: 'June – August, September – October',
+    budgetLevel: 4,
+    tags: ['History', 'Theatre', 'Museums', 'Parks', 'Shopping', 'Pubs'],
+    latitude: 51.5074,
+    longitude: -0.1278,
+    image: 'https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=1200&q=80',
+  },
+  'tokyo': {
+    name: 'Tokyo',
+    country: 'Japan',
+    description: 'Tokyo is a mesmerising blend of the ultra-modern and the deeply traditional. Futuristic skyscrapers stand alongside ancient temples, and the city\'s food scene is unmatched — it holds more Michelin stars than any other city in the world. From the neon-lit streets of Shinjuku to the tranquil gardens of Shinjuku Gyoen, Tokyo never fails to surprise.',
+    language: 'Japanese',
+    currency: 'Japanese Yen (JPY)',
+    timezone: 'JST / UTC+9',
+    bestTimeToVisit: 'March – May, October – November',
+    budgetLevel: 3,
+    tags: ['Technology', 'Anime', 'Cuisine', 'Temples', 'Shopping', 'Cherry Blossoms'],
+    latitude: 35.6762,
+    longitude: 139.6503,
+    image: 'https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=1200&q=80',
+  },
+  'new york': {
+    name: 'New York',
+    country: 'United States',
+    description: 'New York City is the ultimate metropolis — a place that never sleeps and perpetually reinvents itself. The skyline is iconic, the neighbourhoods are endlessly varied, and the cultural institutions are world-leading. From the neon glow of Times Square to the peaceful pathways of Central Park, NYC offers an unparalleled urban experience.',
+    language: 'English',
+    currency: 'US Dollar (USD)',
+    timezone: 'EST / UTC−5',
+    bestTimeToVisit: 'April – June, September – November',
+    budgetLevel: 4,
+    tags: ['City Life', 'Museums', 'Broadway', 'Skyline', 'Food', 'Fashion'],
+    latitude: 40.7128,
+    longitude: -74.006,
+    image: 'https://images.unsplash.com/photo-1496442226666-8d4d0e62e6e9?w=1200&q=80',
+  },
+  'rome': {
+    name: 'Rome',
+    country: 'Italy',
+    description: 'Rome, the Eternal City, is an open-air museum where ancient ruins and Renaissance masterpieces coexist with vibrant street life. The Colosseum, the Vatican, and the Trevi Fountain draw millions of visitors each year, yet the city\'s back streets and neighbourhood trattorias retain an irresistible authenticity. Few cities carry the weight of history as gracefully as Rome.',
+    language: 'Italian',
+    currency: 'Euro (EUR)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'April – June, September – October',
+    budgetLevel: 3,
+    tags: ['History', 'Archaeology', 'Art', 'Cuisine', 'Architecture', 'Vatican'],
+    latitude: 41.9028,
+    longitude: 12.4964,
+    image: 'https://images.unsplash.com/photo-1552832230-c0197dd311b5?w=1200&q=80',
+  },
+  'barcelona': {
+    name: 'Barcelona',
+    country: 'Spain',
+    description: 'Barcelona is a city that seduces with its unique architecture, sun-drenched beaches, and exuberant street life. Gaudí\'s surreal masterpieces — the Sagrada Família, Park Güell, and Casa Batlló — make it unlike anywhere else on earth. Add world-class tapas, FC Barcelona, and a buzzing nightlife and you have one of Europe\'s most beloved cities.',
+    language: 'Catalan / Spanish',
+    currency: 'Euro (EUR)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'May – June, September – October',
+    budgetLevel: 3,
+    tags: ['Architecture', 'Beach', 'Nightlife', 'Tapas', 'Gaudí', 'Football'],
+    latitude: 41.3874,
+    longitude: 2.1686,
+    image: 'https://images.unsplash.com/photo-1583422409516-2895a77efded?w=1200&q=80',
+  },
+  'dubai': {
+    name: 'Dubai',
+    country: 'United Arab Emirates',
+    description: 'Dubai is a city of superlatives — the tallest building, the largest mall, the most ambitious artificial islands. What was once a modest fishing village has transformed into a global hub of luxury, commerce, and innovation in just a few decades. Beyond the glittering skyline, the old quarter of Al Fahidi and the spice souks offer a glimpse into the city\'s heritage.',
+    language: 'Arabic',
+    currency: 'UAE Dirham (AED)',
+    timezone: 'GST / UTC+4',
+    bestTimeToVisit: 'November – March',
+    budgetLevel: 4,
+    tags: ['Luxury', 'Shopping', 'Desert', 'Architecture', 'Modern', 'Beaches'],
+    latitude: 25.2048,
+    longitude: 55.2708,
+    image: 'https://images.unsplash.com/photo-1512453979798-5ea266f8880c?w=1200&q=80',
+  },
+  'sydney': {
+    name: 'Sydney',
+    country: 'Australia',
+    description: 'Sydney is Australia\'s most iconic city, framed by a magnificent harbour and spectacular beaches. The Opera House and Harbour Bridge are two of the world\'s most recognisable structures, while Bondi Beach, the Blue Mountains, and the city\'s thriving food and arts scene ensure there is always more to explore. Sydney radiates an easy-going confidence that is uniquely Australian.',
+    language: 'English',
+    currency: 'Australian Dollar (AUD)',
+    timezone: 'AEDT / UTC+11',
+    bestTimeToVisit: 'September – November, March – May',
+    budgetLevel: 3,
+    tags: ['Harbour', 'Beaches', 'Outdoors', 'Wildlife', 'Surfing', 'Culture'],
+    latitude: -33.8688,
+    longitude: 151.2093,
+    image: 'https://images.unsplash.com/photo-1506973035872-a4ec16b8e8d9?w=1200&q=80',
+  },
+  'bangkok': {
+    name: 'Bangkok',
+    country: 'Thailand',
+    description: 'Bangkok is a city of contrasts: gleaming temples and street food stalls, luxury malls and backpacker hostels, solemn Buddhist monks and outrageous nightlife. The Grand Palace, Wat Pho, and the floating markets are must-sees, while the city\'s incredible street food scene is arguably the best in the world. Bangkok rewards those who venture off the beaten path.',
+    language: 'Thai',
+    currency: 'Thai Baht (THB)',
+    timezone: 'ICT / UTC+7',
+    bestTimeToVisit: 'November – February',
+    budgetLevel: 1,
+    tags: ['Temples', 'Street Food', 'Nightlife', 'Floating Markets', 'Shopping', 'Culture'],
+    latitude: 13.7563,
+    longitude: 100.5018,
+    image: 'https://images.unsplash.com/photo-1508009603885-50cf7c579365?w=1200&q=80',
+  },
+  'amsterdam': {
+    name: 'Amsterdam',
+    country: 'Netherlands',
+    description: 'Amsterdam enchants visitors with its picturesque canal ring, historic gabled houses, and world-class museums. The Rijksmuseum, the Van Gogh Museum, and the Anne Frank House are cultural cornerstones, while the city\'s lively café culture and cycling-friendly streets give it a uniquely liveable, human-scale charm. Few cities are as beautiful to simply wander.',
+    language: 'Dutch',
+    currency: 'Euro (EUR)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'April – May, September – October',
+    budgetLevel: 3,
+    tags: ['Canals', 'Cycling', 'Museums', 'Tulips', 'History', 'Nightlife'],
+    latitude: 52.3676,
+    longitude: 4.9041,
+    image: 'https://images.unsplash.com/photo-1534351590666-13e3e96b5017?w=1200&q=80',
+  },
+  'istanbul': {
+    name: 'Istanbul',
+    country: 'Turkey',
+    description: 'Istanbul is the only city in the world that straddles two continents, and its history reflects that unique position at the crossroads of Europe and Asia. The Hagia Sophia, the Blue Mosque, and the Grand Bazaar are monuments to successive civilisations, while the city\'s bosphorus views, hamams, and vibrant street food scene are thoroughly modern pleasures.',
+    language: 'Turkish',
+    currency: 'Turkish Lira (TRY)',
+    timezone: 'TRT / UTC+3',
+    bestTimeToVisit: 'April – May, September – November',
+    budgetLevel: 2,
+    tags: ['History', 'Architecture', 'Bazaars', 'Bosphorus', 'Culture', 'Cuisine'],
+    latitude: 41.0082,
+    longitude: 28.9784,
+    image: 'https://images.unsplash.com/photo-1527838832700-5059252407fa?w=1200&q=80',
+  },
+  'singapore': {
+    name: 'Singapore',
+    country: 'Singapore',
+    description: 'Singapore is a remarkably compact city-state that punches far above its weight on every measure — cuisine, gardens, architecture, and connectivity. The futuristic Gardens by the Bay, the colonial heritage of Chinatown and Little India, and a food culture that spans hawker centres to Michelin-starred restaurants make it one of Asia\'s most rewarding stops.',
+    language: 'English / Mandarin / Malay / Tamil',
+    currency: 'Singapore Dollar (SGD)',
+    timezone: 'SGT / UTC+8',
+    bestTimeToVisit: 'February – April, November – December',
+    budgetLevel: 4,
+    tags: ['Gardens', 'Food', 'Modern Architecture', 'Culture', 'Clean', 'Shopping'],
+    latitude: 1.3521,
+    longitude: 103.8198,
+    image: 'https://images.unsplash.com/photo-1525625293386-3f8f99389edd?w=1200&q=80',
+  },
+  'lisbon': {
+    name: 'Lisbon',
+    country: 'Portugal',
+    description: 'Lisbon is one of Europe\'s most captivating capitals — a sun-soaked city of hills, trams, and faded grandeur that has quietly become one of the continent\'s most desirable destinations. Fado music drifts from neighbourhood bars, pastel de nata pastries beckon from every corner café, and the views from its many miradouros are simply breathtaking.',
+    language: 'Portuguese',
+    currency: 'Euro (EUR)',
+    timezone: 'WET / UTC+0',
+    bestTimeToVisit: 'March – May, September – October',
+    budgetLevel: 2,
+    tags: ['Trams', 'Fado', 'Seafood', 'Architecture', 'Hills', 'Tiles'],
+    latitude: 38.7223,
+    longitude: -9.1393,
+    image: 'https://images.unsplash.com/photo-1555881400-74d7acaacd8b?w=1200&q=80',
+  },
+  'prague': {
+    name: 'Prague',
+    country: 'Czech Republic',
+    description: 'Prague is arguably Europe\'s most perfectly preserved medieval city, its Old Town a fairy-tale warren of cobbled lanes, Gothic spires, and Baroque palaces. The Astronomical Clock, Charles Bridge at dawn, and the Castle district are unforgettable sights, while the city\'s craft beer scene and vibrant arts culture add a contemporary dimension.',
+    language: 'Czech',
+    currency: 'Czech Koruna (CZK)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'May – June, September – October',
+    budgetLevel: 2,
+    tags: ['Medieval', 'Architecture', 'Beer', 'History', 'Romance', 'Christmas Markets'],
+    latitude: 50.0755,
+    longitude: 14.4378,
+    image: 'https://images.unsplash.com/photo-1541849546-216549ae216d?w=1200&q=80',
+  },
+  'berlin': {
+    name: 'Berlin',
+    country: 'Germany',
+    description: 'Berlin is a city that has reinvented itself repeatedly, and the energy of that transformation is palpable on every street corner. The remnants of the Wall, the Holocaust Memorial, and the DDR Museum bear witness to a turbulent past, while the city\'s legendary nightlife, world-class galleries, and thriving start-up scene make it one of Europe\'s most exciting capitals.',
+    language: 'German',
+    currency: 'Euro (EUR)',
+    timezone: 'CET / UTC+1',
+    bestTimeToVisit: 'May – September',
+    budgetLevel: 2,
+    tags: ['History', 'Nightlife', 'Art', 'Wall', 'Music', 'Culture'],
+    latitude: 52.52,
+    longitude: 13.405,
+    image: 'https://images.unsplash.com/photo-1560969184-10fe8719e047?w=1200&q=80',
+  },
+  'bali': {
+    name: 'Bali',
+    country: 'Indonesia',
+    description: 'Bali is Indonesia\'s crown jewel — an island of extraordinary beauty where terraced rice paddies, ancient Hindu temples, and pristine beaches exist in remarkable harmony. Ubud\'s arts and wellness scene, Seminyak\'s beach clubs, and the surf breaks of Canggu and Uluwatu attract a hugely diverse range of travellers. The Balinese culture and spirituality infuse the island with a unique energy.',
+    language: 'Balinese / Indonesian',
+    currency: 'Indonesian Rupiah (IDR)',
+    timezone: 'WITA / UTC+8',
+    bestTimeToVisit: 'April – October',
+    budgetLevel: 1,
+    tags: ['Beach', 'Temples', 'Rice Terraces', 'Surf', 'Wellness', 'Spirituality'],
+    latitude: -8.4095,
+    longitude: 115.1889,
+    image: 'https://images.unsplash.com/photo-1537996194471-e657df975ab4?w=1200&q=80',
+  },
+}
+
+// ─── Route handler ─────────────────────────────────────────────────────────────
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const { name } = await params
+  const slug = decodeURIComponent(name).toLowerCase().replace(/-/g, ' ').trim()
+
+  // Check hardcoded data first
+  const known = DESTINATIONS[slug]
+  if (known) {
+    return NextResponse.json(known, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400' },
+    })
+  }
+
+  // Fallback: Nominatim geocoding for unknown destinations
+  try {
+    const geoRes = await fetch(
+      `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(slug)}&format=json&limit=1&addressdetails=1`,
+      {
+        headers: {
+          'Accept-Language': 'en',
+          'User-Agent': 'Travyl/1.0 (travel planning app)',
+        },
+        signal: AbortSignal.timeout(6000),
+      }
+    )
+
+    if (!geoRes.ok) {
+      return NextResponse.json(null, { status: 404 })
+    }
+
+    const results: Array<{
+      lat: string
+      lon: string
+      display_name: string
+      address?: { country?: string; country_code?: string; state?: string }
+    }> = await geoRes.json()
+
+    if (!results.length) {
+      return NextResponse.json(null, { status: 404 })
+    }
+
+    const result = results[0]
+    const displayName = result.display_name.split(',')[0].trim()
+    const country = result.address?.country ?? null
+
+    const fallback: DestinationDetail = {
+      name: displayName,
+      country: country ?? '',
+      description: `Discover ${displayName}${country ? `, ${country}` : ''} — explore its attractions, culture, and hidden gems.`,
+      language: '',
+      currency: '',
+      timezone: '',
+      bestTimeToVisit: '',
+      budgetLevel: 2,
+      tags: [],
+      latitude: parseFloat(result.lat),
+      longitude: parseFloat(result.lon),
+      image: '',
+    }
+
+    return NextResponse.json(fallback, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400' },
+    })
+  } catch {
+    return NextResponse.json(null, { status: 404 })
+  }
+}

--- a/apps/web/app/api/hotels/[id]/route.ts
+++ b/apps/web/app/api/hotels/[id]/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const FSQ_API_KEY = process.env.FOURSQUARE_API_KEY
+
+interface FsqCategory {
+  name: string
+}
+
+interface FsqLocation {
+  address?: string
+  locality?: string
+  region?: string
+  country?: string
+  formatted_address?: string
+}
+
+interface FsqPhoto {
+  prefix: string
+  suffix: string
+  width?: number
+  height?: number
+}
+
+interface FsqHours {
+  display?: string
+  is_local_holiday?: boolean
+  open_now?: boolean
+}
+
+interface FsqVenueDetail {
+  fsq_id: string
+  name: string
+  geocodes?: {
+    main?: { latitude: number; longitude: number }
+  }
+  location?: FsqLocation
+  categories?: FsqCategory[]
+  rating?: number
+  stats?: { total_ratings?: number }
+  price?: number
+  tel?: string
+  website?: string
+  description?: string
+  hours?: FsqHours
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!FSQ_API_KEY) {
+    return NextResponse.json({ error: 'Foursquare not configured' }, { status: 500 })
+  }
+
+  try {
+    const headers = { Authorization: FSQ_API_KEY }
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 8000)
+
+    const [detailRes, photosRes] = await Promise.all([
+      fetch(
+        `https://api.foursquare.com/v3/places/${encodeURIComponent(id)}?fields=fsq_id,name,geocodes,location,categories,rating,stats,price,tel,website,description,hours`,
+        { headers, signal: controller.signal }
+      ),
+      fetch(
+        `https://api.foursquare.com/v3/places/${encodeURIComponent(id)}/photos?limit=10`,
+        { headers, signal: controller.signal }
+      ),
+    ])
+    clearTimeout(timer)
+
+    if (detailRes.status === 404) {
+      return NextResponse.json({ error: 'Hotel not found' }, { status: 404 })
+    }
+
+    if (!detailRes.ok) {
+      return NextResponse.json({ error: 'Foursquare fetch failed' }, { status: detailRes.status })
+    }
+
+    const venue: FsqVenueDetail = await detailRes.json()
+    const photosData: FsqPhoto[] = photosRes.ok ? await photosRes.json() : []
+
+    const images = photosData.map((p) => `${p.prefix}original${p.suffix}`)
+
+    // Normalize rating 0–10 → 0–5
+    const rawRating = venue.rating ?? null
+    const rating = rawRating != null ? Math.round((rawRating / 10) * 5 * 10) / 10 : null
+
+    const loc = venue.location ?? {}
+    const coords = venue.geocodes?.main ?? null
+
+    const hotel = {
+      id: venue.fsq_id ?? id,
+      name: venue.name,
+      address: loc.formatted_address ?? loc.address ?? null,
+      city: loc.locality ?? null,
+      region: loc.region ?? null,
+      country: loc.country ?? null,
+      latitude: coords?.latitude ?? null,
+      longitude: coords?.longitude ?? null,
+      rating,
+      starRating: null, // Foursquare v3 does not provide star ratings
+      phone: venue.tel ?? null,
+      website: venue.website ?? null,
+      description: venue.description ?? null,
+      images,
+      image_url: images[0] ?? null,
+      categories: (venue.categories ?? []).map((c) => c.name),
+      hours: venue.hours?.display ?? null,
+      price: venue.price ?? null,
+      reviewCount: venue.stats?.total_ratings ?? null,
+    }
+
+    return NextResponse.json(hotel, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Foursquare service unavailable' }, { status: 500 })
+  }
+}

--- a/apps/web/app/api/parse-intent/route.ts
+++ b/apps/web/app/api/parse-intent/route.ts
@@ -1,0 +1,71 @@
+// apps/web/app/api/parse-intent/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+
+// Lazy — avoids throwing at module load time when ANTHROPIC_API_KEY is absent
+let _client: Anthropic | null = null
+function getClient(): Anthropic {
+  if (!_client) _client = new Anthropic()
+  return _client
+}
+
+const PROMPT = `You are a travel search intent parser. Extract structured intent from a search query.
+
+Return ONLY valid JSON — no explanation, no markdown, no code fences.
+
+Schema:
+{
+  "intent": "discover" | "entity-search" | "create-trip" | "route" | "unknown",
+  "location": string | null,
+  "entityType": "restaurant" | "hotel" | "activity" | "flight" | null
+}
+
+Rules:
+- "discover": user wants to explore a destination with no specific entity type
+- "entity-search": user wants a specific category of place in a location
+- "create-trip": user wants to plan or start a trip
+- "route": user mentions two places (origin to destination)
+- "unknown": none of the above apply
+- location should be in Title Case (e.g. "Bakersfield", "New York")
+
+Query: `
+
+function fallback(q: string) {
+  return NextResponse.json({ intent: 'unknown', location: null, entityType: null, rawQuery: q })
+}
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get('q') ?? ''
+
+  // Auth check — must have a Bearer token (keeps open internet from burning API quota)
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return fallback(q)
+
+  if (!q.trim()) return fallback(q)
+  if (!process.env.ANTHROPIC_API_KEY) return fallback(q)
+
+  try {
+    const msg = await getClient().messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: `${PROMPT}"${q}"` }],
+    })
+
+    const text = (msg.content[0] as { type: 'text'; text: string }).text.trim()
+    const parsed = JSON.parse(text) as {
+      intent: string
+      location: string | null
+      entityType: string | null
+    }
+
+    return NextResponse.json({
+      intent: parsed.intent ?? 'unknown',
+      location: parsed.location ?? undefined,
+      entityType: parsed.entityType ?? undefined,
+      rawQuery: q,
+    })
+  } catch (err) {
+    console.error('[parse-intent] error:', err)
+    return fallback(q)
+  }
+}

--- a/apps/web/app/api/places/[id]/route.ts
+++ b/apps/web/app/api/places/[id]/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
+
+interface BackendPlace {
+  id: string
+  name: string
+  lat: number
+  lng: number
+  category: string
+  subcategory?: string
+  rating: number
+  review_count?: number
+  price_level?: string | number | null
+  description?: string | null
+  photo_url?: string | null
+  website?: string | null
+  address?: string | null
+  opening_hours?: Record<string, string>
+  visit_duration_min?: number | null
+  cuisine?: string | null
+  tags?: string[]
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!API_URL) {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+  }
+
+  try {
+    // Try a dedicated by-ID endpoint first
+    const res = await fetch(`${API_URL}/api/places/${encodeURIComponent(id)}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(8000),
+    })
+
+    if (res.status === 404) {
+      return NextResponse.json({ error: 'Place not found' }, { status: 404 })
+    }
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Place not found' }, { status: 404 })
+    }
+
+    const p: BackendPlace = await res.json()
+
+    const place = mapBackendPlace(p)
+
+    const out = NextResponse.json(place)
+    out.headers.set('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+    return out
+  } catch (err) {
+    console.error('[places/id] Route error:', err)
+    return NextResponse.json({ error: 'Failed to fetch place' }, { status: 500 })
+  }
+}
+
+function mapBackendPlace(p: BackendPlace) {
+  return {
+    id: p.id,
+    name: p.name,
+    image: upscaleGoogleImage(p.photo_url) ?? getFallbackImage(p.name, 0),
+    type: mapType(p.category),
+    rating: p.rating ?? 0,
+    tagline: p.description?.split('.')[0] ?? p.category,
+    category: mapCategory(p.category, p.subcategory),
+    description: p.description ?? '',
+    latitude: p.lat,
+    longitude: p.lng,
+    reviewCount: p.review_count,
+    address: p.address,
+    website: p.website,
+    priceLevel: mapPrice(p.price_level),
+    hours: formatHours(p.opening_hours),
+    duration: formatDuration(p.visit_duration_min),
+    tags: mapTags(p.category, p.tags, p.cuisine),
+  }
+}
+
+function upscaleGoogleImage(url: string | null | undefined): string | null {
+  if (!url) return null
+  return url.replace(/=w\d+-h\d+(-k-no)?/, '=w600-h400-k-no')
+}
+
+const FALLBACK_PHOTOS = [
+  'photo-1488646953014-85cb44e25828', 'photo-1507525428034-b723cf961d3e',
+  'photo-1476514525535-07fb3b4ae5f1', 'photo-1469854523086-cc02fe5d8800',
+  'photo-1530789253388-582c481c54b0', 'photo-1502602898657-3e91760cbb34',
+  'photo-1493976040374-85c8e12f0c0e', 'photo-1504150558240-0b4fd8946624',
+  'photo-1528127269322-539801943592', 'photo-1558642452-9d2a7deb7f62',
+  'photo-1506929562872-bb421503ef21', 'photo-1501785888041-af3ef285b470',
+  'photo-1523906834658-6e24ef2386f9', 'photo-1504598318550-17eba1008a68',
+  'photo-1516483638261-f4dbaf036963', 'photo-1526129318478-62ed807ebdf9',
+]
+
+function getFallbackImage(name: string, idx: number): string {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0
+  const photoIdx = (Math.abs(hash) + idx) % FALLBACK_PHOTOS.length
+  return `https://images.unsplash.com/${FALLBACK_PHOTOS[photoIdx]}?w=500&fit=crop&q=75`
+}
+
+function formatHours(hours?: Record<string, string>): string | undefined {
+  if (!hours) return undefined
+  const days = Object.entries(hours)
+  if (days.length === 0) return undefined
+  const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+  const today = dayNames[new Date().getDay()]
+  if (hours[today]) return `Today: ${hours[today]}`
+  return days[0][1]
+}
+
+function formatDuration(minutes?: number | null): string | undefined {
+  if (!minutes) return undefined
+  if (minutes < 60) return `${minutes} min`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m > 0 ? `${h}h ${m}m` : `${h} hour${h > 1 ? 's' : ''}`
+}
+
+function mapType(backendCat: string): string {
+  const cat = backendCat.toLowerCase()
+  if (['restaurant', 'cafe', 'bar', 'dining'].includes(cat)) return 'restaurant'
+  if (['museum', 'attraction', 'landmark', 'monument', 'sightseeing'].includes(cat)) return 'attraction'
+  if (['park', 'garden', 'outdoor', 'beach'].includes(cat)) return 'experience'
+  if (['event', 'festival', 'concert'].includes(cat)) return 'event'
+  return 'destination'
+}
+
+function mapCategory(cat: string, sub?: string): string {
+  const c = (sub ?? cat).toLowerCase()
+  if (['restaurant', 'dining'].includes(c)) return 'Culinary'
+  if (c === 'cafe') return 'Culinary'
+  if (c === 'bar' || c === 'nightlife') return 'Music Festival'
+  if (c === 'museum') return 'Historical'
+  if (['attraction', 'landmark', 'monument', 'sightseeing'].includes(c)) return 'Landmark'
+  if (['park', 'garden'].includes(c)) return 'Nature'
+  if (c === 'beach') return 'Coastal'
+  if (c === 'shopping') return 'Market'
+  return 'Cultural'
+}
+
+function titleCase(s: string): string {
+  return s.split(/[\s_]+/).map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ')
+}
+
+function mapTags(cat: string, backendTags?: string[], cuisine?: string | null): string[] {
+  const tags: string[] = (backendTags ?? []).map(titleCase)
+  const c = cat.toLowerCase()
+  if (c === 'restaurant' || c === 'cafe' || c === 'dining') tags.push('Food')
+  if (c === 'museum' || c === 'attraction' || c === 'sightseeing') tags.push('Culture', 'Landmark')
+  if (c === 'park' || c === 'garden') tags.push('Nature')
+  if (c === 'bar' || c === 'nightlife') tags.push('Nightlife', 'Bar')
+  if (c === 'beach') tags.push('Beach', 'Coast')
+  if (c === 'shopping') tags.push('Markets')
+  if (cuisine) tags.push(titleCase(cuisine))
+  return [...new Set(tags)]
+}
+
+function mapPrice(level: string | number | null | undefined): 1 | 2 | 3 | 4 | undefined {
+  if (level == null) return undefined
+  if (typeof level === 'number') {
+    return level >= 1 && level <= 4 ? (level as 1 | 2 | 3 | 4) : undefined
+  }
+  const len = level.replace(/[^$]/g, '').length
+  if (len >= 1 && len <= 4) return len as 1 | 2 | 3 | 4
+  const num = parseInt(level, 10)
+  if (num >= 1 && num <= 4) return num as 1 | 2 | 3 | 4
+  return undefined
+}

--- a/apps/web/components/PlaceDetailOverlay.tsx
+++ b/apps/web/components/PlaceDetailOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   Heart, MapPin, Star, X, Share2, ExternalLink, ChevronLeft, ChevronRight,
@@ -919,6 +920,16 @@ function WebOverlayActions({ place }: { place: PlaceItem }) {
           <span className="text-[10px] font-semibold text-white/85">Share</span>
         </button>
       </div>
+
+      {/* View full details link */}
+      <Link
+        href={`/place/${place.id}`}
+        onClick={(e) => e.stopPropagation()}
+        className="flex items-center justify-center gap-1.5 py-2.5 rounded-xl border border-white/20 text-[12px] font-semibold text-white/75 hover:bg-white/10 hover:text-white transition-colors"
+      >
+        <ExternalLink size={12} className="text-white/60" />
+        View full details
+      </Link>
     </div>
   );
 }
@@ -1010,6 +1021,16 @@ function WebPlaceActions({ place }: { place: PlaceItem }) {
           <span className="text-[10px] font-semibold text-white/85">Share</span>
         </button>
       </div>
+
+      {/* View full details link */}
+      <Link
+        href={`/place/${place.id}`}
+        onClick={(e) => e.stopPropagation()}
+        className="flex items-center justify-center gap-1 py-2 rounded-lg border bg-white/[0.08] border-white/10 hover:bg-white/[0.15] transition-colors"
+      >
+        <ExternalLink size={11} className="text-sky-300" />
+        <span className="text-[10px] font-semibold text-white/85">View details</span>
+      </Link>
     </div>
   );
 }

--- a/apps/web/components/calendar/SuggestionDetailDrawer.tsx
+++ b/apps/web/components/calendar/SuggestionDetailDrawer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { getActivityColor } from '@travyl/shared/viewmodels/calendarViewModel'
 import type { SuggestionCard } from './types'
 
@@ -200,6 +201,17 @@ export function SuggestionDetailDrawer({
             {suggestion.description}
           </p>
         )}
+
+        {/* View full details link */}
+        <div className="pt-1">
+          <Link
+            href={`/activity/${suggestion.id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center justify-center gap-1.5 w-full py-2 rounded-lg border border-[var(--cal-border)] text-[12px] font-medium text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)] transition-colors"
+          >
+            View full details
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/components/entity/EntityAccessibility.tsx
+++ b/apps/web/components/entity/EntityAccessibility.tsx
@@ -1,0 +1,26 @@
+import { EntitySection } from './EntitySection'
+import { Check } from 'iconoir-react'
+
+interface Props {
+  items?: string[]
+}
+
+export function EntityAccessibility({ items }: Props) {
+  if (!items?.length) return null
+
+  return (
+    <EntitySection title="Accessibility">
+      <div className="flex flex-wrap gap-2">
+        {items.map((item, i) => (
+          <span
+            key={i}
+            className="inline-flex items-center gap-1.5 rounded-full bg-green-50 text-green-700 text-xs font-medium px-3 py-1"
+          >
+            <Check className="w-3 h-3" />
+            {item}
+          </span>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/EntityActionsBar.tsx
+++ b/apps/web/components/entity/EntityActionsBar.tsx
@@ -1,44 +1,91 @@
 'use client'
 
-import { Pencil, Trash2, Share2, Heart } from 'lucide-react'
+import { useState } from 'react'
+import Link from 'next/link'
+import { Plus, Heart, HeartSolid, ShareAndroid } from 'iconoir-react'
+import { useAuthStore } from '@travyl/shared'
 
 interface Props {
-  onEdit?: () => void
-  onRemove?: () => void
-  onShare?: () => void
-  isFavorited?: boolean
-  onToggleFavorite?: () => void
+  entityId: string
+  entityType: 'place' | 'hotel' | 'activity' | 'destination'
+  entityName: string
+  variant?: 'default' | 'destination'
 }
 
-export function EntityActionsBar({ onEdit, onRemove, onShare, isFavorited, onToggleFavorite }: Props) {
-  return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-t border-gray-200 dark:border-gray-700">
-      <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          {onEdit && (
-            <button onClick={onEdit} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-              <Pencil className="w-3.5 h-3.5" /> Edit
-            </button>
-          )}
-          {onRemove && (
-            <button onClick={onRemove} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/30 rounded-lg hover:bg-red-100 dark:hover:bg-red-950/50 transition-colors">
-              <Trash2 className="w-3.5 h-3.5" /> Remove
-            </button>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {onShare && (
-            <button onClick={onShare} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-              <Share2 className="w-3.5 h-3.5" /> Share
-            </button>
-          )}
-          {onToggleFavorite && (
-            <button onClick={onToggleFavorite} className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-              <Heart className={`w-4 h-4 ${isFavorited ? 'fill-red-500 text-red-500' : 'text-gray-500'}`} />
-            </button>
-          )}
-        </div>
+export function EntityActionsBar({ entityId, entityType, entityName, variant = 'default' }: Props) {
+  const user = useAuthStore((s) => s.user)
+  const [favorited, setFavorited] = useState(false)
+  const [shared, setShared] = useState(false)
+
+  const handleShare = async () => {
+    const url = window.location.href
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: entityName, url })
+      } catch {
+        // user cancelled or error — silent
+      }
+    } else {
+      await navigator.clipboard.writeText(url)
+      setShared(true)
+      setTimeout(() => setShared(false), 2000)
+    }
+  }
+
+  const handleFavorite = () => {
+    setFavorited((f) => !f)
+  }
+
+  if (!user) {
+    return (
+      <div className="px-6 md:px-10 py-4 border-b border-gray-100">
+        <p className="text-sm text-gray-500">
+          <Link href="/login" className="text-[#003594] hover:text-[#002B7A] font-medium underline-offset-2 hover:underline">
+            Sign in
+          </Link>{' '}
+          to save this {entityType}
+        </p>
       </div>
+    )
+  }
+
+  return (
+    <div className="px-6 md:px-10 py-4 border-b border-gray-100 flex items-center gap-3">
+      {/* Primary CTA */}
+      <button className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-4 py-2.5 rounded-xl transition-colors">
+        <Plus className="w-4 h-4" />
+        {variant === 'destination' ? 'Plan a Trip' : 'Add to Trip'}
+      </button>
+
+      {/* Favorite */}
+      <button
+        onClick={handleFavorite}
+        aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
+        className={`inline-flex items-center justify-center w-10 h-10 rounded-xl border transition-colors ${
+          favorited
+            ? 'bg-red-50 border-red-200 text-red-500'
+            : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'
+        }`}
+      >
+        {favorited ? (
+          <HeartSolid className="w-4 h-4 text-red-500" />
+        ) : (
+          <Heart className="w-4 h-4" />
+        )}
+      </button>
+
+      {/* Share */}
+      <button
+        onClick={handleShare}
+        aria-label="Share"
+        className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-gray-200 bg-white text-gray-500 hover:border-gray-300 transition-colors"
+      >
+        <ShareAndroid className="w-4 h-4" />
+      </button>
+
+      {shared && (
+        <span className="text-xs text-gray-500 animate-in fade-in duration-200">Link copied!</span>
+      )}
     </div>
   )
 }

--- a/apps/web/components/entity/EntityBreadcrumb.tsx
+++ b/apps/web/components/entity/EntityBreadcrumb.tsx
@@ -1,21 +1,35 @@
-'use client'
-
 import Link from 'next/link'
-import { ChevronLeft } from 'lucide-react'
+import { NavArrowRight } from 'iconoir-react'
 
-interface Props {
+interface BreadcrumbItem {
   label: string
   href: string
 }
 
-export function EntityBreadcrumb({ label, href }: Props) {
+interface Props {
+  items: BreadcrumbItem[]
+  current: string
+}
+
+export function EntityBreadcrumb({ items, current }: Props) {
   return (
-    <Link
-      href={href}
-      className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors mb-4"
-    >
-      <ChevronLeft className="w-4 h-4" />
-      Back to {label}
-    </Link>
+    <nav aria-label="Breadcrumb" className="px-6 md:px-10 py-3">
+      <ol className="flex items-center gap-1 flex-wrap">
+        {items.map((item, i) => (
+          <li key={i} className="flex items-center gap-1">
+            <Link
+              href={item.href}
+              className="text-sm text-gray-500 hover:text-[#003594] transition-colors"
+            >
+              {item.label}
+            </Link>
+            <NavArrowRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
+          </li>
+        ))}
+        <li>
+          <span className="text-sm text-gray-900 font-medium truncate">{current}</span>
+        </li>
+      </ol>
+    </nav>
   )
 }

--- a/apps/web/components/entity/EntityError.tsx
+++ b/apps/web/components/entity/EntityError.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link'
+
+interface Props {
+  type: 'place' | 'hotel' | 'activity' | 'destination'
+  variant: '404' | 'error'
+  onRetry?: () => void
+}
+
+const listingHrefs: Record<Props['type'], string> = {
+  place: '/places',
+  hotel: '/places',
+  activity: '/places',
+  destination: '/',
+}
+
+const typeLabels: Record<Props['type'], string> = {
+  place: 'place',
+  hotel: 'hotel',
+  activity: 'activity',
+  destination: 'destination',
+}
+
+const typePlurals: Record<Props['type'], string> = {
+  place: 'places',
+  hotel: 'hotels',
+  activity: 'activities',
+  destination: 'destinations',
+}
+
+export function EntityError({ type, variant, onRetry }: Props) {
+  const label = typeLabels[type]
+  const plural = typePlurals[type]
+  const href = listingHrefs[type]
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-6">
+      <div className="text-center max-w-md">
+        {variant === '404' ? (
+          <>
+            <p className="text-6xl font-serif font-normal text-gray-200 mb-4">404</p>
+            <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-3">
+              We couldn&apos;t find this {label}
+            </h1>
+            <p className="text-sm text-gray-500 mb-8">
+              It may have been removed or the link might be incorrect.
+            </p>
+            <Link
+              href={href}
+              className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-6 py-3 rounded-xl transition-colors"
+            >
+              Browse {plural}
+            </Link>
+          </>
+        ) : (
+          <>
+            <p className="text-6xl mb-4">⚠</p>
+            <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-3">
+              Something went wrong
+            </h1>
+            <p className="text-sm text-gray-500 mb-8">
+              We had trouble loading this {label}. Please try again.
+            </p>
+            <div className="flex items-center justify-center gap-3">
+              {onRetry && (
+                <button
+                  onClick={onRetry}
+                  className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-6 py-3 rounded-xl transition-colors"
+                >
+                  Try again
+                </button>
+              )}
+              <Link
+                href={href}
+                className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              >
+                Browse {plural}
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/entity/EntityHero.tsx
+++ b/apps/web/components/entity/EntityHero.tsx
@@ -1,56 +1,127 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import Image from 'next/image'
+import { NavArrowLeft, NavArrowRight, StarSolid } from 'iconoir-react'
 
 interface Props {
   images: string[]
-  alt: string
-  accentColor?: string
+  title: string
+  overline: string
+  rating?: number | null
+  reviewCount?: number
+  priceLevel?: number | null
+  fallbackGradient?: string
 }
 
-export function EntityHero({ images, alt, accentColor }: Props) {
+export function EntityHero({
+  images,
+  title,
+  overline,
+  rating,
+  reviewCount,
+  priceLevel,
+  fallbackGradient = 'from-[#1e3a5f] to-[#0f1d30]',
+}: Props) {
   const [currentIndex, setCurrentIndex] = useState(0)
-  const hasMultiple = images.length > 1
+  const [failedImages, setFailedImages] = useState<Set<number>>(new Set())
 
-  if (!images.length) {
-    return (
-      <div
-        className="w-full h-[280px] rounded-xl flex items-center justify-center"
-        style={{ backgroundColor: accentColor ? `${accentColor}15` : '#f3f4f6' }}
-      >
-        <span className="text-gray-400 text-sm">No image available</span>
-      </div>
-    )
+  const validImages = images.filter((_, i) => !failedImages.has(i))
+  const hasMultiple = validImages.length > 1
+  const currentImage = validImages[currentIndex] ?? null
+
+  const prev = () => setCurrentIndex((i) => (i - 1 + validImages.length) % validImages.length)
+  const next = () => setCurrentIndex((i) => (i + 1) % validImages.length)
+
+  const handleImageError = (index: number) => {
+    setFailedImages((prev) => new Set(prev).add(index))
+    if (currentIndex >= validImages.length - 1) {
+      setCurrentIndex(Math.max(0, validImages.length - 2))
+    }
   }
 
   return (
-    <div className="relative w-full h-[280px] rounded-xl overflow-hidden group">
-      <img
-        src={images[currentIndex]}
-        alt={alt}
-        className="w-full h-full object-cover"
-      />
-      <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+    <div className={`relative w-full aspect-[4/3] md:aspect-[16/9] overflow-hidden group`}>
+      {currentImage ? (
+        <Image
+          src={currentImage}
+          alt={title}
+          fill
+          className="object-cover"
+          priority
+          onError={() => handleImageError(images.indexOf(currentImage))}
+        />
+      ) : (
+        <div className={`w-full h-full bg-gradient-to-br ${fallbackGradient}`} />
+      )}
 
+      {/* Gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-t from-[#0f1d30] via-[#0f1d30]/40 to-transparent" />
+
+      {/* Content in lower third */}
+      <div className="absolute bottom-0 left-0 right-0 px-6 md:px-10 pb-8 pt-16">
+        {/* Overline */}
+        <p className="font-sans text-xs uppercase tracking-widest text-white/70 mb-2">
+          {overline}
+        </p>
+
+        {/* Title */}
+        <h1 className="font-serif font-normal tracking-wide text-3xl md:text-5xl text-white mb-4">
+          {title}
+        </h1>
+
+        {/* Badges row */}
+        <div className="flex items-center gap-3">
+          {rating != null && (
+            <div className="flex items-center gap-1.5 bg-[#1e3a5f]/80 backdrop-blur-sm text-white rounded-lg px-3 py-1.5">
+              <StarSolid className="w-3.5 h-3.5 text-amber-400" />
+              <span className="text-sm font-medium">{rating.toFixed(1)}</span>
+              {reviewCount != null && (
+                <span className="text-xs text-white/70">({reviewCount.toLocaleString()})</span>
+              )}
+            </div>
+          )}
+
+          {priceLevel != null && (
+            <div className="flex items-center bg-[#1e3a5f]/80 backdrop-blur-sm text-white rounded-lg px-3 py-1.5">
+              {[1, 2, 3, 4].map((level) => (
+                <span
+                  key={level}
+                  className={`text-sm font-medium ${level <= priceLevel ? 'text-white' : 'text-white/30'}`}
+                >
+                  $
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Carousel controls */}
       {hasMultiple && (
         <>
           <button
-            onClick={() => setCurrentIndex((i) => (i - 1 + images.length) % images.length)}
-            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={prev}
+            aria-label="Previous image"
+            className="absolute left-4 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-white shadow-md"
           >
-            <ChevronLeft className="w-4 h-4" />
+            <NavArrowLeft className="w-4 h-4 text-gray-900" />
           </button>
           <button
-            onClick={() => setCurrentIndex((i) => (i + 1) % images.length)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={next}
+            aria-label="Next image"
+            className="absolute right-4 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-white shadow-md"
           >
-            <ChevronRight className="w-4 h-4" />
+            <NavArrowRight className="w-4 h-4 text-gray-900" />
           </button>
-          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
-            {images.map((_, i) => (
-              <div
+
+          {/* Dot indicators */}
+          <div className="absolute bottom-4 right-6 flex gap-1.5">
+            {validImages.map((_, i) => (
+              <button
                 key={i}
+                onClick={() => setCurrentIndex(i)}
+                aria-label={`Go to image ${i + 1}`}
                 className={`w-1.5 h-1.5 rounded-full transition-colors ${
                   i === currentIndex ? 'bg-white' : 'bg-white/50'
                 }`}

--- a/apps/web/components/entity/EntityMap.tsx
+++ b/apps/web/components/entity/EntityMap.tsx
@@ -1,20 +1,45 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { MapPin } from 'iconoir-react'
+import { EntitySection } from './EntitySection'
 
 const LeafletMap = dynamic(() => import('@/components/leaflet-map'), { ssr: false })
 
 interface Props {
   latitude: number
   longitude: number
-  label?: string
-  className?: string
+  address?: string | null
+  name: string
 }
 
-export function EntityMap({ latitude, longitude, label, className }: Props) {
+export function EntityMap({ latitude, longitude, address, name }: Props) {
+  const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+    address ?? name
+  )}&query_place_id=`
+
   return (
-    <div className={`rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 ${className ?? 'h-[200px]'}`}>
-      <LeafletMap lat={latitude} lng={longitude} label={label} />
-    </div>
+    <EntitySection title="Location">
+      {address && (
+        <div className="flex items-start gap-2 mb-4">
+          <MapPin className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
+          <p className="text-sm text-gray-700">{address}</p>
+        </div>
+      )}
+
+      <div className="rounded-xl overflow-hidden border border-gray-200 h-64 md:h-80">
+        <LeafletMap lat={latitude} lng={longitude} label={name} height="100%" />
+      </div>
+
+      <a
+        href={googleMapsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 mt-3 text-sm text-[#003594] hover:text-[#002B7A] transition-colors"
+      >
+        <MapPin className="w-3.5 h-3.5" />
+        Open in Google Maps
+      </a>
+    </EntitySection>
   )
 }

--- a/apps/web/components/entity/EntityQuickInfo.tsx
+++ b/apps/web/components/entity/EntityQuickInfo.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react'
+
+interface QuickInfoItem {
+  icon: ReactNode
+  label: string
+  value: string | ReactNode
+  href?: string
+}
+
+interface Props {
+  items: QuickInfoItem[]
+}
+
+export function EntityQuickInfo({ items }: Props) {
+  const visibleItems = items.filter(
+    (item) => item.value !== null && item.value !== undefined && item.value !== ''
+  )
+
+  if (!visibleItems.length) return null
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {visibleItems.map((item, i) => (
+        <div key={i} className="flex items-start gap-3">
+          <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-gray-50 flex items-center justify-center text-gray-500">
+            {item.icon}
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs uppercase tracking-wide text-gray-500 mb-0.5">{item.label}</p>
+            {item.href ? (
+              <a
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-[#003594] hover:text-[#002B7A] transition-colors break-words"
+              >
+                {item.value}
+              </a>
+            ) : (
+              <p className="text-sm text-gray-900 break-words">{item.value}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/components/entity/EntitySection.tsx
+++ b/apps/web/components/entity/EntitySection.tsx
@@ -1,27 +1,18 @@
-'use client'
-
-import { useState } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { ReactNode } from 'react'
 
 interface Props {
   title: string
-  children: React.ReactNode
-  defaultOpen?: boolean
+  children: ReactNode
+  className?: string
 }
 
-export function EntitySection({ title, children, defaultOpen = true }: Props) {
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-
+export function EntitySection({ title, children, className }: Props) {
   return (
-    <div className="border-b border-gray-100 dark:border-gray-800 last:border-0">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between py-3 text-sm font-semibold text-gray-900 dark:text-gray-100"
-      >
+    <section className={`px-6 md:px-10 py-6 ${className ?? ''}`}>
+      <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-4">
         {title}
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
-      {isOpen && <div className="pb-4">{children}</div>}
-    </div>
+      </h2>
+      {children}
+    </section>
   )
 }

--- a/apps/web/components/entity/EntitySkeleton.tsx
+++ b/apps/web/components/entity/EntitySkeleton.tsx
@@ -1,0 +1,55 @@
+export function EntitySkeleton() {
+  return (
+    <div className="animate-pulse">
+      {/* Hero placeholder */}
+      <div className="w-full aspect-[4/3] md:aspect-[16/9] bg-gray-200" />
+
+      {/* Breadcrumb placeholder */}
+      <div className="px-6 md:px-10 py-3 flex items-center gap-2">
+        <div className="h-3 w-16 bg-gray-200 rounded" />
+        <div className="h-3 w-3 bg-gray-200 rounded" />
+        <div className="h-3 w-24 bg-gray-200 rounded" />
+      </div>
+
+      {/* Actions bar placeholder */}
+      <div className="px-6 md:px-10 py-4 border-b border-gray-100 flex items-center gap-3">
+        <div className="h-10 w-32 bg-gray-200 rounded-xl" />
+        <div className="h-10 w-10 bg-gray-200 rounded-xl" />
+        <div className="h-10 w-10 bg-gray-200 rounded-xl" />
+      </div>
+
+      {/* Quick info placeholder */}
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
+        <div className="h-6 w-40 bg-gray-200 rounded mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-gray-200 rounded-lg flex-shrink-0" />
+              <div className="flex-1">
+                <div className="h-2.5 w-16 bg-gray-200 rounded mb-1.5" />
+                <div className="h-3.5 w-32 bg-gray-200 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Description section placeholder */}
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
+        <div className="h-6 w-36 bg-gray-200 rounded mb-4" />
+        <div className="space-y-2">
+          <div className="h-3 bg-gray-200 rounded w-full" />
+          <div className="h-3 bg-gray-200 rounded w-full" />
+          <div className="h-3 bg-gray-200 rounded w-5/6" />
+          <div className="h-3 bg-gray-200 rounded w-4/6" />
+        </div>
+      </div>
+
+      {/* Map placeholder */}
+      <div className="px-6 md:px-10 py-6">
+        <div className="h-6 w-28 bg-gray-200 rounded mb-4" />
+        <div className="h-64 md:h-80 bg-gray-200 rounded-xl" />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/entity/EntityTagList.tsx
+++ b/apps/web/components/entity/EntityTagList.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  tags: string[]
+}
+
+export function EntityTagList({ tags }: Props) {
+  if (!tags.length) return null
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag, i) => (
+        <span
+          key={i}
+          className="rounded-full bg-gray-100 text-gray-600 text-xs font-medium px-3 py-1"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/components/entity/EntityTips.tsx
+++ b/apps/web/components/entity/EntityTips.tsx
@@ -1,0 +1,22 @@
+import { EntitySection } from './EntitySection'
+
+interface Props {
+  tips?: string[]
+}
+
+export function EntityTips({ tips }: Props) {
+  if (!tips?.length) return null
+
+  return (
+    <EntitySection title="Tips">
+      <ul className="space-y-2">
+        {tips.map((tip, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-gray-400 flex-shrink-0" />
+            <p className="text-sm text-gray-700">{tip}</p>
+          </li>
+        ))}
+      </ul>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/NearbySection.tsx
+++ b/apps/web/components/entity/NearbySection.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useRef } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { NavArrowLeft, NavArrowRight, StarSolid } from 'iconoir-react'
+
+interface NearbyItem {
+  id: string
+  name: string
+  image: string
+  type: string
+  rating: number | null
+  href: string
+}
+
+interface Props {
+  title: string
+  items: NearbyItem[]
+}
+
+export function NearbySection({ title, items }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  if (!items.length) return null
+
+  const scroll = (direction: 'left' | 'right') => {
+    if (!scrollRef.current) return
+    const amount = 240
+    scrollRef.current.scrollBy({
+      left: direction === 'left' ? -amount : amount,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <section className="px-6 md:px-10 py-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide">{title}</h2>
+        <div className="hidden md:flex items-center gap-2">
+          <button
+            onClick={() => scroll('left')}
+            aria-label="Scroll left"
+            className="w-8 h-8 rounded-full border border-gray-200 bg-white flex items-center justify-center text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+          >
+            <NavArrowLeft className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => scroll('right')}
+            aria-label="Scroll right"
+            className="w-8 h-8 rounded-full border border-gray-200 bg-white flex items-center justify-center text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+          >
+            <NavArrowRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+      >
+        {items.map((item) => (
+          <Link
+            key={item.id}
+            href={item.href}
+            className="flex-shrink-0 w-56 snap-start rounded-xl border border-gray-200 overflow-hidden group hover:border-gray-300 hover:shadow-md transition-all"
+          >
+            <div className="relative aspect-[4/3] overflow-hidden">
+              <Image
+                src={item.image}
+                alt={item.name}
+                fill
+                className="object-cover group-hover:scale-105 transition-transform duration-300"
+              />
+              {item.rating != null && (
+                <div className="absolute top-2 right-2 flex items-center gap-1 bg-white/90 backdrop-blur-sm rounded-md px-2 py-0.5">
+                  <StarSolid className="w-3 h-3 text-amber-400" />
+                  <span className="text-xs font-medium text-gray-900">{item.rating.toFixed(1)}</span>
+                </div>
+              )}
+            </div>
+            <div className="p-3">
+              <p className="text-sm font-medium text-gray-900 truncate">{item.name}</p>
+              <p className="text-xs text-gray-500 mt-0.5">{item.type}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/components/entity/activity/ActivityAbout.tsx
+++ b/apps/web/components/entity/activity/ActivityAbout.tsx
@@ -1,0 +1,27 @@
+import type { ActivityDetail } from '@travyl/shared'
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+interface Props {
+  activity: ActivityDetail
+}
+
+export function ActivityAbout({ activity }: Props) {
+  return (
+    <EntitySection title="About">
+      {activity.source === 'ai' && activity.reason && (
+        <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 mb-4">
+          <p className="text-sm text-blue-800">
+            <span className="font-medium">Recommended for you:</span> {activity.reason}
+          </p>
+        </div>
+      )}
+
+      {activity.description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4">{activity.description}</p>
+      )}
+
+      <EntityTagList tags={[activity.category]} />
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/activity/ActivityDetails.tsx
+++ b/apps/web/components/entity/activity/ActivityDetails.tsx
@@ -1,0 +1,51 @@
+import type { ActivityDetail } from '@travyl/shared'
+import { Clock, Wallet, MapPin, Group, Language } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+interface Props {
+  activity: ActivityDetail
+}
+
+export function ActivityDetails({ activity }: Props) {
+  const items = [
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Duration',
+      value: activity.duration ? `${activity.duration} hour${activity.duration !== 1 ? 's' : ''}` : '',
+    },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Price per person',
+      value: activity.price != null
+        ? `${activity.currency ?? 'USD'} ${activity.price}`
+        : '',
+    },
+    {
+      icon: <MapPin className="w-4 h-4" />,
+      label: 'Meeting point',
+      value: activity.meetingPoint ?? '',
+    },
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Available times',
+      value: activity.availableTimes?.join(', ') ?? '',
+    },
+    {
+      icon: <Group className="w-4 h-4" />,
+      label: 'Group size',
+      value: activity.groupSize ? `Up to ${activity.groupSize} people` : '',
+    },
+    {
+      icon: <Language className="w-4 h-4" />,
+      label: 'Languages',
+      value: activity.languages?.join(', ') ?? '',
+    },
+  ]
+
+  return (
+    <EntitySection title="Details">
+      <EntityQuickInfo items={items} />
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/activity/ActivityInclusions.tsx
+++ b/apps/web/components/entity/activity/ActivityInclusions.tsx
@@ -1,0 +1,34 @@
+import { Check, Xmark } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+
+interface Props {
+  included?: string[]
+  notIncluded?: string[]
+}
+
+export function ActivityInclusions({ included, notIncluded }: Props) {
+  if (!included?.length && !notIncluded?.length) return null
+
+  return (
+    <EntitySection title="What's Included">
+      <div className="space-y-2">
+        {included?.map((item, i) => (
+          <div key={`in-${i}`} className="flex items-start gap-3">
+            <span className="flex-shrink-0 w-5 h-5 rounded-full bg-green-100 flex items-center justify-center mt-0.5">
+              <Check className="w-3 h-3 text-green-600" />
+            </span>
+            <p className="text-sm text-gray-700">{item}</p>
+          </div>
+        ))}
+        {notIncluded?.map((item, i) => (
+          <div key={`not-${i}`} className="flex items-start gap-3">
+            <span className="flex-shrink-0 w-5 h-5 rounded-full bg-red-100 flex items-center justify-center mt-0.5">
+              <Xmark className="w-3 h-3 text-red-500" />
+            </span>
+            <p className="text-sm text-gray-500">{item}</p>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/destination/DestinationOverview.tsx
+++ b/apps/web/components/entity/destination/DestinationOverview.tsx
@@ -1,0 +1,21 @@
+import { EntitySection } from '@/components/entity/EntitySection'
+import { EntityTagList } from '@/components/entity/EntityTagList'
+
+interface Props {
+  description?: string | null
+  tags?: string[]
+}
+
+export function DestinationOverview({ description, tags }: Props) {
+  const hasTags = (tags ?? []).length > 0
+  if (!description && !hasTags) return null
+
+  return (
+    <EntitySection title="Overview">
+      {description && (
+        <p className="text-gray-700 leading-relaxed mb-4">{description}</p>
+      )}
+      {hasTags && <EntityTagList tags={tags!} />}
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/destination/DestinationQuickFacts.tsx
+++ b/apps/web/components/entity/destination/DestinationQuickFacts.tsx
@@ -1,0 +1,71 @@
+import { MapPin, Clock, Wallet } from 'iconoir-react'
+import { EntitySection } from '@/components/entity/EntitySection'
+import { EntityQuickInfo } from '@/components/entity/EntityQuickInfo'
+
+interface Props {
+  country?: string
+  language?: string
+  currency?: string
+  timezone?: string
+  bestTimeToVisit?: string
+  budgetLevel?: 1 | 2 | 3 | 4
+}
+
+function BudgetDots({ level }: { level: 1 | 2 | 3 | 4 }) {
+  const labels = ['Budget', 'Moderate', 'Upscale', 'Luxury']
+  return (
+    <span className="flex items-center gap-1">
+      {[1, 2, 3, 4].map((l) => (
+        <span
+          key={l}
+          className={`text-sm font-medium ${l <= level ? 'text-gray-900' : 'text-gray-300'}`}
+        >
+          $
+        </span>
+      ))}
+      <span className="text-sm text-gray-500 ml-1">({labels[level - 1]})</span>
+    </span>
+  )
+}
+
+export function DestinationQuickFacts({
+  country,
+  language,
+  currency,
+  timezone,
+  bestTimeToVisit,
+  budgetLevel,
+}: Props) {
+  const items = [
+    country
+      ? { icon: <MapPin className="w-4 h-4" />, label: 'Country', value: country }
+      : null,
+    language
+      ? { icon: <MapPin className="w-4 h-4" />, label: 'Language', value: language }
+      : null,
+    currency
+      ? { icon: <Wallet className="w-4 h-4" />, label: 'Currency', value: currency }
+      : null,
+    timezone
+      ? { icon: <Clock className="w-4 h-4" />, label: 'Timezone', value: timezone }
+      : null,
+    bestTimeToVisit
+      ? { icon: <Clock className="w-4 h-4" />, label: 'Best Time to Visit', value: bestTimeToVisit }
+      : null,
+    budgetLevel
+      ? {
+          icon: <Wallet className="w-4 h-4" />,
+          label: 'Budget Level',
+          value: <BudgetDots level={budgetLevel} />,
+        }
+      : null,
+  ].filter(Boolean) as { icon: React.ReactNode; label: string; value: string | React.ReactNode }[]
+
+  if (!items.length) return null
+
+  return (
+    <EntitySection title="Quick Facts">
+      <EntityQuickInfo items={items} />
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/destination/DestinationTopActivities.tsx
+++ b/apps/web/components/entity/destination/DestinationTopActivities.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '@/components/entity/NearbySection'
+import type { SuggestionCard } from '@travyl/shared'
+
+interface Props {
+  destinationName: string
+}
+
+export function DestinationTopActivities({ destinationName }: Props) {
+  const { data } = useQuery({
+    queryKey: ['destination-activities', destinationName],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        destination: destinationName,
+        category: 'sightseeing',
+      })
+      const res = await fetch(`/api/suggest?${params}`)
+      if (!res.ok) return []
+      const json = await res.json() as { suggestions?: SuggestionCard[] }
+      return json.suggestions ?? []
+    },
+    staleTime: 1000 * 60 * 60,
+  })
+
+  if (!data?.length) return null
+
+  const items = data.map((s) => ({
+    id: s.id,
+    name: s.name,
+    image: s.imageUrl || s.imageUrls?.[0] || '',
+    type: s.category ?? 'Activity',
+    rating: s.rating ?? null,
+    href: `/activity/${s.id}`,
+  }))
+
+  return <NearbySection title="Top Activities" items={items} />
+}

--- a/apps/web/components/entity/destination/DestinationTopPlaces.tsx
+++ b/apps/web/components/entity/destination/DestinationTopPlaces.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '@/components/entity/NearbySection'
+import type { PlaceItem } from '@travyl/shared'
+
+interface Props {
+  destinationName: string
+  latitude: number
+  longitude: number
+}
+
+export function DestinationTopPlaces({ destinationName, latitude, longitude }: Props) {
+  const { data: places } = useQuery({
+    queryKey: ['destination-places', destinationName, latitude, longitude],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        q: destinationName,
+        lat: String(latitude),
+        lng: String(longitude),
+        limit: '8',
+        category: 'sightseeing',
+      })
+      const res = await fetch(`/api/places?${params}`)
+      if (!res.ok) return []
+      return res.json() as Promise<PlaceItem[]>
+    },
+    staleTime: 1000 * 60 * 60,
+  })
+
+  if (!places?.length) return null
+
+  const items = places.map((p) => ({
+    id: p.id,
+    name: p.name,
+    image: p.image,
+    type: p.category ?? p.type ?? 'Attraction',
+    rating: p.rating ?? null,
+    href: `/place/${p.id}`,
+  }))
+
+  return <NearbySection title="Top Places to See" items={items} />
+}

--- a/apps/web/components/entity/destination/DestinationTrips.tsx
+++ b/apps/web/components/entity/destination/DestinationTrips.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+import { Plus, MapPin, Calendar, Airplane } from 'iconoir-react'
+import { useTrips, useAuthStore, formatDateRange } from '@travyl/shared'
+import type { Trip } from '@travyl/shared'
+import { EntitySection } from '@/components/entity/EntitySection'
+
+interface Props {
+  destinationName: string
+}
+
+const STATUS_BADGE: Record<string, { label: string; className: string }> = {
+  planning: { label: 'Planning', className: 'bg-blue-100 text-blue-700' },
+  booked: { label: 'Booked', className: 'bg-amber-100 text-amber-700' },
+  active: { label: 'Active', className: 'bg-emerald-100 text-emerald-700' },
+  completed: { label: 'Completed', className: 'bg-gray-100 text-gray-600' },
+  abandoned: { label: 'Cancelled', className: 'bg-red-100 text-red-600' },
+}
+
+function TripCard({ trip }: { trip: Trip }) {
+  const badge = STATUS_BADGE[trip.status] ?? STATUS_BADGE.planning
+  const dateRange = formatDateRange(trip.start_date, trip.end_date)
+
+  return (
+    <Link
+      href={`/trip/${trip.id}`}
+      className="group block rounded-xl border border-gray-200 p-4 hover:shadow-md hover:border-gray-300 transition-all duration-200"
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h3 className="font-medium text-gray-900 group-hover:text-[#1e3a5f] transition-colors leading-tight line-clamp-2 text-sm">
+          {trip.title}
+        </h3>
+        <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${badge.className}`}>
+          {badge.label}
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5 text-xs text-gray-500 mb-1.5">
+        <MapPin className="w-3 h-3 shrink-0" />
+        <span className="line-clamp-1">{trip.destination}</span>
+      </div>
+      <div className="flex items-center gap-1.5 text-xs text-gray-400">
+        <Calendar className="w-3 h-3 shrink-0" />
+        <span>{dateRange}</span>
+      </div>
+    </Link>
+  )
+}
+
+export function DestinationTrips({ destinationName }: Props) {
+  const user = useAuthStore((s) => s.user)
+  const { data: trips, isLoading } = useTrips()
+
+  if (!user) return null
+
+  const matchingTrips: Trip[] = (trips ?? []).filter((trip) =>
+    trip.destination.toLowerCase().includes(destinationName.toLowerCase()) ||
+    destinationName.toLowerCase().includes(trip.destination.toLowerCase())
+  )
+
+  return (
+    <EntitySection title="Your Trips Here">
+      {isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-28 bg-gray-100 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      ) : matchingTrips.length > 0 ? (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+            {matchingTrips.map((trip) => (
+              <TripCard key={trip.id} trip={trip} />
+            ))}
+          </div>
+          <Link
+            href={`/?destination=${encodeURIComponent(destinationName)}`}
+            className="inline-flex items-center gap-1.5 text-sm text-[#003594] hover:text-[#002B7A] transition-colors font-medium"
+          >
+            <Plus className="w-4 h-4" />
+            Plan a new trip to {destinationName}
+          </Link>
+        </>
+      ) : (
+        <div className="rounded-xl border border-dashed border-gray-200 p-8 text-center">
+          <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-3">
+            <Airplane className="w-5 h-5 text-gray-400" />
+          </div>
+          <p className="text-sm text-gray-500 mb-1">No trips to {destinationName} yet</p>
+          <Link
+            href={`/?destination=${encodeURIComponent(destinationName)}`}
+            className="inline-flex items-center gap-1.5 text-sm text-[#003594] hover:text-[#002B7A] transition-colors font-medium mt-2"
+          >
+            <Plus className="w-4 h-4" />
+            Plan a trip to {destinationName}
+          </Link>
+        </div>
+      )}
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/destination/DestinationWhereToStay.tsx
+++ b/apps/web/components/entity/destination/DestinationWhereToStay.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '@/components/entity/NearbySection'
+import type { PlaceItem } from '@travyl/shared'
+
+interface Props {
+  destinationName: string
+  latitude: number
+  longitude: number
+}
+
+export function DestinationWhereToStay({ destinationName, latitude, longitude }: Props) {
+  const { data: hotels } = useQuery({
+    queryKey: ['destination-hotels', destinationName, latitude, longitude],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        q: `${destinationName} hotel`,
+        lat: String(latitude),
+        lng: String(longitude),
+        limit: '8',
+        category: 'hotel',
+      })
+      const res = await fetch(`/api/places?${params}`)
+      if (!res.ok) return []
+      return res.json() as Promise<PlaceItem[]>
+    },
+    staleTime: 1000 * 60 * 60,
+  })
+
+  if (!hotels?.length) return null
+
+  const items = hotels.map((h) => ({
+    id: h.id,
+    name: h.name,
+    image: h.image,
+    type: 'Hotel',
+    rating: h.rating ?? null,
+    href: `/hotel/${h.id}`,
+  }))
+
+  return <NearbySection title="Where to Stay" items={items} />
+}

--- a/apps/web/components/entity/hotel/HotelAmenities.tsx
+++ b/apps/web/components/entity/hotel/HotelAmenities.tsx
@@ -1,0 +1,37 @@
+import { EntitySection } from '../EntitySection'
+
+interface AmenityGroup {
+  category: string
+  items: string[]
+}
+
+interface Props {
+  groups?: AmenityGroup[]
+}
+
+export function HotelAmenities({ groups }: Props) {
+  if (!groups || groups.length === 0) return null
+
+  return (
+    <EntitySection title="Amenities">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {groups.map((group, i) => (
+          <div key={i}>
+            <h3 className="text-sm font-semibold text-gray-900 mb-2">{group.category}</h3>
+            <ul className="space-y-1.5">
+              {group.items.map((item, j) => (
+                <li key={j} className="flex items-start gap-2 text-sm text-gray-700">
+                  <span
+                    className="mt-1.5 w-1.5 h-1.5 rounded-full bg-[#003594] flex-shrink-0"
+                    aria-hidden="true"
+                  />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/hotel/HotelGuestRatings.tsx
+++ b/apps/web/components/entity/hotel/HotelGuestRatings.tsx
@@ -1,0 +1,67 @@
+import { EntitySection } from '../EntitySection'
+
+interface RatingCategory {
+  label: string
+  score: number
+}
+
+interface Props {
+  overall: number
+  reviewCount?: number | null
+  categories?: RatingCategory[]
+}
+
+const RATING_LABELS = [
+  { min: 4.5, label: 'Excellent' },
+  { min: 4.0, label: 'Very Good' },
+  { min: 3.0, label: 'Good' },
+  { min: 0, label: 'Fair' },
+]
+
+function getRatingLabel(score: number): string {
+  return RATING_LABELS.find((r) => score >= r.min)?.label ?? 'Fair'
+}
+
+export function HotelGuestRatings({ overall, reviewCount, categories }: Props) {
+  if (!categories || categories.length === 0) return null
+
+  return (
+    <EntitySection title="Guest Ratings">
+      <div className="space-y-6">
+        {/* Overall score */}
+        <div className="flex items-center gap-4">
+          <div className="w-16 h-16 rounded-xl bg-[#1e3a5f] flex items-center justify-center flex-shrink-0">
+            <span className="text-white text-xl font-semibold">{overall.toFixed(1)}</span>
+          </div>
+          <div>
+            <p className="text-base font-semibold text-gray-900">{getRatingLabel(overall)}</p>
+            {reviewCount != null && (
+              <p className="text-sm text-gray-500">{reviewCount.toLocaleString()} reviews</p>
+            )}
+          </div>
+        </div>
+
+        {/* Category bars */}
+        <div className="space-y-3">
+          {categories.map((cat, i) => {
+            const pct = Math.min(100, Math.max(0, (cat.score / 5) * 100))
+            return (
+              <div key={i}>
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm text-gray-700">{cat.label}</span>
+                  <span className="text-sm font-medium text-gray-900">{cat.score.toFixed(1)}</span>
+                </div>
+                <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-[#003594]"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/hotel/HotelOverview.tsx
+++ b/apps/web/components/entity/hotel/HotelOverview.tsx
@@ -1,0 +1,72 @@
+import { StarSolid, Star } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+interface Props {
+  description?: string | null
+  starRating?: number | null
+  guestRating?: number | null
+  reviewCount?: number | null
+  tags?: string[]
+}
+
+const RATING_LABELS = [
+  { min: 4.5, label: 'Excellent' },
+  { min: 4.0, label: 'Very Good' },
+  { min: 3.0, label: 'Good' },
+  { min: 0, label: 'Fair' },
+]
+
+function getRatingLabel(score: number): string {
+  return RATING_LABELS.find((r) => score >= r.min)?.label ?? 'Fair'
+}
+
+export function HotelOverview({ description, starRating, guestRating, reviewCount, tags }: Props) {
+  const hasContent = description || starRating != null || guestRating != null || tags?.length
+  if (!hasContent) return null
+
+  const stars = starRating != null ? Math.round(starRating) : null
+
+  return (
+    <EntitySection title="Overview">
+      <div className="space-y-5">
+        {/* Star rating row */}
+        {stars != null && (
+          <div className="flex items-center gap-1">
+            {[1, 2, 3, 4, 5].map((n) => (
+              n <= stars ? (
+                <StarSolid key={n} className="w-5 h-5 text-amber-400" />
+              ) : (
+                <Star key={n} className="w-5 h-5 text-gray-300" />
+              )
+            ))}
+            <span className="ml-1 text-sm text-gray-500">{stars}-star hotel</span>
+          </div>
+        )}
+
+        {/* Guest rating */}
+        {guestRating != null && (
+          <div className="flex items-center gap-3">
+            <div className="w-14 h-14 rounded-xl bg-[#1e3a5f] flex items-center justify-center flex-shrink-0">
+              <span className="text-white text-lg font-semibold">{guestRating.toFixed(1)}</span>
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-gray-900">{getRatingLabel(guestRating)}</p>
+              {reviewCount != null && (
+                <p className="text-xs text-gray-500">{reviewCount.toLocaleString()} reviews</p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Description */}
+        {description && (
+          <p className="text-sm text-gray-700 leading-relaxed">{description}</p>
+        )}
+
+        {/* Tags */}
+        {tags && tags.length > 0 && <EntityTagList tags={tags} />}
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/hotel/HotelRooms.tsx
+++ b/apps/web/components/entity/hotel/HotelRooms.tsx
@@ -1,0 +1,74 @@
+import Image from 'next/image'
+import { EntitySection } from '../EntitySection'
+import type { RoomType } from '@travyl/shared'
+
+interface Props {
+  rooms?: RoomType[]
+  currency?: string | null
+}
+
+export function HotelRooms({ rooms, currency }: Props) {
+  if (!rooms || rooms.length === 0) return null
+
+  const currencySymbol = currency ?? 'USD'
+
+  return (
+    <EntitySection title="Rooms">
+      <div className="space-y-4">
+        {rooms.map((room, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-gray-200 overflow-hidden flex flex-col sm:flex-row"
+          >
+            {/* Room image */}
+            {room.image && (
+              <div className="relative w-full sm:w-48 h-48 sm:h-auto flex-shrink-0">
+                <Image
+                  src={room.image}
+                  alt={room.type}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 100vw, 192px"
+                />
+              </div>
+            )}
+
+            {/* Room details */}
+            <div className="p-4 flex-1 flex flex-col justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900 mb-1">{room.type}</h3>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500">
+                  {room.beds && <span>{room.beds}</span>}
+                  {room.size && <span>{room.size}</span>}
+                  {room.guests > 0 && <span>Up to {room.guests} guests</span>}
+                </div>
+              </div>
+
+              {/* Amenity chips */}
+              {room.amenities && room.amenities.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {room.amenities.map((a, j) => (
+                    <span
+                      key={j}
+                      className="rounded-full bg-gray-100 text-gray-600 text-xs font-medium px-2.5 py-0.5"
+                    >
+                      {a}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Price */}
+              {room.price > 0 && (
+                <p className="text-sm font-semibold text-[#1e3a5f]">
+                  {currencySymbol} {room.price.toLocaleString()}
+                  <span className="text-gray-400 font-normal"> / night</span>
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/hotel/HotelStayDetails.tsx
+++ b/apps/web/components/entity/hotel/HotelStayDetails.tsx
@@ -1,0 +1,95 @@
+import { MapPin, Wallet, Clock, Phone, Globe } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+interface Props {
+  address?: string | null
+  pricePerNight?: number | null
+  currency?: string | null
+  checkIn?: string | null
+  checkOut?: string | null
+  phone?: string | null
+  website?: string | null
+}
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+export function HotelStayDetails({
+  address,
+  pricePerNight,
+  currency,
+  checkIn,
+  checkOut,
+  phone,
+  website,
+}: Props) {
+  const currencySymbol = currency ?? 'USD'
+
+  const checkInOutValue =
+    checkIn && checkOut
+      ? `Check-in: ${checkIn} · Check-out: ${checkOut}`
+      : checkIn
+      ? `Check-in: ${checkIn}`
+      : checkOut
+      ? `Check-out: ${checkOut}`
+      : null
+
+  const items = [
+    address
+      ? {
+          icon: <MapPin className="w-4 h-4" />,
+          label: 'Address',
+          value: address,
+        }
+      : null,
+    pricePerNight != null
+      ? {
+          icon: <Wallet className="w-4 h-4" />,
+          label: 'Price per night',
+          value: `${currencySymbol} ${pricePerNight.toLocaleString()}`,
+        }
+      : null,
+    checkInOutValue
+      ? {
+          icon: <Clock className="w-4 h-4" />,
+          label: 'Check-in / Check-out',
+          value: checkInOutValue,
+        }
+      : null,
+    phone
+      ? {
+          icon: <Phone className="w-4 h-4" />,
+          label: 'Phone',
+          value: phone,
+          href: `tel:${phone}`,
+        }
+      : null,
+    website
+      ? {
+          icon: <Globe className="w-4 h-4" />,
+          label: 'Website',
+          value: safeHostname(website),
+          href: website,
+        }
+      : null,
+  ].filter(Boolean) as {
+    icon: React.ReactNode
+    label: string
+    value: string
+    href?: string
+  }[]
+
+  if (!items.length) return null
+
+  return (
+    <EntitySection title="Stay Details">
+      <EntityQuickInfo items={items} />
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/place/PlaceAbout.tsx
+++ b/apps/web/components/entity/place/PlaceAbout.tsx
@@ -1,0 +1,23 @@
+import type { PlaceItem } from '@travyl/shared'
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+interface Props {
+  place: PlaceItem
+}
+
+export function PlaceAbout({ place }: Props) {
+  const text = place.description || place.tagline || null
+  const tags = place.tags ?? []
+
+  if (!text && tags.length === 0) return null
+
+  return (
+    <EntitySection title="About">
+      {text && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4">{text}</p>
+      )}
+      {tags.length > 0 && <EntityTagList tags={tags} />}
+    </EntitySection>
+  )
+}

--- a/apps/web/components/entity/place/PlaceQuickInfo.tsx
+++ b/apps/web/components/entity/place/PlaceQuickInfo.tsx
@@ -1,0 +1,83 @@
+import type { PlaceItem } from '@travyl/shared'
+import { Clock, Phone, Globe, Wallet } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+interface Props {
+  place: PlaceItem
+}
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+function priceLevelLabel(level: 1 | 2 | 3 | 4): string {
+  const labels: Record<number, string> = {
+    1: 'Budget-friendly ($)',
+    2: 'Moderate ($$)',
+    3: 'Upscale ($$$)',
+    4: 'Luxury ($$$$)',
+  }
+  return labels[level] ?? '$'.repeat(level)
+}
+
+export function PlaceQuickInfo({ place }: Props) {
+  const items = [
+    place.hours
+      ? {
+          icon: <Clock className="w-4 h-4" />,
+          label: 'Hours',
+          value: place.hours,
+        }
+      : null,
+    place.priceLevel != null
+      ? {
+          icon: <Wallet className="w-4 h-4" />,
+          label: 'Price Level',
+          value: priceLevelLabel(place.priceLevel),
+        }
+      : null,
+    place.phone
+      ? {
+          icon: <Phone className="w-4 h-4" />,
+          label: 'Phone',
+          value: place.phone,
+          href: `tel:${place.phone}`,
+        }
+      : null,
+    place.website
+      ? {
+          icon: <Globe className="w-4 h-4" />,
+          label: 'Website',
+          value: getHostname(place.website),
+          href: place.website,
+        }
+      : null,
+    place.duration
+      ? {
+          icon: <Clock className="w-4 h-4" />,
+          label: 'Typical Visit',
+          value: place.duration,
+        }
+      : null,
+    place.admissionFee
+      ? {
+          icon: <Wallet className="w-4 h-4" />,
+          label: 'Admission',
+          value: place.admissionFee,
+        }
+      : null,
+  ].filter(Boolean) as { icon: React.ReactNode; label: string; value: string; href?: string }[]
+
+  if (items.length === 0) return null
+
+  return (
+    <EntitySection title="Quick Info">
+      <EntityQuickInfo items={items} />
+    </EntitySection>
+  )
+}

--- a/apps/web/components/itinerary/HotelCard.tsx
+++ b/apps/web/components/itinerary/HotelCard.tsx
@@ -86,6 +86,15 @@ export function HotelCard({ hotel }: HotelCardProps) {
         <button className="w-full mt-3 py-2.5 bg-[#60a5fa] hover:bg-[#3b82f6] text-white text-[13px] font-semibold rounded-xl shadow-md hover:shadow-lg transition-all">
           Book Hotel
         </button>
+
+        {/* View full details */}
+        <Link
+          href={`/hotel/${hotel.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="flex items-center justify-center mt-2 py-2 text-[12px] font-medium text-gray-400 hover:text-[#1e3a5f] transition-colors"
+        >
+          View full details
+        </Link>
       </div>
     </div>
     </Link>

--- a/apps/web/hooks/useSpotlightSearch.ts
+++ b/apps/web/hooks/useSpotlightSearch.ts
@@ -7,6 +7,7 @@ import { useAuthStore, useTrip, mergeSearchResults, type SpotlightResult } from 
 import { useContextSearch } from './useContextSearch'
 import { useCalendarCommandsStore } from '@/stores/calendarCommandsStore'
 import { fuzzyMatch } from '@/components/spotlight/fuzzyMatch'
+import { parseQueryIntent, type ParsedIntent } from '@/lib/parseQueryIntent'
 
 const RECENT_SEARCHES_KEY = 'travyl:recentSearches'
 const PINNED_RESULTS_KEY = 'travyl:pinnedResults'
@@ -179,6 +180,14 @@ export function useSpotlightSearch() {
 
   const shouldSearch = debouncedQuery.length >= 3 && !!token
 
+  // Intent parsing — Phase 1 (sync regex) or Phase 2 (Haiku LLM fallback) before any search fires
+  const { data: parsedIntent, isLoading: intentLoading } = useQuery<ParsedIntent>({
+    queryKey: ['parse-intent', debouncedQuery],
+    queryFn: () => parseQueryIntent(debouncedQuery, token!),
+    enabled: shouldSearch,
+    staleTime: Infinity, // intent for a given query string never changes
+  })
+
   // Existing context-search for trips (vector-powered)
   const { results: tripSearchResults, isLoading: tripSearchLoading } = useContextSearch(query)
 
@@ -190,12 +199,15 @@ export function useSpotlightSearch() {
     staleTime: 30_000,
   })
 
-  // Live discover for destination queries (restaurants, attractions, activities)
+  // Use parsed location if available (e.g. "Bakersfield" from "bakersfield restaurants")
+  const discoverLocation = parsedIntent?.location ?? debouncedQuery
+
+  // Live discover for destination queries — waits for intent to resolve before firing
   const { data: discoverData, isLoading: discoverLoading } = useQuery({
-    queryKey: ['discover', debouncedQuery],
-    queryFn: () => fetchDiscover(debouncedQuery, token!),
-    enabled: shouldSearch && !scope, // only when no scope filter active
-    staleTime: 60_000, // 1 minute (server caches for 1 hour)
+    queryKey: ['discover', discoverLocation],
+    queryFn: () => fetchDiscover(discoverLocation, token!),
+    enabled: shouldSearch && !scope && parsedIntent !== undefined,
+    staleTime: 60_000,
   })
 
   // Client-side filter for navigation items using fuzzy match
@@ -319,50 +331,54 @@ export function useSpotlightSearch() {
     return results
   }, [discoverData, debouncedQuery])
 
-  // Detect route pattern "X to Y" from discover response
-  const routeIntent = useMemo((): SpotlightResult | null => {
-    if (!discoverData?.route) return null
-    const { origin, destination } = discoverData.route
-    return {
-      id: 'create-trip-route',
-      type: 'action' as const,
-      title: `Plan trip: ${origin} to ${destination}`,
-      subtitle: 'Start planning with destinations pre-filled',
-      href: '',
-      score: 100,
-      metadata: { prefillDestination: destination, origin },
-    }
-  }, [discoverData])
+  // Action results derived from parsed intent (replaces createTripIntent + routeIntent memos)
+  const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
+    if (!parsedIntent) return {}
+    const actions: SpotlightResult[] = []
 
-  // Detect trip creation intent
-  const createTripIntent = useMemo((): SpotlightResult | null => {
-    const q = query.toLowerCase().trim()
-    const createMatch = q.match(/^(?:new|create)\s+trip(?:\s+to\s+(.+))?$/i)
-    const tripToMatch = q.match(/^trip\s+to\s+(.+)$/i)
-
-    if (createMatch || tripToMatch) {
-      const dest = createMatch?.[1] || tripToMatch?.[1] || ''
-      return {
+    if (parsedIntent.intent === 'create-trip') {
+      actions.push({
         id: 'create-trip',
         type: 'action' as const,
-        title: dest ? `Create trip to ${dest.charAt(0).toUpperCase() + dest.slice(1)}` : 'Create New Trip',
+        title: parsedIntent.location
+          ? `Create trip to ${parsedIntent.location}`
+          : 'Create New Trip',
         subtitle: 'Start planning a new adventure',
         href: '',
         score: 100,
-        metadata: { prefillDestination: dest },
-      }
+        metadata: { prefillDestination: parsedIntent.location ?? '' },
+      })
     }
-    return null
-  }, [query])
 
-  // Inject create-trip action into results
-  const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
-    const actions: SpotlightResult[] = []
-    if (createTripIntent) actions.push(createTripIntent)
-    if (routeIntent) actions.push(routeIntent)
-    if (!actions.length) return {}
-    return { action: actions }
-  }, [createTripIntent, routeIntent])
+    if (parsedIntent.intent === 'route' && discoverData?.route) {
+      const { origin, destination } = discoverData.route
+      actions.push({
+        id: 'create-trip-route',
+        type: 'action' as const,
+        title: `Plan trip: ${origin} to ${destination}`,
+        subtitle: 'Start planning with destinations pre-filled',
+        href: '',
+        score: 100,
+        metadata: { prefillDestination: destination, origin },
+      })
+    }
+
+    return actions.length ? { action: actions } : {}
+  }, [parsedIntent, discoverData?.route])
+
+  // Auto-set scope from parsed entity type (only when user hasn't set one manually)
+  const ENTITY_TYPE_TO_SCOPE: Partial<Record<string, SearchScope>> = {
+    restaurant: 'restaurants',
+    activity: 'activities',
+  }
+
+  useEffect(() => {
+    if (parsedIntent?.entityType && scope === null) {
+      const autoScope = ENTITY_TYPE_TO_SCOPE[parsedIntent.entityType]
+      if (autoScope) setScope(autoScope)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [parsedIntent?.entityType, scope])
 
   // Merge all sources (now including commands, actions, and discover)
   const results = useMemo(() => {
@@ -420,7 +436,7 @@ export function useSpotlightSearch() {
     query,
     setQuery,
     results,
-    isLoading: tripSearchLoading || entityLoading || discoverLoading,
+    isLoading: tripSearchLoading || entityLoading || discoverLoading || intentLoading,
     recentSearches,
     addRecentSearch,
     clearRecent,

--- a/apps/web/lib/__tests__/parseQueryIntent.test.ts
+++ b/apps/web/lib/__tests__/parseQueryIntent.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest'
+import { parseQueryIntentSync } from '../parseQueryIntent'
+
+describe('parseQueryIntentSync — Pattern 1: trip to X', () => {
+  it('matches "trip to paris"', () => {
+    const r = parseQueryIntentSync('trip to paris')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('Paris')
+  })
+
+  it('matches "trip to new york"', () => {
+    const r = parseQueryIntentSync('trip to new york')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('New York')
+  })
+
+  it('is case-insensitive', () => {
+    const r = parseQueryIntentSync('TRIP TO LONDON')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('London')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 2: new/create trip', () => {
+  it('matches "new trip"', () => {
+    const r = parseQueryIntentSync('new trip')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBeUndefined()
+  })
+
+  it('matches "create trip"', () => {
+    const r = parseQueryIntentSync('create trip')
+    expect(r?.intent).toBe('create-trip')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 3: [entity] in [city]', () => {
+  it('matches "restaurants in bakersfield"', () => {
+    const r = parseQueryIntentSync('restaurants in bakersfield')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches "food in chicago"', () => {
+    const r = parseQueryIntentSync('food in chicago')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Chicago')
+  })
+
+  it('matches "hotels in miami"', () => {
+    const r = parseQueryIntentSync('hotels in miami')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('hotel')
+    expect(r?.location).toBe('Miami')
+  })
+
+  it('matches "flights in denver"', () => {
+    const r = parseQueryIntentSync('flights in denver')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('flight')
+    expect(r?.location).toBe('Denver')
+  })
+
+  it('matches "attractions in rome"', () => {
+    const r = parseQueryIntentSync('attractions in rome')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Rome')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 4: things to do in [city]', () => {
+  it('matches "things to do in nyc"', () => {
+    const r = parseQueryIntentSync('things to do in nyc')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Nyc')
+  })
+
+  it('matches "thing to do in seattle"', () => {
+    const r = parseQueryIntentSync('thing to do in seattle')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Seattle')
+  })
+
+  it('does NOT misclassify as route (priority over Pattern 6)', () => {
+    const r = parseQueryIntentSync('things to do in nyc')
+    expect(r?.intent).not.toBe('route')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 5: [city] [entity]', () => {
+  it('matches "bakersfield restaurants"', () => {
+    const r = parseQueryIntentSync('bakersfield restaurants')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches "miami hotels"', () => {
+    const r = parseQueryIntentSync('miami hotels')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('hotel')
+    expect(r?.location).toBe('Miami')
+  })
+
+  it('matches "london flights"', () => {
+    const r = parseQueryIntentSync('london flights')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('flight')
+    expect(r?.location).toBe('London')
+  })
+
+  it('matches "paris museums"', () => {
+    const r = parseQueryIntentSync('paris museums')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Paris')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 6: X to Y (route)', () => {
+  it('matches "la to sf"', () => {
+    const r = parseQueryIntentSync('la to sf')
+    expect(r?.intent).toBe('route')
+    expect(r?.location).toBe('Sf')
+  })
+
+  it('matches "new york to boston"', () => {
+    const r = parseQueryIntentSync('new york to boston')
+    expect(r?.intent).toBe('route')
+    expect(r?.location).toBe('Boston')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 7: bare single-word location', () => {
+  it('matches a single city name', () => {
+    const r = parseQueryIntentSync('bakersfield')
+    expect(r?.intent).toBe('discover')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches another single city name', () => {
+    const r = parseQueryIntentSync('paris')
+    expect(r?.intent).toBe('discover')
+    expect(r?.location).toBe('Paris')
+  })
+})
+
+describe('parseQueryIntentSync — no match → null (Phase 2)', () => {
+  it('returns null for "good vibes only" (multi-word, no pattern)', () => {
+    expect(parseQueryIntentSync('good vibes only')).toBeNull()
+  })
+
+  it('returns null for "somewhere to eat in bakersfield"', () => {
+    expect(parseQueryIntentSync('somewhere to eat in bakersfield')).toBeNull()
+  })
+})
+
+describe('parseQueryIntentSync — rawQuery is always preserved', () => {
+  it('preserves the original raw query', () => {
+    const r = parseQueryIntentSync('restaurants in Bakersfield')
+    expect(r?.rawQuery).toBe('restaurants in Bakersfield')
+  })
+})
+
+describe('parseQueryIntent (async) — Phase 2 not called when Phase 1 matches', () => {
+  it('does not call fetch when Phase 1 matches', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch')
+    const { parseQueryIntent } = await import('../parseQueryIntent')
+    await parseQueryIntent('bakersfield restaurants', 'test-token')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+})

--- a/apps/web/lib/__tests__/parseQueryIntent.test.ts
+++ b/apps/web/lib/__tests__/parseQueryIntent.test.ts
@@ -156,6 +156,7 @@ describe('parseQueryIntentSync — no match → null (Phase 2)', () => {
   })
 
   it('returns null for "somewhere to eat in bakersfield"', () => {
+    // Pattern 6 fires but the guard filters it (destination contains " in ") — falls through to Phase 2
     expect(parseQueryIntentSync('somewhere to eat in bakersfield')).toBeNull()
   })
 })

--- a/apps/web/lib/parseQueryIntent.ts
+++ b/apps/web/lib/parseQueryIntent.ts
@@ -86,7 +86,10 @@ export function parseQueryIntentSync(rawQuery: string): ParsedIntent | null {
   const entityInCity = matchEntityInCity(q)
   if (entityInCity) return { intent: 'entity-search', ...entityInCity, rawQuery }
 
-  // Pattern 4: "things to do in [city]" — must come before generic "X to Y"
+  // Pattern 4: "things to do in [city]"
+  // Must come before Pattern 6 (X to Y) to prevent "things to do in nyc" being classified as route.
+  // Safe to run after Pattern 3 only because "things" and "do" are not entity synonyms.
+  // If the synonym table expands to include multi-word synonyms, re-evaluate ordering.
   const thingsToDo = q.match(/^things?\s+to\s+do\s+in\s+(.+)$/)
   if (thingsToDo) return { intent: 'entity-search', entityType: 'activity', location: toTitleCase(thingsToDo[1].trim()), rawQuery }
 

--- a/apps/web/lib/parseQueryIntent.ts
+++ b/apps/web/lib/parseQueryIntent.ts
@@ -1,0 +1,150 @@
+// apps/web/lib/parseQueryIntent.ts
+
+export type SearchIntent =
+  | 'discover'
+  | 'entity-search'
+  | 'create-trip'
+  | 'route'
+  | 'unknown'
+
+export interface ParsedIntent {
+  intent: SearchIntent
+  /** Title-cased place name, e.g. "Bakersfield". Normalized at parse time. */
+  location?: string
+  entityType?: 'restaurant' | 'hotel' | 'activity' | 'flight'
+  rawQuery: string
+}
+
+// ---------------------------------------------------------------------------
+// Synonym map
+// ---------------------------------------------------------------------------
+
+const ENTITY_SYNONYMS: Record<string, ParsedIntent['entityType']> = {
+  restaurant: 'restaurant', restaurants: 'restaurant',
+  food: 'restaurant', dining: 'restaurant', eat: 'restaurant',
+  eats: 'restaurant', cafe: 'restaurant', cafes: 'restaurant',
+  bar: 'restaurant', bars: 'restaurant', brunch: 'restaurant',
+  lunch: 'restaurant', dinner: 'restaurant',
+  hotel: 'hotel', hotels: 'hotel', stay: 'hotel',
+  lodging: 'hotel', accommodation: 'hotel', accommodations: 'hotel',
+  hostel: 'hotel', hostels: 'hotel', motel: 'hotel', motels: 'hotel',
+  airbnb: 'hotel', resort: 'hotel', resorts: 'hotel',
+  activity: 'activity', activities: 'activity',
+  attraction: 'activity', attractions: 'activity',
+  sights: 'activity', sightseeing: 'activity',
+  tour: 'activity', tours: 'activity',
+  museum: 'activity', museums: 'activity', park: 'activity', parks: 'activity',
+  flight: 'flight', flights: 'flight', fly: 'flight',
+  airline: 'flight', airlines: 'flight',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toTitleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchEntityInCity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^${escapeRegex(synonym)}\\s+in\\s+(.+)$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+function matchCityEntity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^(.+?)\\s+${escapeRegex(synonym)}$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: synchronous regex parser (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export function parseQueryIntentSync(rawQuery: string): ParsedIntent | null {
+  const q = rawQuery.trim().toLowerCase()
+
+  // Pattern 1: "trip to [destination]"
+  const tripTo = q.match(/^trip\s+to\s+(.+)$/)
+  if (tripTo) return { intent: 'create-trip', location: toTitleCase(tripTo[1].trim()), rawQuery }
+
+  // Pattern 2: "new trip" / "create trip"
+  if (/^(?:new|create)\s+trip$/.test(q)) return { intent: 'create-trip', rawQuery }
+
+  // Pattern 3: "[entity] in [city]"
+  const entityInCity = matchEntityInCity(q)
+  if (entityInCity) return { intent: 'entity-search', ...entityInCity, rawQuery }
+
+  // Pattern 4: "things to do in [city]" — must come before generic "X to Y"
+  const thingsToDo = q.match(/^things?\s+to\s+do\s+in\s+(.+)$/)
+  if (thingsToDo) return { intent: 'entity-search', entityType: 'activity', location: toTitleCase(thingsToDo[1].trim()), rawQuery }
+
+  // Pattern 5: "[city] [entity]"
+  const cityEntity = matchCityEntity(q)
+  if (cityEntity) return { intent: 'entity-search', ...cityEntity, rawQuery }
+
+  // Pattern 6: "X to Y" (generic route)
+  // Exclude matches where the destination part contains " in " or " to " —
+  // those are more complex phrases that should fall through to Phase 2 (null).
+  const route = q.match(/^(.+?)\s+to\s+(.+)$/)
+  if (route) {
+    const dest = route[2].trim()
+    if (!/\s+(?:in|to)\s+/.test(dest)) {
+      return { intent: 'route', location: toTitleCase(dest), rawQuery }
+    }
+  }
+
+  // Pattern 7: bare single word — treat as destination discovery
+  // Multi-word queries that don't match any pattern above go to Phase 2 (LLM).
+  if (!q.includes(' ')) return { intent: 'discover', location: toTitleCase(q), rawQuery }
+
+  // No match — caller falls back to Phase 2 (LLM)
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: LLM fallback via /api/parse-intent (client-side, session-cached)
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = (q: string) => `parse-intent:${q.toLowerCase().trim()}`
+
+async function parseViaLLM(query: string, token: string): Promise<ParsedIntent> {
+  const cacheKey = CACHE_KEY(query)
+
+  try {
+    const cached = sessionStorage.getItem(cacheKey)
+    if (cached) return JSON.parse(cached) as ParsedIntent
+  } catch { /* SSR / unavailable */ }
+
+  try {
+    const res = await fetch(`/api/parse-intent?q=${encodeURIComponent(query)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const data = await res.json() as ParsedIntent
+    try { sessionStorage.setItem(cacheKey, JSON.stringify(data)) } catch { /* ignore */ }
+    return data
+  } catch {
+    return { intent: 'unknown', rawQuery: query }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main exported function
+// ---------------------------------------------------------------------------
+
+export async function parseQueryIntent(query: string, token: string): Promise<ParsedIntent> {
+  const syncResult = parseQueryIntentSync(query)
+  if (syncResult) return syncResult
+  return parseViaLLM(query, token)
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,9 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.9.0",
@@ -40,6 +42,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.12",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.1"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    // Anchor to this package only — avoids picking up shared/node_modules tests
+    include: [
+      'lib/**/__tests__/**/*.test.ts',
+      'hooks/**/__tests__/**/*.test.ts',
+      'app/**/__tests__/**/*.test.ts',
+    ],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})

--- a/docs/superpowers/plans/2026-03-25-spotlight-intent-parsing.md
+++ b/docs/superpowers/plans/2026-03-25-spotlight-intent-parsing.md
@@ -1,0 +1,822 @@
+# Spotlight Intent Parsing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a two-phase query intent parser to Spotlight Search so that queries like "bakersfield restaurants" correctly extract a clean location + entity type instead of passing the raw string to the discover backend.
+
+**Architecture:** A new `parseQueryIntent(query, token)` function runs before any search API calls. Phase 1 uses regex + a synonym table (zero latency, synchronous). Phase 2 falls back to Claude Haiku via a new Next.js API route when Phase 1 doesn't match. `useSpotlightSearch` consumes the parsed intent to pass a clean location to discover, auto-set the scope pill, and surface create-trip/route actions.
+
+**Tech Stack:** TypeScript, Vitest (new for apps/web), `@anthropic-ai/sdk`, React Query (`useQuery`), Next.js App Router API route.
+
+**Spec:** `docs/superpowers/specs/2026-03-25-spotlight-intent-parsing-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/web/lib/parseQueryIntent.ts` | Create | Phase 1 sync parser + Phase 2 LLM fallback |
+| `apps/web/lib/__tests__/parseQueryIntent.test.ts` | Create | Unit tests for Phase 1 logic |
+| `apps/web/vitest.config.ts` | Create | Vitest config for apps/web |
+| `apps/web/app/api/parse-intent/route.ts` | Create | Next.js route: calls Haiku, returns ParsedIntent |
+| `apps/web/hooks/useSpotlightSearch.ts` | Modify | Wire parsedIntent, update discover, replace memos |
+| `apps/web/package.json` | Modify | Add `@anthropic-ai/sdk`, `vitest`, test script |
+
+---
+
+## Chunk 1: Phase 1 Parser + Tests
+
+### Task 1: Install dependencies and set up Vitest for apps/web
+
+**Files:**
+- Modify: `apps/web/package.json`
+- Create: `apps/web/vitest.config.ts`
+
+- [ ] **Step 1: Add vitest and @anthropic-ai/sdk to apps/web**
+
+```bash
+npm install --workspace=apps/web --save-dev vitest@^4.0.18
+npm install --workspace=apps/web @anthropic-ai/sdk
+```
+
+- [ ] **Step 2: Add test script to apps/web/package.json**
+
+In `apps/web/package.json`, add to the `"scripts"` block:
+```json
+"test": "vitest run"
+```
+
+- [ ] **Step 3: Create apps/web/vitest.config.ts**
+
+```ts
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    // Anchor to this package only — avoids picking up shared/node_modules tests
+    include: [
+      'lib/**/__tests__/**/*.test.ts',
+      'hooks/**/__tests__/**/*.test.ts',
+      'app/**/__tests__/**/*.test.ts',
+    ],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})
+```
+
+- [ ] **Step 4: Verify vitest runs (no tests yet — just check it starts)**
+
+```bash
+cd apps/web && npx vitest run --reporter=verbose
+```
+
+Expected: exits cleanly with "No test files found" or similar (no error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/package.json apps/web/vitest.config.ts
+git commit -m "chore(web): add vitest + @anthropic-ai/sdk for intent parsing"
+```
+
+---
+
+### Task 2: Write parseQueryIntent Phase 1 (TDD)
+
+**Files:**
+- Create: `apps/web/lib/__tests__/parseQueryIntent.test.ts`
+- Create: `apps/web/lib/parseQueryIntent.ts`
+
+- [ ] **Step 1: Create the test file with failing tests**
+
+Create `apps/web/lib/__tests__/parseQueryIntent.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { parseQueryIntentSync } from '../parseQueryIntent'
+
+describe('parseQueryIntentSync — Pattern 1: trip to X', () => {
+  it('matches "trip to paris"', () => {
+    const r = parseQueryIntentSync('trip to paris')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('Paris')
+  })
+
+  it('matches "trip to new york"', () => {
+    const r = parseQueryIntentSync('trip to new york')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('New York')
+  })
+
+  it('is case-insensitive', () => {
+    const r = parseQueryIntentSync('TRIP TO LONDON')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBe('London')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 2: new/create trip', () => {
+  it('matches "new trip"', () => {
+    const r = parseQueryIntentSync('new trip')
+    expect(r?.intent).toBe('create-trip')
+    expect(r?.location).toBeUndefined()
+  })
+
+  it('matches "create trip"', () => {
+    const r = parseQueryIntentSync('create trip')
+    expect(r?.intent).toBe('create-trip')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 3: [entity] in [city]', () => {
+  it('matches "restaurants in bakersfield"', () => {
+    const r = parseQueryIntentSync('restaurants in bakersfield')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches "food in chicago"', () => {
+    const r = parseQueryIntentSync('food in chicago')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Chicago')
+  })
+
+  it('matches "hotels in miami"', () => {
+    const r = parseQueryIntentSync('hotels in miami')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('hotel')
+    expect(r?.location).toBe('Miami')
+  })
+
+  it('matches "flights in denver"', () => {
+    const r = parseQueryIntentSync('flights in denver')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('flight')
+    expect(r?.location).toBe('Denver')
+  })
+
+  it('matches "attractions in rome"', () => {
+    const r = parseQueryIntentSync('attractions in rome')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Rome')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 4: things to do in [city]', () => {
+  it('matches "things to do in nyc"', () => {
+    const r = parseQueryIntentSync('things to do in nyc')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Nyc')
+  })
+
+  it('matches "thing to do in seattle"', () => {
+    const r = parseQueryIntentSync('thing to do in seattle')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Seattle')
+  })
+
+  it('does NOT misclassify as route (priority over Pattern 6)', () => {
+    const r = parseQueryIntentSync('things to do in nyc')
+    expect(r?.intent).not.toBe('route')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 5: [city] [entity]', () => {
+  it('matches "bakersfield restaurants"', () => {
+    const r = parseQueryIntentSync('bakersfield restaurants')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('restaurant')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches "miami hotels"', () => {
+    const r = parseQueryIntentSync('miami hotels')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('hotel')
+    expect(r?.location).toBe('Miami')
+  })
+
+  it('matches "london flights"', () => {
+    const r = parseQueryIntentSync('london flights')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('flight')
+    expect(r?.location).toBe('London')
+  })
+
+  it('matches "paris museums"', () => {
+    const r = parseQueryIntentSync('paris museums')
+    expect(r?.intent).toBe('entity-search')
+    expect(r?.entityType).toBe('activity')
+    expect(r?.location).toBe('Paris')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 6: X to Y (route)', () => {
+  it('matches "la to sf"', () => {
+    const r = parseQueryIntentSync('la to sf')
+    expect(r?.intent).toBe('route')
+    expect(r?.location).toBe('Sf')
+  })
+
+  it('matches "new york to boston"', () => {
+    const r = parseQueryIntentSync('new york to boston')
+    expect(r?.intent).toBe('route')
+    expect(r?.location).toBe('Boston')
+  })
+})
+
+describe('parseQueryIntentSync — Pattern 7: bare single-word location', () => {
+  it('matches a single city name', () => {
+    const r = parseQueryIntentSync('bakersfield')
+    expect(r?.intent).toBe('discover')
+    expect(r?.location).toBe('Bakersfield')
+  })
+
+  it('matches another single city name', () => {
+    const r = parseQueryIntentSync('paris')
+    expect(r?.intent).toBe('discover')
+    expect(r?.location).toBe('Paris')
+  })
+})
+
+describe('parseQueryIntentSync — no match → null (Phase 2)', () => {
+  it('returns null for "good vibes only" (multi-word, no pattern)', () => {
+    expect(parseQueryIntentSync('good vibes only')).toBeNull()
+  })
+
+  it('returns null for "somewhere to eat in bakersfield"', () => {
+    expect(parseQueryIntentSync('somewhere to eat in bakersfield')).toBeNull()
+  })
+})
+
+describe('parseQueryIntentSync — rawQuery is always preserved', () => {
+  it('preserves the original raw query', () => {
+    const r = parseQueryIntentSync('restaurants in Bakersfield')
+    expect(r?.rawQuery).toBe('restaurants in Bakersfield')
+  })
+})
+
+describe('parseQueryIntent (async) — Phase 2 not called when Phase 1 matches', () => {
+  it('does not call fetch when Phase 1 matches', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch')
+    const { parseQueryIntent } = await import('../parseQueryIntent')
+    await parseQueryIntent('bakersfield restaurants', 'test-token')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they all fail**
+
+```bash
+cd apps/web && npx vitest run --reporter=verbose
+```
+
+Expected: All tests FAIL with "Cannot find module '../parseQueryIntent'".
+
+- [ ] **Step 3: Create apps/web/lib/parseQueryIntent.ts with Phase 1 implementation**
+
+```ts
+// apps/web/lib/parseQueryIntent.ts
+
+export type SearchIntent =
+  | 'discover'
+  | 'entity-search'
+  | 'create-trip'
+  | 'route'
+  | 'unknown'
+
+export interface ParsedIntent {
+  intent: SearchIntent
+  /** Title-cased place name, e.g. "Bakersfield". Normalized at parse time. */
+  location?: string
+  entityType?: 'restaurant' | 'hotel' | 'activity' | 'flight'
+  rawQuery: string
+}
+
+// ---------------------------------------------------------------------------
+// Synonym map — maps query words to canonical entity types
+// ---------------------------------------------------------------------------
+
+const ENTITY_SYNONYMS: Record<string, ParsedIntent['entityType']> = {
+  // restaurant
+  restaurant: 'restaurant', restaurants: 'restaurant',
+  food: 'restaurant', dining: 'restaurant', eat: 'restaurant',
+  eats: 'restaurant', cafe: 'restaurant', cafes: 'restaurant',
+  bar: 'restaurant', bars: 'restaurant', brunch: 'restaurant',
+  lunch: 'restaurant', dinner: 'restaurant',
+  // hotel
+  hotel: 'hotel', hotels: 'hotel', stay: 'hotel',
+  lodging: 'hotel', accommodation: 'hotel', accommodations: 'hotel',
+  hostel: 'hotel', hostels: 'hotel', motel: 'hotel', motels: 'hotel',
+  airbnb: 'hotel', resort: 'hotel', resorts: 'hotel',
+  // activity
+  activity: 'activity', activities: 'activity',
+  attraction: 'activity', attractions: 'activity',
+  sights: 'activity', sightseeing: 'activity',
+  tour: 'activity', tours: 'activity',
+  museum: 'activity', museums: 'activity', park: 'activity', parks: 'activity',
+  // flight
+  flight: 'flight', flights: 'flight', fly: 'flight',
+  airline: 'flight', airlines: 'flight',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toTitleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Try each synonym as a prefix: "[synonym] in [city]" */
+function matchEntityInCity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^${escapeRegex(synonym)}\\s+in\\s+(.+)$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+/** Try each synonym as a suffix: "[city] [synonym]" */
+function matchCityEntity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^(.+?)\\s+${escapeRegex(synonym)}$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: synchronous regex parser (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronously parse a search query into a structured intent.
+ * Returns null if no pattern matches — caller should fall back to Phase 2 (LLM).
+ */
+export function parseQueryIntentSync(rawQuery: string): ParsedIntent | null {
+  const q = rawQuery.trim().toLowerCase()
+
+  // Pattern 1: "trip to [destination]"
+  const tripTo = q.match(/^trip\s+to\s+(.+)$/)
+  if (tripTo) {
+    return { intent: 'create-trip', location: toTitleCase(tripTo[1].trim()), rawQuery }
+  }
+
+  // Pattern 2: "new trip" / "create trip"
+  if (/^(?:new|create)\s+trip$/.test(q)) {
+    return { intent: 'create-trip', rawQuery }
+  }
+
+  // Pattern 3: "[entity] in [city]"
+  const entityInCity = matchEntityInCity(q)
+  if (entityInCity) {
+    return { intent: 'entity-search', ...entityInCity, rawQuery }
+  }
+
+  // Pattern 4: "things to do in [city]" — must come before generic "X to Y"
+  const thingsToDo = q.match(/^things?\s+to\s+do\s+in\s+(.+)$/)
+  if (thingsToDo) {
+    return { intent: 'entity-search', entityType: 'activity', location: toTitleCase(thingsToDo[1].trim()), rawQuery }
+  }
+
+  // Pattern 5: "[city] [entity]"
+  const cityEntity = matchCityEntity(q)
+  if (cityEntity) {
+    return { intent: 'entity-search', ...cityEntity, rawQuery }
+  }
+
+  // Pattern 6: "X to Y" (generic route)
+  const route = q.match(/^(.+?)\s+to\s+(.+)$/)
+  if (route) {
+    return { intent: 'route', location: toTitleCase(route[2].trim()), rawQuery }
+  }
+
+  // Pattern 7: bare single word — treat as destination discovery
+  // Multi-word queries that don't match any pattern above go to Phase 2 (LLM).
+  if (!q.includes(' ')) {
+    return { intent: 'discover', location: toTitleCase(q), rawQuery }
+  }
+
+  // No match — caller falls back to Phase 2 (LLM)
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: LLM fallback via /api/parse-intent (client-side, session-cached)
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = (q: string) => `parse-intent:${q.toLowerCase().trim()}`
+
+async function parseViaLLM(query: string, token: string): Promise<ParsedIntent> {
+  const cacheKey = CACHE_KEY(query)
+
+  // Check session cache first
+  try {
+    const cached = sessionStorage.getItem(cacheKey)
+    if (cached) return JSON.parse(cached) as ParsedIntent
+  } catch {
+    // sessionStorage unavailable (SSR) — continue
+  }
+
+  // Call /api/parse-intent
+  try {
+    const res = await fetch(`/api/parse-intent?q=${encodeURIComponent(query)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const data = await res.json() as ParsedIntent
+
+    // Cache the result
+    try { sessionStorage.setItem(cacheKey, JSON.stringify(data)) } catch { /* ignore */ }
+
+    return data
+  } catch {
+    // Network failure or parse error — degrade gracefully
+    return { intent: 'unknown', rawQuery: query }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main exported function
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a search query into structured intent.
+ * Phase 1 (sync, zero latency) → Phase 2 (async LLM) if no pattern matched.
+ */
+export async function parseQueryIntent(query: string, token: string): Promise<ParsedIntent> {
+  const syncResult = parseQueryIntentSync(query)
+  if (syncResult) return syncResult
+  return parseViaLLM(query, token)
+}
+```
+
+- [ ] **Step 4: Run tests — all should pass**
+
+```bash
+cd apps/web && npx vitest run --reporter=verbose
+```
+
+Expected: All tests PASS. If any fail, fix the regex/synonym before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/parseQueryIntent.ts apps/web/lib/__tests__/parseQueryIntent.test.ts
+git commit -m "feat(web): add parseQueryIntent Phase 1 regex parser with tests"
+```
+
+---
+
+## Chunk 2: API Route (Phase 2)
+
+### Task 3: Create /api/parse-intent Next.js route
+
+**Files:**
+- Create: `apps/web/app/api/parse-intent/route.ts`
+
+- [ ] **Step 1: Create the route file**
+
+```ts
+// apps/web/app/api/parse-intent/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+
+// Lazy — avoids throwing at module load time when ANTHROPIC_API_KEY is absent
+let _client: Anthropic | null = null
+function getClient(): Anthropic {
+  if (!_client) _client = new Anthropic()
+  return _client
+}
+
+const PROMPT = `You are a travel search intent parser. Extract structured intent from a search query.
+
+Return ONLY valid JSON — no explanation, no markdown, no code fences.
+
+Schema:
+{
+  "intent": "discover" | "entity-search" | "create-trip" | "route" | "unknown",
+  "location": string | null,
+  "entityType": "restaurant" | "hotel" | "activity" | "flight" | null
+}
+
+Rules:
+- "discover": user wants to explore a destination with no specific entity type
+- "entity-search": user wants a specific category of place in a location
+- "create-trip": user wants to plan or start a trip
+- "route": user mentions two places (origin to destination)
+- "unknown": none of the above apply
+- location should be in Title Case (e.g. "Bakersfield", "New York")
+
+Query: `
+
+function fallback(q: string) {
+  return NextResponse.json({ intent: 'unknown', location: null, entityType: null, rawQuery: q })
+}
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get('q') ?? ''
+
+  // Auth check — must have a Bearer token (keeps open internet from burning API quota)
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return fallback(q)
+
+  if (!q.trim()) return fallback(q)
+  if (!process.env.ANTHROPIC_API_KEY) return fallback(q)
+
+  try {
+    const msg = await getClient().messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: `${PROMPT}"${q}"` }],
+    })
+
+    const text = (msg.content[0] as { type: 'text'; text: string }).text.trim()
+    const parsed = JSON.parse(text) as {
+      intent: string
+      location: string | null
+      entityType: string | null
+    }
+
+    return NextResponse.json({
+      intent: parsed.intent ?? 'unknown',
+      location: parsed.location ?? undefined,
+      entityType: parsed.entityType ?? undefined,
+      rawQuery: q,
+    })
+  } catch (err) {
+    console.error('[parse-intent] error:', err)
+    return fallback(q)
+  }
+}
+```
+
+- [ ] **Step 2: Set ANTHROPIC_API_KEY in .env.local**
+
+Add to `apps/web/.env.local` (do not commit this file):
+```
+ANTHROPIC_API_KEY=<your-key-here>
+```
+
+The user will provide the key value. Only add this line — don't overwrite other vars.
+
+- [ ] **Step 3: Manual smoke test**
+
+With the dev server running (`npm run web`), get your session token from browser devtools (Application → Local Storage → `sb-*-auth-token` → `access_token`), then:
+
+```bash
+curl "http://localhost:3000/api/parse-intent?q=somewhere+nice+to+eat+in+bakersfield" \
+  -H "Authorization: Bearer <your-token>"
+```
+
+Expected response:
+```json
+{ "intent": "entity-search", "location": "Bakersfield", "entityType": "restaurant", "rawQuery": "somewhere nice to eat in bakersfield" }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/api/parse-intent/route.ts
+git commit -m "feat(web): add /api/parse-intent route (Haiku LLM intent fallback)"
+```
+
+---
+
+## Chunk 3: Wire into useSpotlightSearch
+
+### Task 4: Update useSpotlightSearch.ts
+
+**Files:**
+- Modify: `apps/web/hooks/useSpotlightSearch.ts`
+
+This task replaces three memos (`routeIntent`, `createTripIntent`, `actionResults`) and updates the discover query. Make each step a focused edit.
+
+- [ ] **Step 1: Add the parsedIntent import**
+
+At the top of `useSpotlightSearch.ts`, add the import after the existing imports:
+
+```ts
+import { parseQueryIntent, type ParsedIntent } from '@/lib/parseQueryIntent'
+```
+
+- [ ] **Step 2: Add the parsedIntent useQuery after `shouldSearch`**
+
+Find this line (around line 180):
+```ts
+const shouldSearch = debouncedQuery.length >= 3 && !!token
+```
+
+Add directly after it:
+```ts
+// Intent parsing — Phase 1 (sync) or Phase 2 (Haiku LLM) before any search fires
+const { data: parsedIntent, isLoading: intentLoading } = useQuery<ParsedIntent>({
+  queryKey: ['parse-intent', debouncedQuery],
+  queryFn: () => parseQueryIntent(debouncedQuery, token!),
+  enabled: shouldSearch,
+  staleTime: Infinity, // intent for a given query string never changes
+})
+```
+
+- [ ] **Step 3: Update the discover query**
+
+Find this block (around lines 194–199):
+```ts
+// Live discover for destination queries (restaurants, attractions, activities)
+const { data: discoverData, isLoading: discoverLoading } = useQuery({
+  queryKey: ['discover', debouncedQuery],
+  queryFn: () => fetchDiscover(debouncedQuery, token!),
+  enabled: shouldSearch && !scope, // only when no scope filter active
+  staleTime: 60_000, // 1 minute (server caches for 1 hour)
+})
+```
+
+Replace with:
+```ts
+// Use parsed location if available, fall back to raw query
+const discoverLocation = parsedIntent?.location ?? debouncedQuery
+
+// Live discover for destination queries (restaurants, attractions, activities)
+const { data: discoverData, isLoading: discoverLoading } = useQuery({
+  queryKey: ['discover', discoverLocation],
+  queryFn: () => fetchDiscover(discoverLocation, token!),
+  // Wait for intent to resolve; disable when scope is active
+  enabled: shouldSearch && !scope && parsedIntent !== undefined,
+  staleTime: 60_000,
+})
+```
+
+- [ ] **Step 4: Replace routeIntent, createTripIntent, and actionResults memos**
+
+Find and delete these three memo blocks (approximately lines 322–365):
+```ts
+// Detect route pattern "X to Y" from discover response
+const routeIntent = useMemo((): SpotlightResult | null => {
+  ...
+}, [discoverData])
+
+// Detect trip creation intent
+const createTripIntent = useMemo((): SpotlightResult | null => {
+  ...
+}, [query])
+
+// Inject create-trip action into results
+const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
+  ...
+}, [createTripIntent, routeIntent])
+```
+
+Replace all three with this single memo:
+```ts
+// Action results derived from parsed intent (replaces createTripIntent + routeIntent memos)
+const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
+  if (!parsedIntent) return {}
+  const actions: SpotlightResult[] = []
+
+  if (parsedIntent.intent === 'create-trip') {
+    actions.push({
+      id: 'create-trip',
+      type: 'action' as const,
+      title: parsedIntent.location
+        ? `Create trip to ${parsedIntent.location}`
+        : 'Create New Trip',
+      subtitle: 'Start planning a new adventure',
+      href: '',
+      score: 100,
+      metadata: { prefillDestination: parsedIntent.location ?? '' },
+    })
+  }
+
+  if (parsedIntent.intent === 'route' && discoverData?.route) {
+    const { origin, destination } = discoverData.route
+    actions.push({
+      id: 'create-trip-route',
+      type: 'action' as const,
+      title: `Plan trip: ${origin} to ${destination}`,
+      subtitle: 'Start planning with destinations pre-filled',
+      href: '',
+      score: 100,
+      metadata: { prefillDestination: destination, origin },
+    })
+  }
+
+  return actions.length ? { action: actions } : {}
+}, [parsedIntent, discoverData?.route])
+```
+
+- [ ] **Step 5: Add the auto-scope effect**
+
+After the `actionResults` memo, add:
+```ts
+// Auto-set scope from parsed entity type (only when user hasn't set one manually)
+const ENTITY_TYPE_TO_SCOPE: Partial<Record<string, SearchScope>> = {
+  restaurant: 'restaurants',
+  activity: 'activities',
+}
+
+useEffect(() => {
+  if (parsedIntent?.entityType && scope === null) {
+    const autoScope = ENTITY_TYPE_TO_SCOPE[parsedIntent.entityType]
+    if (autoScope) setScope(autoScope)
+  }
+}, [parsedIntent?.entityType, scope])
+```
+
+- [ ] **Step 6: Update isLoading in the return statement**
+
+Find:
+```ts
+isLoading: tripSearchLoading || entityLoading || discoverLoading,
+```
+
+Replace with:
+```ts
+isLoading: tripSearchLoading || entityLoading || discoverLoading || intentLoading,
+```
+
+- [ ] **Step 7: Run typecheck to confirm no TypeScript errors**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors. Fix any type issues before continuing (common: `parsedIntent` may be `undefined` in some paths — the `parsedIntent?.` optional chaining should handle this).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/hooks/useSpotlightSearch.ts
+git commit -m "feat(web): wire parsedIntent into useSpotlightSearch — clean discover location + auto-scope"
+```
+
+---
+
+## Chunk 4: Verification
+
+### Task 5: Manual QA
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run web
+```
+
+- [ ] **Step 2: Open Spotlight (Ctrl+K) and test each case**
+
+| Query | Expected scope pill | Expected destination card title |
+|---|---|---|
+| `bakersfield restaurants` | Restaurants | Bakersfield |
+| `restaurants in bakersfield` | Restaurants | Bakersfield (same cache as above) |
+| `things to do in nyc` | Activities | Nyc |
+| `hotel in miami` | (none) | Miami |
+| `flights to london` | (none) | London |
+| `somewhere to eat in bakersfield` | Restaurants (via Haiku) | Bakersfield (via Haiku) |
+| `trip to paris` | (none) | Create trip to Paris action card |
+| `la to sf` | (none) | Plan trip: La to Sf action card |
+
+- [ ] **Step 3: Verify existing flows are not broken**
+
+| Query | Expected behavior |
+|---|---|
+| `rome` (existing trip name) | Trip results still appear |
+| `duplicate activity` | Command result still appears |
+| `settings` | Navigation result still appears |
+
+- [ ] **Step 4: Final commit and push**
+
+```bash
+git add -A
+git status  # review — should be clean or only have .env.local (which is gitignored)
+git commit -m "feat(web): spotlight intent parsing — regex Phase 1 + Haiku Phase 2 fallback" --allow-empty
+git push origin feature/tra-279
+```
+
+---
+
+## Deployment Checklist
+
+Before merging to develop, the following must be done in the production environment:
+
+- [ ] Set `ANTHROPIC_API_KEY` environment variable in the production deployment (user provides value)
+- [ ] Verify the `/api/parse-intent` route is reachable in production
+- [ ] Smoke test "bakersfield restaurants" in production Spotlight after deploy

--- a/docs/superpowers/plans/2026-03-26-entity-detail-pages.md
+++ b/docs/superpowers/plans/2026-03-26-entity-detail-pages.md
@@ -1,0 +1,2984 @@
+# Entity Detail Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add dedicated detail pages for places, hotels, activities, and destinations with a shared layout shell and type-specific sections.
+
+**Architecture:** Shared Entity Shell (Option A) — all four routes share common layout components (EntityHero, EntityActionsBar, EntityMap, EntityBreadcrumb, NearbySection). Each route has its own page file and type-specific section components. API endpoints fetch single entities by ID. Pages are server components with `generateMetadata` for SEO, hydrated client-side with React Query.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind CSS v4, iconoir-react, Leaflet, React Query v5, @travyl/shared types
+
+**Spec:** `docs/superpowers/specs/2026-03-26-entity-detail-pages-design.md`
+
+---
+
+## File Structure Overview
+
+### New Files
+
+**Shared components** (`apps/web/components/entity/`):
+- `EntityHero.tsx` — Full-bleed image carousel with gradient, title, overline, badges (REPLACES existing 64-line version)
+- `EntityActionsBar.tsx` — Add-to-trip, favorite, share (REPLACES existing 44-line version)
+- `EntityMap.tsx` — Leaflet map section (REPLACES existing 20-line version)
+- `EntityBreadcrumb.tsx` — Hierarchical breadcrumb (REPLACES existing 21-line version)
+- `EntitySection.tsx` — Section wrapper with Lustria heading (REPLACES existing 27-line version)
+- `NearbySection.tsx` — Horizontal scroll of related entity cards (NEW)
+- `EntityQuickInfo.tsx` — 2-column info grid (NEW)
+- `EntityTagList.tsx` — Tag pills display (NEW)
+- `EntitySkeleton.tsx` — Loading skeleton for all entity pages (NEW)
+- `EntityError.tsx` — Error/404 state (NEW)
+- `EntityTips.tsx` — Shared bulleted tips list (NEW, used by place + activity)
+- `EntityAccessibility.tsx` — Shared accessibility badges (NEW, used by place + activity)
+
+**Place components** (`apps/web/components/entity/place/`):
+- `PlaceAbout.tsx` — Description + tags
+- `PlaceQuickInfo.tsx` — Hours, price, phone, website, duration, admission
+- (Uses shared `EntityTips.tsx`)
+- (Uses shared `EntityAccessibility.tsx`)
+
+**Hotel components** (`apps/web/components/entity/hotel/`):
+- `HotelOverview.tsx` — Description, star rating, guest rating, tags
+- `HotelStayDetails.tsx` — Address, price, check-in/out, phone, website
+- `HotelGuestRatings.tsx` — Overall + 5 subcategory progress bars
+- `HotelRooms.tsx` — Room type cards with photos
+- `HotelAmenities.tsx` — Grouped amenities with icons
+
+**Activity components** (`apps/web/components/entity/activity/`):
+- `ActivityAbout.tsx` — Description, AI reason callout, tags
+- `ActivityDetails.tsx` — Duration, price, meeting point, times, group size, languages
+- `ActivityInclusions.tsx` — Included/not-included checklist
+- (Uses shared `EntityTips.tsx`)
+- (Uses shared `EntityAccessibility.tsx`)
+
+**Destination components** (`apps/web/components/entity/destination/`):
+- `DestinationOverview.tsx` — Description + tags
+- `DestinationQuickFacts.tsx` — Country, language, currency, timezone, best time, budget
+- `DestinationTrips.tsx` — User's trips + "Plan a trip" CTA
+- `DestinationTopPlaces.tsx` — Horizontal scroll of places
+- `DestinationTopActivities.tsx` — Horizontal scroll of activities
+- `DestinationWhereToStay.tsx` — Horizontal scroll of hotels
+
+**Pages** (`apps/web/app/(main)/`):
+- `place/[id]/page.tsx` — Place detail route (NEW)
+- `hotel/[id]/page.tsx` — Hotel detail route (NEW)
+- `activity/[id]/page.tsx` — Activity detail route (NEW)
+- `destination/[name]/page.tsx` — Enhanced destination route (MODIFY existing)
+
+**API routes** (`apps/web/app/api/`):
+- `places/[id]/route.ts` — Single place fetch (NEW)
+- `hotels/[id]/route.ts` — Single hotel fetch (NEW)
+- `activities/[id]/route.ts` — Single activity fetch (NEW)
+- `destinations/[name]/route.ts` — Destination metadata (NEW)
+
+**Types** (`packages/shared/src/types/index.ts`):
+- Add `ActivityDetail` interface
+- Add `DestinationDetail` interface
+
+---
+
+## Chunk 1: Types & Shared Entity Components
+
+### Task 1: Add new type definitions
+
+**Files:**
+- Modify: `packages/shared/src/types/index.ts`
+- Modify: `packages/shared/src/index.ts` (ensure re-export)
+
+- [ ] **Step 1: Add ActivityDetail type**
+
+Add after the existing `SuggestionCard` interface (~line 541):
+
+```typescript
+export interface ActivityDetail {
+  id: string
+  name: string
+  category: ActivityCategory
+  imageUrl: string
+  imageUrls?: string[]
+  duration: number
+  price: number | null
+  currency: string
+  rating: number | null
+  location: string
+  latitude: number
+  longitude: number
+  description: string
+  source: 'ai' | 'search'
+  relevanceScore: number
+  reason?: string
+  meetingPoint?: string
+  availableTimes?: string[]
+  groupSize?: number
+  languages?: string[]
+  included?: string[]
+  notIncluded?: string[]
+  tips?: string[]
+  accessibility?: string[]
+  address?: string
+  phone?: string
+  website?: string
+}
+```
+
+- [ ] **Step 2: Add DestinationDetail type**
+
+Add after `ActivityDetail`:
+
+```typescript
+export interface DestinationDetail {
+  name: string
+  country: string
+  description: string
+  language: string
+  currency: string
+  timezone: string
+  bestTimeToVisit: string
+  budgetLevel: 1 | 2 | 3 | 4
+  tags: string[]
+  image: string
+  images?: string[]
+  latitude: number
+  longitude: number
+  population?: string
+}
+```
+
+- [ ] **Step 3: Add EntityImage helper type for normalization**
+
+```typescript
+export interface NormalizedEntity {
+  name: string
+  images: string[]
+  overline: string
+  rating: number | null
+  priceLevel?: number | null
+  href: string
+}
+```
+
+- [ ] **Step 4: Verify exports**
+
+Check `packages/shared/src/index.ts` re-exports from `./types`. If it uses `export * from './types'`, the new types are auto-exported.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no new usage yet, just type definitions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/types/index.ts
+git commit -m "feat(types): add ActivityDetail, DestinationDetail, NormalizedEntity types (TRA-279)"
+```
+
+---
+
+### Task 2: EntityHero — Full-bleed image carousel with gradient overlay
+
+**Files:**
+- Replace: `apps/web/components/entity/EntityHero.tsx` (currently 64 lines, uses lucide-react)
+
+- [ ] **Step 1: Write EntityHero component**
+
+```tsx
+'use client'
+
+import { useState, useCallback } from 'react'
+import Image from 'next/image'
+import { NavArrowLeft, NavArrowRight } from 'iconoir-react'
+
+interface EntityHeroProps {
+  images: string[]
+  title: string
+  overline: string
+  rating?: number | null
+  reviewCount?: number
+  priceLevel?: number | null
+  fallbackGradient?: string
+}
+
+export function EntityHero({
+  images,
+  title,
+  overline,
+  rating,
+  reviewCount,
+  priceLevel,
+  fallbackGradient = 'from-[#1e3a5f] to-[#2d4a6f]',
+}: EntityHeroProps) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [failedUrls, setFailedUrls] = useState<Set<string>>(new Set())
+
+  const validImages = images.filter((url) => url && !failedUrls.has(url))
+  const hasImages = validImages.length > 0
+  const currentImage = validImages[currentIndex] ?? null
+
+  const goTo = useCallback(
+    (dir: 'prev' | 'next') => {
+      if (validImages.length <= 1) return
+      setCurrentIndex((i) =>
+        dir === 'next'
+          ? (i + 1) % validImages.length
+          : (i - 1 + validImages.length) % validImages.length
+      )
+    },
+    [validImages.length]
+  )
+
+  const handleImageError = useCallback((url: string) => {
+    setFailedUrls((prev) => new Set(prev).add(url))
+    setCurrentIndex(0)
+  }, [])
+
+  return (
+    <div className="relative w-full aspect-[4/3] md:aspect-[16/9] overflow-hidden group">
+      {/* Image or gradient fallback */}
+      {hasImages && currentImage ? (
+        <Image
+          src={currentImage}
+          alt={title}
+          fill
+          className="object-cover"
+          priority
+          onError={() => handleImageError(currentImage)}
+        />
+      ) : (
+        <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient}`} />
+      )}
+
+      {/* Bottom gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-t from-[#0f1d30] via-[#0f1d30]/40 to-transparent" />
+
+      {/* Content positioned in lower third */}
+      <div className="absolute bottom-0 left-0 right-0 p-6 md:p-10">
+        {/* Overline */}
+        <p className="font-sans text-xs font-medium tracking-widest uppercase text-white/70 mb-1">
+          {overline}
+        </p>
+        {/* Title — Lustria */}
+        <h1 className="text-3xl md:text-5xl font-serif font-normal tracking-wide text-white leading-tight">
+          {title}
+        </h1>
+        {/* Badges row */}
+        <div className="flex items-center gap-3 mt-3">
+          {rating != null && (
+            <span className="inline-flex items-center gap-1.5 bg-[#1e3a5f]/80 backdrop-blur-sm text-white text-sm font-medium px-3 py-1 rounded-lg">
+              <span className="text-amber-400">&#9733;</span>
+              {rating.toFixed(1)}
+              {reviewCount != null && (
+                <span className="text-white/60 text-xs">({reviewCount})</span>
+              )}
+            </span>
+          )}
+          {priceLevel != null && priceLevel > 0 && (
+            <span className="inline-flex items-center gap-0.5 bg-[#1e3a5f]/80 backdrop-blur-sm text-white text-sm font-medium px-3 py-1 rounded-lg">
+              {Array.from({ length: 4 }, (_, i) => (
+                <span
+                  key={i}
+                  className={i < priceLevel ? 'text-white' : 'text-white/30'}
+                >
+                  $
+                </span>
+              ))}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Carousel navigation arrows (hover-visible) */}
+      {validImages.length > 1 && (
+        <>
+          <button
+            onClick={() => goTo('prev')}
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/30 backdrop-blur-sm text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/50"
+            aria-label="Previous image"
+          >
+            <NavArrowLeft className="w-5 h-5" />
+          </button>
+          <button
+            onClick={() => goTo('next')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/30 backdrop-blur-sm text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/50"
+            aria-label="Next image"
+          >
+            <NavArrowRight className="w-5 h-5" />
+          </button>
+          {/* Dot indicators */}
+          <div className="absolute bottom-4 right-6 md:right-10 flex items-center gap-1.5">
+            {validImages.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setCurrentIndex(i)}
+                className={`w-2 h-2 rounded-full transition-all ${
+                  i === currentIndex ? 'bg-white w-4' : 'bg-white/50'
+                }`}
+                aria-label={`Image ${i + 1}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/entity/EntityHero.tsx
+git commit -m "feat(entity): replace EntityHero with full-bleed carousel + gradient overlay (TRA-279)"
+```
+
+---
+
+### Task 3: EntityActionsBar — Add to trip, favorite, share
+
+**Files:**
+- Replace: `apps/web/components/entity/EntityActionsBar.tsx` (currently 44 lines, uses lucide-react)
+
+- [ ] **Step 1: Write EntityActionsBar component**
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { Heart, ShareAndroid, Plus } from 'iconoir-react'
+import { useAuthStore } from '@travyl/shared'
+
+interface EntityActionsBarProps {
+  entityId: string
+  entityType: 'place' | 'hotel' | 'activity' | 'destination'
+  entityName: string
+  /** For destination, show "Plan a Trip" instead of "Add to Trip" */
+  variant?: 'default' | 'destination'
+}
+
+export function EntityActionsBar({
+  entityId,
+  entityType,
+  entityName,
+  variant = 'default',
+}: EntityActionsBarProps) {
+  const user = useAuthStore((s) => s.user)
+  const [isFavorited, setIsFavorited] = useState(false)
+  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
+
+  const handleFavorite = () => {
+    if (!user) {
+      setShowAuthPrompt(true)
+      return
+    }
+    setIsFavorited((prev) => !prev)
+    // TODO: persist to favorite_places table
+  }
+
+  const handleAddToTrip = () => {
+    if (!user) {
+      setShowAuthPrompt(true)
+      return
+    }
+    // TODO: open trip picker dropdown
+  }
+
+  const handleShare = async () => {
+    const url = window.location.href
+    if (navigator.share) {
+      await navigator.share({ title: entityName, url })
+    } else {
+      await navigator.clipboard.writeText(url)
+      // TODO: show toast "Link copied"
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 px-6 md:px-10 py-4 border-b border-gray-200">
+      {/* Primary action */}
+      <button
+        onClick={handleAddToTrip}
+        className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-5 py-2.5 rounded-xl transition-colors"
+      >
+        <Plus className="w-4 h-4" />
+        {variant === 'destination' ? 'Plan a Trip' : 'Add to Trip'}
+      </button>
+
+      {/* Favorite */}
+      <button
+        onClick={handleFavorite}
+        className={`inline-flex items-center justify-center w-10 h-10 rounded-xl border transition-colors ${
+          isFavorited
+            ? 'bg-red-50 border-red-200 text-red-500'
+            : 'border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700'
+        }`}
+        aria-label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+      >
+        <Heart className={`w-5 h-5 ${isFavorited ? 'fill-red-500' : ''}`} />
+      </button>
+
+      {/* Share */}
+      <button
+        onClick={handleShare}
+        className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+        aria-label="Share"
+      >
+        <ShareAndroid className="w-5 h-5" />
+      </button>
+
+      {/* Auth prompt */}
+      {showAuthPrompt && (
+        <div className="ml-auto text-sm text-gray-500">
+          <a href="/login" className="text-[#003594] hover:underline font-medium">
+            Sign in
+          </a>{' '}
+          to save this {entityType}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/entity/EntityActionsBar.tsx
+git commit -m "feat(entity): replace EntityActionsBar with add-to-trip/favorite/share (TRA-279)"
+```
+
+---
+
+### Task 4: EntityBreadcrumb — Hierarchical navigation
+
+**Files:**
+- Replace: `apps/web/components/entity/EntityBreadcrumb.tsx` (currently 21 lines, uses lucide-react)
+
+- [ ] **Step 1: Write EntityBreadcrumb component**
+
+```tsx
+import Link from 'next/link'
+import { NavArrowRight } from 'iconoir-react'
+
+interface BreadcrumbItem {
+  label: string
+  href: string
+}
+
+interface EntityBreadcrumbProps {
+  items: BreadcrumbItem[]
+  current: string
+}
+
+export function EntityBreadcrumb({ items, current }: EntityBreadcrumbProps) {
+  return (
+    <nav className="flex items-center gap-1.5 px-6 md:px-10 py-3 text-sm" aria-label="Breadcrumb">
+      {items.map((item, i) => (
+        <span key={i} className="flex items-center gap-1.5">
+          <Link
+            href={item.href}
+            className="text-gray-500 hover:text-[#003594] transition-colors"
+          >
+            {item.label}
+          </Link>
+          <NavArrowRight className="w-3.5 h-3.5 text-gray-400" />
+        </span>
+      ))}
+      <span className="text-gray-900 font-medium truncate">{current}</span>
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/components/entity/EntityBreadcrumb.tsx
+git commit -m "feat(entity): replace EntityBreadcrumb with hierarchical nav (TRA-279)"
+```
+
+---
+
+### Task 5: EntitySection — Section wrapper with Lustria heading
+
+**Files:**
+- Replace: `apps/web/components/entity/EntitySection.tsx` (currently 27 lines, uses lucide-react)
+
+- [ ] **Step 1: Write EntitySection component**
+
+```tsx
+interface EntitySectionProps {
+  title: string
+  children: React.ReactNode
+  className?: string
+}
+
+export function EntitySection({ title, children, className = '' }: EntitySectionProps) {
+  return (
+    <section className={`px-6 md:px-10 py-6 ${className}`}>
+      <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-4">
+        {title}
+      </h2>
+      {children}
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/components/entity/EntitySection.tsx
+git commit -m "feat(entity): replace EntitySection with Lustria heading wrapper (TRA-279)"
+```
+
+---
+
+### Task 6: EntityMap — Leaflet map section
+
+**Files:**
+- Replace: `apps/web/components/entity/EntityMap.tsx` (currently 20 lines)
+
+- [ ] **Step 1: Write EntityMap component**
+
+```tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { MapPin } from 'iconoir-react'
+
+const LeafletMap = dynamic(() => import('@/components/leaflet-map'), { ssr: false })
+
+interface EntityMapProps {
+  latitude: number
+  longitude: number
+  address?: string | null
+  name: string
+}
+
+export function EntityMap({ latitude, longitude, address, name }: EntityMapProps) {
+  const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`
+
+  return (
+    <section className="px-6 md:px-10 py-6">
+      <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-4">
+        Location
+      </h2>
+      {address && (
+        <div className="flex items-start gap-2 mb-4">
+          <MapPin className="w-4 h-4 text-gray-400 mt-0.5 shrink-0" />
+          <p className="text-sm text-gray-600">{address}</p>
+        </div>
+      )}
+      <div className="rounded-xl overflow-hidden border border-gray-200 h-64 md:h-80">
+        <LeafletMap
+          lat={latitude}
+          lng={longitude}
+          zoom={15}
+          label={name}
+        />
+      </div>
+      <a
+        href={googleMapsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm text-[#003594] hover:underline mt-3"
+      >
+        <MapPin className="w-3.5 h-3.5" />
+        Open in Google Maps
+      </a>
+    </section>
+  )
+}
+```
+
+Note: Uses the existing `leaflet-map.tsx` component at `@/components/leaflet-map`. Props are `lat`, `lng`, `zoom`, `label`. Verify during implementation and adjust if the interface has changed.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/entity/EntityMap.tsx
+git commit -m "feat(entity): replace EntityMap with Leaflet section + address (TRA-279)"
+```
+
+---
+
+### Task 7: New shared utility components
+
+**Files:**
+- Create: `apps/web/components/entity/EntityQuickInfo.tsx`
+- Create: `apps/web/components/entity/EntityTagList.tsx`
+- Create: `apps/web/components/entity/NearbySection.tsx`
+- Create: `apps/web/components/entity/EntitySkeleton.tsx`
+- Create: `apps/web/components/entity/EntityError.tsx`
+
+- [ ] **Step 1: Write EntityQuickInfo — 2-column info grid**
+
+```tsx
+import type { ReactNode } from 'react'
+
+interface InfoItem {
+  icon: ReactNode
+  label: string
+  value: string | ReactNode
+  href?: string
+}
+
+interface EntityQuickInfoProps {
+  items: InfoItem[]
+}
+
+export function EntityQuickInfo({ items }: EntityQuickInfoProps) {
+  const filtered = items.filter((item) => item.value)
+
+  if (filtered.length === 0) return null
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {filtered.map((item, i) => (
+        <div key={i} className="flex items-start gap-3">
+          <span className="text-gray-400 mt-0.5 shrink-0">{item.icon}</span>
+          <div>
+            <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">
+              {item.label}
+            </p>
+            {item.href ? (
+              <a
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-[#003594] hover:underline"
+              >
+                {item.value}
+              </a>
+            ) : (
+              <p className="text-sm text-gray-900">{item.value}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Write EntityTagList — Tag pills**
+
+```tsx
+interface EntityTagListProps {
+  tags: string[]
+}
+
+export function EntityTagList({ tags }: EntityTagListProps) {
+  if (!tags || tags.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="rounded-full bg-gray-100 text-gray-600 text-xs font-medium px-3 py-1"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Write NearbySection — Horizontal scroll of related cards**
+
+```tsx
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { NavArrowLeft, NavArrowRight } from 'iconoir-react'
+import { useRef } from 'react'
+
+interface NearbyItem {
+  id: string
+  name: string
+  image: string
+  type: string
+  rating: number | null
+  href: string
+}
+
+interface NearbySectionProps {
+  title: string
+  items: NearbyItem[]
+}
+
+export function NearbySection({ title, items }: NearbySectionProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  if (!items || items.length === 0) return null
+
+  const scroll = (dir: 'left' | 'right') => {
+    if (!scrollRef.current) return
+    const amount = 280
+    scrollRef.current.scrollBy({
+      left: dir === 'left' ? -amount : amount,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <section className="px-6 md:px-10 py-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide">
+          {title}
+        </h2>
+        <div className="hidden md:flex items-center gap-2">
+          <button
+            onClick={() => scroll('left')}
+            className="w-8 h-8 rounded-full border border-gray-200 flex items-center justify-center text-gray-500 hover:border-gray-300 transition-colors"
+            aria-label="Scroll left"
+          >
+            <NavArrowLeft className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => scroll('right')}
+            className="w-8 h-8 rounded-full border border-gray-200 flex items-center justify-center text-gray-500 hover:border-gray-300 transition-colors"
+            aria-label="Scroll right"
+          >
+            <NavArrowRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+      >
+        {items.map((item) => (
+          <Link
+            key={item.id}
+            href={item.href}
+            className="flex-shrink-0 w-56 snap-start rounded-xl border border-gray-200 overflow-hidden hover:border-gray-300 hover:shadow-md transition-all group"
+          >
+            <div className="relative aspect-[4/3] overflow-hidden">
+              <Image
+                src={item.image}
+                alt={item.name}
+                fill
+                className="object-cover group-hover:scale-105 transition-transform duration-300"
+              />
+              {item.rating != null && (
+                <span className="absolute top-2 right-2 bg-[#1e3a5f]/80 backdrop-blur-sm text-white text-xs font-medium px-2 py-0.5 rounded-md">
+                  &#9733; {item.rating.toFixed(1)}
+                </span>
+              )}
+            </div>
+            <div className="p-3">
+              <p className="text-sm font-semibold text-gray-900 truncate">{item.name}</p>
+              <p className="text-xs text-gray-500 mt-0.5 capitalize">{item.type}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 4: Write EntitySkeleton — Loading state**
+
+```tsx
+export function EntitySkeleton() {
+  return (
+    <div className="animate-pulse">
+      {/* Hero skeleton */}
+      <div className="w-full aspect-[4/3] md:aspect-[16/9] bg-gray-200" />
+      {/* Actions bar skeleton */}
+      <div className="flex items-center gap-3 px-6 md:px-10 py-4 border-b border-gray-200">
+        <div className="h-10 w-32 bg-gray-200 rounded-xl" />
+        <div className="h-10 w-10 bg-gray-200 rounded-xl" />
+        <div className="h-10 w-10 bg-gray-200 rounded-xl" />
+      </div>
+      {/* Content sections skeleton */}
+      <div className="px-6 md:px-10 py-6 space-y-6">
+        <div className="h-8 w-40 bg-gray-200 rounded" />
+        <div className="space-y-3">
+          <div className="h-4 w-full bg-gray-200 rounded" />
+          <div className="h-4 w-5/6 bg-gray-200 rounded" />
+          <div className="h-4 w-4/6 bg-gray-200 rounded" />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="h-12 bg-gray-200 rounded" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Write EntityError — 404 and error states**
+
+```tsx
+import Link from 'next/link'
+
+interface EntityErrorProps {
+  type: 'place' | 'hotel' | 'activity' | 'destination'
+  variant: '404' | 'error'
+  onRetry?: () => void
+}
+
+const listingHrefs: Record<string, string> = {
+  place: '/places',
+  hotel: '/places',
+  activity: '/places',
+  destination: '/',
+}
+
+export function EntityError({ type, variant, onRetry }: EntityErrorProps) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center">
+      <div className="w-20 h-20 rounded-full bg-gray-100 flex items-center justify-center mb-6">
+        <span className="text-3xl text-gray-400">?</span>
+      </div>
+      {variant === '404' ? (
+        <>
+          <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] mb-2">
+            We couldn&apos;t find this {type}
+          </h1>
+          <p className="text-sm text-gray-500 mb-6">
+            It may have been removed or the link might be incorrect.
+          </p>
+          <Link
+            href={listingHrefs[type]}
+            className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-5 py-2.5 rounded-xl transition-colors"
+          >
+            Browse {type}s
+          </Link>
+        </>
+      ) : (
+        <>
+          <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] mb-2">
+            Something went wrong
+          </h1>
+          <p className="text-sm text-gray-500 mb-6">
+            We had trouble loading this {type}. Please try again.
+          </p>
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-5 py-2.5 rounded-xl transition-colors"
+            >
+              Try again
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: Write EntityTips — shared bulleted tips list**
+
+```tsx
+import { EntitySection } from './EntitySection'
+
+export function EntityTips({ tips }: { tips?: string[] }) {
+  if (!tips || tips.length === 0) return null
+
+  return (
+    <EntitySection title="Tips">
+      <ul className="space-y-2">
+        {tips.map((tip, i) => (
+          <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+            <span className="text-gray-400 mt-0.5 shrink-0">&bull;</span>
+            {tip}
+          </li>
+        ))}
+      </ul>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 7: Write EntityAccessibility — shared accessibility badges**
+
+```tsx
+import { EntitySection } from './EntitySection'
+
+export function EntityAccessibility({ items }: { items?: string[] }) {
+  if (!items || items.length === 0) return null
+
+  return (
+    <EntitySection title="Accessibility">
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => (
+          <span
+            key={item}
+            className="inline-flex items-center gap-1.5 rounded-full bg-green-50 text-green-700 text-xs font-medium px-3 py-1"
+          >
+            <span className="text-green-500">&#10003;</span>
+            {item}
+          </span>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 8: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/components/entity/EntityQuickInfo.tsx apps/web/components/entity/EntityTagList.tsx apps/web/components/entity/NearbySection.tsx apps/web/components/entity/EntitySkeleton.tsx apps/web/components/entity/EntityError.tsx apps/web/components/entity/EntityTips.tsx apps/web/components/entity/EntityAccessibility.tsx
+git commit -m "feat(entity): add shared QuickInfo, TagList, NearbySection, Skeleton, Error, Tips, Accessibility components (TRA-279)"
+```
+
+---
+
+## Chunk 2: Place Detail Page
+
+### Task 8: Place API endpoint
+
+**Files:**
+- Create: `apps/web/app/api/places/[id]/route.ts`
+
+- [ ] **Step 1: Write single-place API route**
+
+This endpoint fetches a single place from the existing backend places API by ID.
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+
+// Re-use the mapping logic from the parent /api/places route
+// Import the known cities table and backend place mapping
+
+const BACKEND_URL = process.env.PLACES_BACKEND_URL
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json({ error: 'Missing place ID' }, { status: 400 })
+  }
+
+  try {
+    // Fetch from backend by ID
+    const res = await fetch(`${BACKEND_URL}/places/${id}`, {
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Place not found' }, { status: 404 })
+    }
+
+    const place = await res.json()
+
+    return NextResponse.json(place, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch place' }, { status: 500 })
+  }
+}
+```
+
+Note: The exact backend URL and response shape depend on how `/api/places/route.ts` works. Read that file during implementation and adapt. If the backend doesn't support single-place fetch, use the existing `/api/places` endpoint with a query filter and return the first match.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/places/\[id\]/route.ts
+git commit -m "feat(api): add /api/places/[id] endpoint (TRA-279)"
+```
+
+---
+
+### Task 9: Place section components
+
+**Files:**
+- Create: `apps/web/components/entity/place/PlaceAbout.tsx`
+- Create: `apps/web/components/entity/place/PlaceQuickInfo.tsx`
+- Create: `apps/web/components/entity/place/PlaceTips.tsx`
+- Create: `apps/web/components/entity/place/PlaceAccessibility.tsx`
+
+- [ ] **Step 1: Write PlaceAbout**
+
+```tsx
+import type { PlaceItem } from '@travyl/shared'
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+export function PlaceAbout({ place }: { place: PlaceItem }) {
+  if (!place.description && (!place.tags || place.tags.length === 0)) return null
+
+  return (
+    <EntitySection title="About">
+      {place.description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4 whitespace-pre-line">
+          {place.description}
+        </p>
+      )}
+      {place.tagline && !place.description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4">{place.tagline}</p>
+      )}
+      <EntityTagList tags={place.tags ?? []} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 2: Write PlaceQuickInfo**
+
+```tsx
+import type { PlaceItem } from '@travyl/shared'
+import { Clock, MapPin, Phone, Globe, Wallet } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+export function PlaceQuickInfo({ place }: { place: PlaceItem }) {
+  const items = [
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Hours',
+      value: place.hours ?? '',
+    },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Price',
+      value: place.priceLevel
+        ? Array.from({ length: 4 }, (_, i) => (i < place.priceLevel! ? '$' : '')).join('')
+        : '',
+    },
+    {
+      icon: <Phone className="w-4 h-4" />,
+      label: 'Phone',
+      value: place.phone ?? '',
+      href: place.phone ? `tel:${place.phone}` : undefined,
+    },
+    {
+      icon: <Globe className="w-4 h-4" />,
+      label: 'Website',
+      value: place.website ? (() => { try { return new URL(place.website!).hostname } catch { return place.website! } })() : '',
+      href: place.website ?? undefined,
+    },
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Typical visit',
+      value: place.duration ?? '',
+    },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Admission',
+      value: place.admissionFee ?? '',
+    },
+  ]
+
+  const filtered = items.filter((item) => item.value)
+  if (filtered.length === 0) return null
+
+  return (
+    <EntitySection title="Quick Info">
+      <EntityQuickInfo items={filtered} />
+    </EntitySection>
+  )
+}
+```
+
+Note: `Phone` and `Globe` may not exist in iconoir-react. During implementation, check available icons and use the closest match (e.g., `PhoneOutcome` for phone, `Internet` or `OpenNewWindow` for website). Use the existing codebase patterns as reference.
+
+- [ ] **Step 3: (PlaceTips and PlaceAccessibility use shared EntityTips and EntityAccessibility — created in Task 7)**
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/entity/place/
+git commit -m "feat(place): add PlaceAbout, PlaceQuickInfo, PlaceTips, PlaceAccessibility sections (TRA-279)"
+```
+
+---
+
+### Task 10: Place detail page route
+
+**Files:**
+- Create: `apps/web/app/(main)/place/[id]/page.tsx`
+
+- [ ] **Step 1: Write the place detail page with generateMetadata**
+
+```tsx
+import { Metadata } from 'next'
+import { PlaceDetailClient } from './PlaceDetailClient'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+async function fetchPlace(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/places/${id}`, {
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  const place = await fetchPlace(id)
+
+  if (!place) {
+    return { title: 'Place Not Found | Travyl' }
+  }
+
+  return {
+    title: `${place.name}${place.address ? ` - ${place.address}` : ''} | Travyl`,
+    description: place.description?.slice(0, 160) || place.tagline || `Discover ${place.name} on Travyl`,
+    alternates: { canonical: `/place/${id}` },
+    openGraph: {
+      type: 'website',
+      title: place.name,
+      description: place.description?.slice(0, 160) || place.tagline,
+      images: place.images?.[0] || place.image ? [{ url: place.images?.[0] || place.image }] : [],
+    },
+  }
+}
+
+export default async function PlaceDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const place = await fetchPlace(id)
+
+  return <PlaceDetailClient initialPlace={place} placeId={id} />
+}
+```
+
+- [ ] **Step 2: Write the client component**
+
+Create `apps/web/app/(main)/place/[id]/PlaceDetailClient.tsx`:
+
+```tsx
+'use client'
+
+import type { PlaceItem } from '@travyl/shared'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { NearbySection } from '@/components/entity/NearbySection'
+import { EntitySkeleton } from '@/components/entity/EntitySkeleton'
+import { EntityError } from '@/components/entity/EntityError'
+import { PlaceAbout } from '@/components/entity/place/PlaceAbout'
+import { PlaceQuickInfo } from '@/components/entity/place/PlaceQuickInfo'
+import { EntityTips } from '@/components/entity/EntityTips'
+import { EntityAccessibility } from '@/components/entity/EntityAccessibility'
+
+interface PlaceDetailClientProps {
+  initialPlace: PlaceItem | null
+  placeId: string
+}
+
+export function PlaceDetailClient({ initialPlace, placeId }: PlaceDetailClientProps) {
+  // TODO: React Query hydration from initialPlace for client-side interactivity
+  const place = initialPlace
+
+  if (!place) {
+    return <EntityError type="place" variant="404" />
+  }
+
+  const images = [place.image, ...(place.images ?? [])].filter(Boolean)
+  const overline = [place.category?.toUpperCase(), place.address?.split(',').pop()?.trim()]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[
+          { label: 'Places', href: '/places' },
+        ]}
+        current={place.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={place.name}
+        overline={overline}
+        rating={place.rating}
+        reviewCount={place.reviewCount}
+        priceLevel={place.priceLevel}
+      />
+
+      <EntityActionsBar
+        entityId={placeId}
+        entityType="place"
+        entityName={place.name}
+      />
+
+      <PlaceAbout place={place} />
+      <PlaceQuickInfo place={place} />
+      <EntityTips tips={place.tips} />
+      <EntityAccessibility items={place.accessibility} />
+
+      {place.latitude != null && place.longitude != null && (
+        <EntityMap
+          latitude={place.latitude}
+          longitude={place.longitude}
+          address={place.address}
+          name={place.name}
+        />
+      )}
+
+      {/* NearbySection will be wired when nearby API is ready */}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/\(main\)/place/
+git commit -m "feat(place): add /place/[id] detail page with SSR metadata (TRA-279)"
+```
+
+---
+
+## Chunk 3: Hotel Detail Page
+
+### Task 11: Hotel API endpoint
+
+**Files:**
+- Create: `apps/web/app/api/hotels/[id]/route.ts`
+
+- [ ] **Step 1: Write hotel API route**
+
+Uses Foursquare venue lookup by ID. Read the existing `apps/web/app/api/foursquare/route.ts` to understand the Foursquare integration pattern, then adapt for single-venue fetch.
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+
+const FSQ_API_KEY = process.env.FOURSQUARE_API_KEY
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json({ error: 'Missing hotel ID' }, { status: 400 })
+  }
+
+  try {
+    // Try Foursquare venue details endpoint
+    const res = await fetch(`https://api.foursquare.com/v3/places/${id}`, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: FSQ_API_KEY ?? '',
+      },
+    })
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Hotel not found' }, { status: 404 })
+    }
+
+    const venue = await res.json()
+
+    // Also fetch photos
+    const photosRes = await fetch(
+      `https://api.foursquare.com/v3/places/${id}/photos?limit=10`,
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: FSQ_API_KEY ?? '',
+        },
+      }
+    )
+    const photos = photosRes.ok ? await photosRes.json() : []
+
+    // Map to hotel detail shape
+    const hotel = {
+      id: venue.fsq_id,
+      name: venue.name,
+      address: venue.location?.formatted_address ?? venue.location?.address ?? null,
+      latitude: venue.geocodes?.main?.latitude ?? null,
+      longitude: venue.geocodes?.main?.longitude ?? null,
+      rating: venue.rating ? venue.rating / 2 : null, // Foursquare is 0-10, normalize to 0-5
+      starRating: venue.stats?.total_ratings ? Math.min(5, Math.round(venue.rating / 2)) : null,
+      phone: venue.tel ?? null,
+      website: venue.website ?? null,
+      description: venue.description ?? venue.tastes?.join(', ') ?? null,
+      images: photos.map?.((p: { prefix: string; suffix: string }) =>
+        `${p.prefix}original${p.suffix}`
+      ) ?? [],
+      categories: venue.categories?.map?.((c: { name: string }) => c.name) ?? [],
+      hours: venue.hours?.display ?? null,
+      price: venue.price ?? null,
+    }
+
+    return NextResponse.json(hotel, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch hotel' }, { status: 500 })
+  }
+}
+```
+
+Note: Adapt the Foursquare response mapping based on the actual API response structure. The existing `services/lib/foursquare.ts` has the enrichment pattern — reference it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/hotels/\[id\]/route.ts
+git commit -m "feat(api): add /api/hotels/[id] Foursquare venue endpoint (TRA-279)"
+```
+
+---
+
+### Task 12: Hotel section components
+
+**Files:**
+- Create: `apps/web/components/entity/hotel/HotelOverview.tsx`
+- Create: `apps/web/components/entity/hotel/HotelStayDetails.tsx`
+- Create: `apps/web/components/entity/hotel/HotelGuestRatings.tsx`
+- Create: `apps/web/components/entity/hotel/HotelRooms.tsx`
+- Create: `apps/web/components/entity/hotel/HotelAmenities.tsx`
+
+- [ ] **Step 1: Write HotelOverview**
+
+```tsx
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+import { Star } from 'iconoir-react'
+
+interface HotelOverviewProps {
+  description?: string | null
+  starRating?: number | null
+  guestRating?: number | null
+  reviewCount?: number
+  tags?: string[]
+}
+
+export function HotelOverview({
+  description,
+  starRating,
+  guestRating,
+  reviewCount,
+  tags,
+}: HotelOverviewProps) {
+  if (!description && !starRating && !guestRating) return null
+
+  return (
+    <EntitySection title="Overview">
+      {/* Star rating */}
+      {starRating != null && starRating > 0 && (
+        <div className="flex items-center gap-1 mb-3">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Star
+              key={i}
+              className={`w-4 h-4 ${
+                i < starRating ? 'fill-amber-400 text-amber-400' : 'text-gray-300'
+              }`}
+            />
+          ))}
+          <span className="text-sm text-gray-500 ml-1">{starRating}-star hotel</span>
+        </div>
+      )}
+
+      {/* Guest rating inline */}
+      {guestRating != null && (
+        <div className="flex items-center gap-2 mb-4">
+          <span className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-[#1e3a5f] text-white font-semibold text-sm">
+            {guestRating.toFixed(1)}
+          </span>
+          <div>
+            <p className="text-sm font-medium text-gray-900">
+              {guestRating >= 4.5 ? 'Excellent' : guestRating >= 4.0 ? 'Very Good' : guestRating >= 3.5 ? 'Good' : 'Fair'}
+            </p>
+            {reviewCount != null && (
+              <p className="text-xs text-gray-500">{reviewCount} reviews</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4">{description}</p>
+      )}
+
+      <EntityTagList tags={tags ?? []} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 2: Write HotelStayDetails**
+
+```tsx
+import { MapPin, Clock, Wallet, Globe, Phone } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+interface HotelStayDetailsProps {
+  address?: string | null
+  pricePerNight?: number | null
+  currency?: string | null
+  checkIn?: string | null
+  checkOut?: string | null
+  phone?: string | null
+  website?: string | null
+}
+
+export function HotelStayDetails({
+  address,
+  pricePerNight,
+  currency,
+  checkIn,
+  checkOut,
+  phone,
+  website,
+}: HotelStayDetailsProps) {
+  const items = [
+    {
+      icon: <MapPin className="w-4 h-4" />,
+      label: 'Address',
+      value: address ?? '',
+    },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Price',
+      value: pricePerNight != null ? `${currency ?? '$'}${pricePerNight}/night` : '',
+    },
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Check-in',
+      value: checkIn ?? '',
+    },
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Check-out',
+      value: checkOut ?? '',
+    },
+    ...(phone ? [{
+      icon: <Phone className="w-4 h-4" />,
+      label: 'Phone',
+      value: phone,
+      href: `tel:${phone}`,
+    }] : []),
+    ...(website ? [{
+      icon: <Globe className="w-4 h-4" />,
+      label: 'Website',
+      value: (() => { try { return new URL(website).hostname } catch { return website } })(),
+      href: website,
+    }] : []),
+  ]
+
+  const filtered = items.filter((item) => item.value)
+  if (filtered.length === 0) return null
+
+  return (
+    <EntitySection title="Stay Details">
+      <EntityQuickInfo items={filtered} />
+    </EntitySection>
+  )
+}
+```
+
+Note: `Globe` may not exist in iconoir-react. Use `Internet` or `OpenNewWindow` instead — check during implementation.
+
+- [ ] **Step 3: Write HotelGuestRatings**
+
+```tsx
+import { EntitySection } from '../EntitySection'
+
+interface RatingCategory {
+  label: string
+  score: number
+}
+
+interface HotelGuestRatingsProps {
+  overall: number
+  reviewCount?: number
+  categories?: RatingCategory[]
+}
+
+export function HotelGuestRatings({ overall, reviewCount, categories }: HotelGuestRatingsProps) {
+  if (!categories || categories.length === 0) return null
+
+  return (
+    <EntitySection title="Guest Ratings">
+      <div className="flex items-center gap-4 mb-6">
+        <span className="inline-flex items-center justify-center w-16 h-16 rounded-xl bg-[#1e3a5f] text-white font-bold text-2xl">
+          {overall.toFixed(1)}
+        </span>
+        <div>
+          <p className="text-lg font-semibold text-gray-900">
+            {overall >= 4.5 ? 'Excellent' : overall >= 4.0 ? 'Very Good' : overall >= 3.5 ? 'Good' : 'Fair'}
+          </p>
+          {reviewCount != null && (
+            <p className="text-sm text-gray-500">Based on {reviewCount} reviews</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {categories.map((cat) => (
+          <div key={cat.label} className="flex items-center gap-3">
+            <span className="text-sm text-gray-600 w-24 shrink-0">{cat.label}</span>
+            <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-[#003594] rounded-full transition-all"
+                style={{ width: `${(cat.score / 5) * 100}%` }}
+              />
+            </div>
+            <span className="text-sm font-medium text-gray-900 w-8 text-right">
+              {cat.score.toFixed(1)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 4: Write HotelRooms**
+
+```tsx
+import Image from 'next/image'
+import type { RoomType } from '@travyl/shared'
+import { EntitySection } from '../EntitySection'
+
+interface HotelRoomsProps {
+  rooms?: RoomType[]
+  currency?: string
+}
+
+export function HotelRooms({ rooms, currency = '$' }: HotelRoomsProps) {
+  if (!rooms || rooms.length === 0) return null
+
+  return (
+    <EntitySection title="Rooms">
+      <div className="space-y-4">
+        {rooms.map((room, i) => (
+          <div
+            key={i}
+            className="flex flex-col md:flex-row gap-4 p-4 rounded-xl border border-gray-200 hover:border-gray-300 transition-colors"
+          >
+            {/* Room image */}
+            <div className="relative w-full md:w-48 h-32 rounded-lg overflow-hidden shrink-0">
+              <Image
+                src={room.image}
+                alt={room.type}
+                fill
+                className="object-cover"
+              />
+            </div>
+
+            {/* Room details */}
+            <div className="flex-1">
+              <h3 className="font-semibold text-gray-900">{room.type}</h3>
+              <p className="text-sm text-gray-500 mt-1">
+                {[room.beds, room.size, `${room.guests} guest${room.guests > 1 ? 's' : ''}`]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </p>
+              {room.amenities && room.amenities.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {room.amenities.map((a) => (
+                    <span
+                      key={a}
+                      className="rounded-full bg-gray-100 text-gray-600 text-xs px-2 py-0.5"
+                    >
+                      {a}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Price */}
+            <div className="text-right shrink-0">
+              <p className="text-lg font-semibold text-gray-900">
+                {currency}{room.price}
+              </p>
+              <p className="text-xs text-gray-500">per night</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 5: Write HotelAmenities**
+
+```tsx
+import { EntitySection } from '../EntitySection'
+
+interface AmenityGroup {
+  category: string
+  items: string[]
+}
+
+interface HotelAmenitiesProps {
+  groups?: AmenityGroup[]
+}
+
+export function HotelAmenities({ groups }: HotelAmenitiesProps) {
+  if (!groups || groups.length === 0) return null
+
+  return (
+    <EntitySection title="Amenities">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {groups.map((group) => (
+          <div key={group.category}>
+            <h3 className="text-sm font-semibold text-gray-900 mb-2">{group.category}</h3>
+            <ul className="space-y-1.5">
+              {group.items.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-center gap-2 text-sm text-gray-600"
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-[#003594] shrink-0" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/components/entity/hotel/
+git commit -m "feat(hotel): add Overview, StayDetails, GuestRatings, Rooms, Amenities sections (TRA-279)"
+```
+
+---
+
+### Task 13: Hotel detail page route
+
+**Files:**
+- Create: `apps/web/app/(main)/hotel/[id]/page.tsx`
+- Create: `apps/web/app/(main)/hotel/[id]/HotelDetailClient.tsx`
+
+- [ ] **Step 1: Write hotel page with generateMetadata**
+
+```tsx
+import { Metadata } from 'next'
+import { HotelDetailClient } from './HotelDetailClient'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+async function fetchHotel(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/hotels/${id}`, {
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  const hotel = await fetchHotel(id)
+
+  if (!hotel) {
+    return { title: 'Hotel Not Found | Travyl' }
+  }
+
+  return {
+    title: `${hotel.name}${hotel.address ? ` - ${hotel.address}` : ''} | Travyl`,
+    description: hotel.description?.slice(0, 160) || `Book ${hotel.name} on Travyl`,
+    alternates: { canonical: `/hotel/${id}` },
+    openGraph: {
+      type: 'website',
+      title: hotel.name,
+      description: hotel.description?.slice(0, 160),
+      images: hotel.images?.[0] ? [{ url: hotel.images[0] }] : [],
+    },
+  }
+}
+
+export default async function HotelDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const hotel = await fetchHotel(id)
+
+  return <HotelDetailClient initialHotel={hotel} hotelId={id} />
+}
+```
+
+- [ ] **Step 2: Write HotelDetailClient**
+
+```tsx
+'use client'
+
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { HotelOverview } from '@/components/entity/hotel/HotelOverview'
+import { HotelStayDetails } from '@/components/entity/hotel/HotelStayDetails'
+import { HotelGuestRatings } from '@/components/entity/hotel/HotelGuestRatings'
+import { HotelRooms } from '@/components/entity/hotel/HotelRooms'
+import { HotelAmenities } from '@/components/entity/hotel/HotelAmenities'
+
+interface HotelApiResponse {
+  id: string
+  name: string
+  address: string | null
+  latitude: number | null
+  longitude: number | null
+  rating: number | null
+  starRating: number | null
+  phone: string | null
+  website: string | null
+  description: string | null
+  images: string[]
+  categories: string[]
+  hours: string | null
+  price: number | null
+  image_url?: string | null
+  pricePerNight?: number | null
+  currency?: string | null
+  checkIn?: string | null
+  checkOut?: string | null
+  reviewCount?: number
+  ratingCategories?: { label: string; score: number }[]
+  rooms?: import('@travyl/shared').RoomType[]
+  amenityGroups?: { category: string; items: string[] }[]
+}
+
+interface HotelDetailClientProps {
+  initialHotel: HotelApiResponse | null
+  hotelId: string
+}
+
+export function HotelDetailClient({ initialHotel, hotelId }: HotelDetailClientProps) {
+  const hotel = initialHotel
+
+  if (!hotel) {
+    return <EntityError type="hotel" variant="404" />
+  }
+
+  const images = [hotel.image_url, ...(hotel.images ?? [])].filter(Boolean)
+  const overline = [
+    'HOTEL',
+    hotel.starRating ? `${hotel.starRating}★` : null,
+    hotel.address?.split(',').pop()?.trim(),
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[{ label: 'Hotels', href: '/places' }]}
+        current={hotel.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={hotel.name}
+        overline={overline}
+        rating={hotel.rating}
+        reviewCount={hotel.reviewCount}
+        priceLevel={hotel.price}
+      />
+
+      <EntityActionsBar
+        entityId={hotelId}
+        entityType="hotel"
+        entityName={hotel.name}
+      />
+
+      <HotelOverview
+        description={hotel.description}
+        starRating={hotel.starRating}
+        guestRating={hotel.rating}
+        reviewCount={hotel.reviewCount}
+        tags={hotel.categories}
+      />
+
+      <HotelStayDetails
+        address={hotel.address}
+        pricePerNight={hotel.pricePerNight}
+        currency={hotel.currency}
+        checkIn={hotel.checkIn}
+        checkOut={hotel.checkOut}
+        phone={hotel.phone}
+        website={hotel.website}
+      />
+
+      <HotelGuestRatings
+        overall={hotel.rating ?? 0}
+        reviewCount={hotel.reviewCount}
+        categories={hotel.ratingCategories}
+      />
+
+      <HotelRooms rooms={hotel.rooms} currency={hotel.currency} />
+
+      <HotelAmenities groups={hotel.amenityGroups} />
+
+      {hotel.latitude != null && hotel.longitude != null && (
+        <EntityMap
+          latitude={hotel.latitude}
+          longitude={hotel.longitude}
+          address={hotel.address}
+          name={hotel.name}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/\(main\)/hotel/
+git commit -m "feat(hotel): add /hotel/[id] detail page with SSR metadata (TRA-279)"
+```
+
+---
+
+## Chunk 4: Activity Detail Page
+
+### Task 14: Activity API endpoint
+
+**Files:**
+- Create: `apps/web/app/api/activities/[id]/route.ts`
+
+- [ ] **Step 1: Write activity API route**
+
+Uses SerpAPI place_id for stable lookups. Read `apps/web/app/api/suggest/route.ts` to understand the existing SerpAPI integration, then adapt for single-activity fetch.
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+
+const SERP_API_KEY = process.env.SERP_API_KEY
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json({ error: 'Missing activity ID' }, { status: 400 })
+  }
+
+  // Strip 'serp-' prefix if present
+  const placeId = id.startsWith('serp-') ? id.slice(5) : id
+
+  try {
+    // Use SerpAPI Google Maps place details
+    const serpUrl = new URL('https://serpapi.com/search.json')
+    serpUrl.searchParams.set('engine', 'google_maps')
+    serpUrl.searchParams.set('place_id', placeId)
+    serpUrl.searchParams.set('api_key', SERP_API_KEY ?? '')
+
+    const res = await fetch(serpUrl.toString())
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Activity not found' }, { status: 404 })
+    }
+
+    const data = await res.json()
+    const place = data.place_results
+
+    if (!place) {
+      return NextResponse.json({ error: 'Activity not found' }, { status: 404 })
+    }
+
+    const activity = {
+      id: `serp-${placeId}`,
+      name: place.title ?? place.name ?? 'Unknown',
+      category: place.type ?? 'activity',
+      imageUrl: place.thumbnail ?? '',
+      imageUrls: place.images?.map((img: { image: string }) => img.image) ?? [],
+      duration: place.visit_duration_min ? place.visit_duration_min / 60 : 2,
+      price: place.price ? parseFloat(place.price.replace(/[^0-9.]/g, '')) : null,
+      currency: '$',
+      rating: place.rating ?? null,
+      reviewCount: place.reviews ?? null,
+      location: place.address ?? '',
+      latitude: place.gps_coordinates?.latitude ?? 0,
+      longitude: place.gps_coordinates?.longitude ?? 0,
+      description: place.description ?? place.snippet ?? '',
+      source: 'search' as const,
+      relevanceScore: 1,
+      address: place.address ?? null,
+      phone: place.phone ?? null,
+      website: place.website ?? null,
+      hours: place.operating_hours ?? null,
+    }
+
+    return NextResponse.json(activity, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch activity' }, { status: 500 })
+  }
+}
+```
+
+Note: The exact SerpAPI response shape for Google Maps place details may differ. Adapt the mapping during implementation based on actual response data.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/activities/\[id\]/route.ts
+git commit -m "feat(api): add /api/activities/[id] SerpAPI place details endpoint (TRA-279)"
+```
+
+---
+
+### Task 15: Activity section components
+
+**Files:**
+- Create: `apps/web/components/entity/activity/ActivityAbout.tsx`
+- Create: `apps/web/components/entity/activity/ActivityDetails.tsx`
+- Create: `apps/web/components/entity/activity/ActivityInclusions.tsx`
+- Create: `apps/web/components/entity/activity/ActivityTips.tsx`
+- Create: `apps/web/components/entity/activity/ActivityAccessibility.tsx`
+
+- [ ] **Step 1: Write ActivityAbout**
+
+```tsx
+import type { ActivityDetail } from '@travyl/shared'
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+export function ActivityAbout({ activity }: { activity: ActivityDetail }) {
+  return (
+    <EntitySection title="About">
+      {/* AI recommendation callout */}
+      {activity.source === 'ai' && activity.reason && (
+        <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 mb-4">
+          <p className="text-sm text-[#003594]">
+            <span className="font-medium">Recommended for you:</span>{' '}
+            {activity.reason}
+          </p>
+        </div>
+      )}
+
+      {activity.description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4 whitespace-pre-line">
+          {activity.description}
+        </p>
+      )}
+
+      <EntityTagList tags={activity.category ? [activity.category] : []} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 2: Write ActivityDetails**
+
+```tsx
+import type { ActivityDetail } from '@travyl/shared'
+import { Clock, Wallet, MapPin, Group, Language } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+export function ActivityDetails({ activity }: { activity: ActivityDetail }) {
+  const items = [
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: 'Duration',
+      value: activity.duration
+        ? activity.duration >= 1
+          ? `${activity.duration} hour${activity.duration > 1 ? 's' : ''}`
+          : `${Math.round(activity.duration * 60)} minutes`
+        : '',
+    },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Price',
+      value:
+        activity.price != null
+          ? `${activity.currency ?? '$'}${activity.price}/person`
+          : 'Free',
+    },
+    {
+      icon: <MapPin className="w-4 h-4" />,
+      label: 'Meeting point',
+      value: activity.meetingPoint ?? activity.location ?? '',
+    },
+    ...(activity.availableTimes?.length
+      ? [
+          {
+            icon: <Clock className="w-4 h-4" />,
+            label: 'Available times',
+            value: activity.availableTimes.join(', '),
+          },
+        ]
+      : []),
+    ...(activity.groupSize
+      ? [
+          {
+            icon: <Group className="w-4 h-4" />,
+            label: 'Group size',
+            value: `Up to ${activity.groupSize}`,
+          },
+        ]
+      : []),
+    ...(activity.languages?.length
+      ? [
+          {
+            icon: <Language className="w-4 h-4" />,
+            label: 'Languages',
+            value: activity.languages.join(', '),
+          },
+        ]
+      : []),
+  ]
+
+  const filtered = items.filter((item) => item.value)
+  if (filtered.length === 0) return null
+
+  return (
+    <EntitySection title="Details">
+      <EntityQuickInfo items={filtered} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 3: Write ActivityInclusions**
+
+```tsx
+import { EntitySection } from '../EntitySection'
+
+interface ActivityInclusionsProps {
+  included?: string[]
+  notIncluded?: string[]
+}
+
+export function ActivityInclusions({ included, notIncluded }: ActivityInclusionsProps) {
+  if ((!included || included.length === 0) && (!notIncluded || notIncluded.length === 0)) {
+    return null
+  }
+
+  return (
+    <EntitySection title="What's Included">
+      <div className="space-y-2">
+        {included?.map((item) => (
+          <div key={item} className="flex items-center gap-2 text-sm">
+            <span className="text-green-500 shrink-0">&#10003;</span>
+            <span className="text-gray-700">{item}</span>
+          </div>
+        ))}
+        {notIncluded?.map((item) => (
+          <div key={item} className="flex items-center gap-2 text-sm">
+            <span className="text-red-400 shrink-0">&#10007;</span>
+            <span className="text-gray-500">{item}</span>
+          </div>
+        ))}
+      </div>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 4: (ActivityTips and ActivityAccessibility use shared EntityTips and EntityAccessibility — created in Task 7)**
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/components/entity/activity/
+git commit -m "feat(activity): add About, Details, Inclusions, Tips, Accessibility sections (TRA-279)"
+```
+
+---
+
+### Task 16: Activity detail page route
+
+**Files:**
+- Create: `apps/web/app/(main)/activity/[id]/page.tsx`
+- Create: `apps/web/app/(main)/activity/[id]/ActivityDetailClient.tsx`
+
+- [ ] **Step 1: Write activity page with generateMetadata**
+
+Follow the same pattern as Task 10 (place page). Server component fetches from `/api/activities/{id}`, passes to `ActivityDetailClient`.
+
+```tsx
+import { Metadata } from 'next'
+import { ActivityDetailClient } from './ActivityDetailClient'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+async function fetchActivity(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/activities/${id}`, {
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  const activity = await fetchActivity(id)
+
+  if (!activity) {
+    return { title: 'Activity Not Found | Travyl' }
+  }
+
+  return {
+    title: `${activity.name}${activity.location ? ` - ${activity.location}` : ''} | Travyl`,
+    description: activity.description?.slice(0, 160) || `Discover ${activity.name} on Travyl`,
+    alternates: { canonical: `/activity/${id}` },
+    openGraph: {
+      type: 'website',
+      title: activity.name,
+      description: activity.description?.slice(0, 160),
+      images: activity.imageUrl ? [{ url: activity.imageUrl }] : [],
+    },
+  }
+}
+
+export default async function ActivityDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const activity = await fetchActivity(id)
+
+  return <ActivityDetailClient initialActivity={activity} activityId={id} />
+}
+```
+
+- [ ] **Step 2: Write ActivityDetailClient**
+
+```tsx
+'use client'
+
+import type { ActivityDetail } from '@travyl/shared'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { ActivityAbout } from '@/components/entity/activity/ActivityAbout'
+import { ActivityDetails } from '@/components/entity/activity/ActivityDetails'
+import { ActivityInclusions } from '@/components/entity/activity/ActivityInclusions'
+import { EntityTips } from '@/components/entity/EntityTips'
+import { EntityAccessibility } from '@/components/entity/EntityAccessibility'
+
+interface ActivityDetailClientProps {
+  initialActivity: ActivityDetail | null
+  activityId: string
+}
+
+export function ActivityDetailClient({ initialActivity, activityId }: ActivityDetailClientProps) {
+  const activity = initialActivity
+
+  if (!activity) {
+    return <EntityError type="activity" variant="404" />
+  }
+
+  const images = [activity.imageUrl, ...(activity.imageUrls ?? [])].filter(Boolean)
+  const overline = [activity.category?.toUpperCase(), activity.location?.split(',').pop()?.trim()]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[{ label: 'Activities', href: '/places' }]}
+        current={activity.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={activity.name}
+        overline={overline}
+        rating={activity.rating}
+      />
+
+      <EntityActionsBar
+        entityId={activityId}
+        entityType="activity"
+        entityName={activity.name}
+      />
+
+      <ActivityAbout activity={activity} />
+      <ActivityDetails activity={activity} />
+      <ActivityInclusions
+        included={activity.included}
+        notIncluded={activity.notIncluded}
+      />
+      <EntityTips tips={activity.tips} />
+      <EntityAccessibility items={activity.accessibility} />
+
+      {activity.latitude != null && activity.longitude != null && (
+        <EntityMap
+          latitude={activity.latitude}
+          longitude={activity.longitude}
+          address={activity.address}
+          name={activity.name}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/\(main\)/activity/
+git commit -m "feat(activity): add /activity/[id] detail page with SSR metadata (TRA-279)"
+```
+
+---
+
+## Chunk 5: Destination Detail Page (Enhance Existing)
+
+### Task 17: Destination API endpoint
+
+**Files:**
+- Create: `apps/web/app/api/destinations/[name]/route.ts`
+
+- [ ] **Step 1: Write destination metadata API**
+
+Hardcoded metadata for popular destinations + Nominatim fallback. Reference the known cities table in `/api/places/route.ts` (101 cities) for the initial set.
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+
+// Hardcoded destination metadata — expand over time
+const DESTINATIONS: Record<string, {
+  country: string
+  description: string
+  language: string
+  currency: string
+  timezone: string
+  bestTimeToVisit: string
+  budgetLevel: 1 | 2 | 3 | 4
+  tags: string[]
+  latitude: number
+  longitude: number
+  image: string
+}> = {
+  paris: {
+    country: 'France',
+    description: 'The City of Light captivates with its blend of world-class art, iconic landmarks, and vibrant cafe culture. From the Eiffel Tower to hidden Marais bistros, Paris offers endless discovery for every traveler.',
+    language: 'French',
+    currency: 'EUR',
+    timezone: 'CET (UTC+1)',
+    bestTimeToVisit: 'April - June, September - October',
+    budgetLevel: 3,
+    tags: ['Europe', 'Culture', 'Romance', 'Food', 'Art'],
+    latitude: 48.8566,
+    longitude: 2.3522,
+    image: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=1200&q=80',
+  },
+  london: {
+    country: 'United Kingdom',
+    description: 'A global city blending centuries of history with cutting-edge culture. Explore royal palaces, world-famous museums, vibrant markets, and a dining scene that rivals any in the world.',
+    language: 'English',
+    currency: 'GBP',
+    timezone: 'GMT (UTC+0)',
+    bestTimeToVisit: 'May - September',
+    budgetLevel: 4,
+    tags: ['Europe', 'Culture', 'History', 'Shopping', 'Theatre'],
+    latitude: 51.5074,
+    longitude: -0.1278,
+    image: 'https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=1200&q=80',
+  },
+  tokyo: {
+    country: 'Japan',
+    description: 'Where ancient tradition meets neon-lit modernity. Experience serene temples, the world\'s best street food, cutting-edge technology, and a culture of precision and hospitality.',
+    language: 'Japanese',
+    currency: 'JPY',
+    timezone: 'JST (UTC+9)',
+    bestTimeToVisit: 'March - May, September - November',
+    budgetLevel: 3,
+    tags: ['Asia', 'Culture', 'Food', 'Technology', 'Temples'],
+    latitude: 35.6762,
+    longitude: 139.6503,
+    image: 'https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?w=1200&q=80',
+  },
+  // Add more destinations during implementation — pull from the known cities
+  // table in /api/places/route.ts and enrich with metadata
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const { name } = await params
+  const slug = decodeURIComponent(name).toLowerCase().replace(/-/g, ' ').trim()
+  const slugKey = slug.replace(/\s+/g, '-')
+
+  // Check hardcoded metadata
+  const destination = DESTINATIONS[slug] ?? DESTINATIONS[slugKey]
+
+  if (destination) {
+    return NextResponse.json(
+      { name: slug.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '), ...destination },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        },
+      }
+    )
+  }
+
+  // Fallback: Nominatim geocoding for unknown destinations
+  try {
+    const nomRes = await fetch(
+      `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(slug)}&format=json&limit=1&accept-language=en`,
+      { headers: { 'User-Agent': 'Travyl/1.0' } }
+    )
+    const results = await nomRes.json()
+
+    if (!results || results.length === 0) {
+      return NextResponse.json({ error: 'Destination not found' }, { status: 404 })
+    }
+
+    const result = results[0]
+    const displayName = result.display_name?.split(',')[0] ?? slug
+
+    return NextResponse.json(
+      {
+        name: displayName,
+        country: result.display_name?.split(',').pop()?.trim() ?? '',
+        description: null,
+        language: '',
+        currency: '',
+        timezone: '',
+        bestTimeToVisit: '',
+        budgetLevel: null,
+        tags: [],
+        latitude: parseFloat(result.lat),
+        longitude: parseFloat(result.lon),
+        image: `https://images.unsplash.com/photo-1488646953014-85cb44e25828?w=1200&q=80`,
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        },
+      }
+    )
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch destination' }, { status: 500 })
+  }
+}
+```
+
+Note: Expand the `DESTINATIONS` object during implementation to cover the 99+ cities already in the known cities table. This is a starting point with 3 examples.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/api/destinations/\[name\]/route.ts
+git commit -m "feat(api): add /api/destinations/[name] metadata endpoint (TRA-279)"
+```
+
+---
+
+### Task 18: Destination section components
+
+**Files:**
+- Create: `apps/web/components/entity/destination/DestinationOverview.tsx`
+- Create: `apps/web/components/entity/destination/DestinationQuickFacts.tsx`
+- Create: `apps/web/components/entity/destination/DestinationTrips.tsx`
+- Create: `apps/web/components/entity/destination/DestinationTopPlaces.tsx`
+- Create: `apps/web/components/entity/destination/DestinationTopActivities.tsx`
+- Create: `apps/web/components/entity/destination/DestinationWhereToStay.tsx`
+
+- [ ] **Step 1: Write DestinationOverview**
+
+```tsx
+import { EntitySection } from '../EntitySection'
+import { EntityTagList } from '../EntityTagList'
+
+interface DestinationOverviewProps {
+  description?: string | null
+  tags?: string[]
+}
+
+export function DestinationOverview({ description, tags }: DestinationOverviewProps) {
+  if (!description && (!tags || tags.length === 0)) return null
+
+  return (
+    <EntitySection title="Overview">
+      {description && (
+        <p className="text-sm text-gray-700 leading-relaxed mb-4">{description}</p>
+      )}
+      <EntityTagList tags={tags ?? []} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 2: Write DestinationQuickFacts**
+
+```tsx
+import { MapPin, Clock, Wallet } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+import { EntityQuickInfo } from '../EntityQuickInfo'
+
+interface DestinationQuickFactsProps {
+  country?: string
+  language?: string
+  currency?: string
+  timezone?: string
+  bestTimeToVisit?: string
+  budgetLevel?: number | null
+}
+
+export function DestinationQuickFacts({
+  country,
+  language,
+  currency,
+  timezone,
+  bestTimeToVisit,
+  budgetLevel,
+}: DestinationQuickFactsProps) {
+  const items = [
+    { icon: <MapPin className="w-4 h-4" />, label: 'Country', value: country ?? '' },
+    { icon: <MapPin className="w-4 h-4" />, label: 'Language', value: language ?? '' },
+    { icon: <Wallet className="w-4 h-4" />, label: 'Currency', value: currency ?? '' },
+    { icon: <Clock className="w-4 h-4" />, label: 'Timezone', value: timezone ?? '' },
+    { icon: <Clock className="w-4 h-4" />, label: 'Best time to visit', value: bestTimeToVisit ?? '' },
+    {
+      icon: <Wallet className="w-4 h-4" />,
+      label: 'Budget',
+      value: budgetLevel ? Array.from({ length: 4 }, (_, i) => (i < budgetLevel ? '$' : '')).join('') : '',
+    },
+  ]
+
+  const filtered = items.filter((item) => item.value)
+  if (filtered.length === 0) return null
+
+  return (
+    <EntitySection title="Quick Facts">
+      <EntityQuickInfo items={filtered} />
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 3: Write DestinationTrips**
+
+This component shows the user's trips to this destination. Reuse logic from the existing `destination/[name]/page.tsx`.
+
+```tsx
+'use client'
+
+import Link from 'next/link'
+import { useTrips, useAuthStore } from '@travyl/shared'
+import { Plus } from 'iconoir-react'
+import { EntitySection } from '../EntitySection'
+
+interface DestinationTripsProps {
+  destinationName: string
+}
+
+const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  planning: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  booked: { bg: 'bg-amber-100', text: 'text-amber-700' },
+  active: { bg: 'bg-emerald-100', text: 'text-emerald-700' },
+  completed: { bg: 'bg-gray-100', text: 'text-gray-600' },
+  abandoned: { bg: 'bg-red-100', text: 'text-red-600' },
+}
+
+export function DestinationTrips({ destinationName }: DestinationTripsProps) {
+  const user = useAuthStore((s) => s.user)
+  const { data: trips } = useTrips()
+
+  if (!user) return null
+
+  const matchingTrips = trips?.filter((t) =>
+    t.destination.toLowerCase().includes(destinationName.toLowerCase())
+  ) ?? []
+
+  return (
+    <EntitySection title="Your Trips Here">
+      {matchingTrips.length > 0 ? (
+        <div className="space-y-3">
+          {matchingTrips.map((trip) => {
+            const colors = STATUS_COLORS[trip.status] ?? STATUS_COLORS.planning
+            return (
+              <Link
+                key={trip.id}
+                href={`/trip/${trip.id}`}
+                className="block rounded-xl border border-gray-200 p-4 hover:border-gray-300 transition-colors"
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h3 className="font-semibold text-gray-900">{trip.title}</h3>
+                    <p className="text-sm text-gray-500 mt-1">{trip.destination}</p>
+                  </div>
+                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${colors.bg} ${colors.text}`}>
+                    {trip.status}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-400 mt-2">
+                  {trip.start_date} - {trip.end_date}
+                </p>
+              </Link>
+            )
+          })}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">You don&apos;t have any trips to {destinationName} yet.</p>
+      )}
+
+      <Link
+        href="/trips"
+        className="inline-flex items-center gap-2 mt-4 text-sm text-[#003594] hover:underline font-medium"
+      >
+        <Plus className="w-4 h-4" />
+        Plan a new trip to {destinationName}
+      </Link>
+    </EntitySection>
+  )
+}
+```
+
+- [ ] **Step 4: Write DestinationTopPlaces, DestinationTopActivities, DestinationWhereToStay**
+
+These three follow the same pattern — fetch from existing APIs and display as horizontal card scrolls. Use `NearbySection` component.
+
+Create `DestinationTopPlaces.tsx`:
+
+```tsx
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '../NearbySection'
+
+interface DestinationTopPlacesProps {
+  destinationName: string
+  latitude: number
+  longitude: number
+}
+
+export function DestinationTopPlaces({ destinationName, latitude, longitude }: DestinationTopPlacesProps) {
+  const { data: places } = useQuery({
+    queryKey: ['destination-places', destinationName],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/places?q=${encodeURIComponent(destinationName)}&lat=${latitude}&lng=${longitude}&limit=8&category=sightseeing`
+      )
+      if (!res.ok) return []
+      return res.json()
+    },
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const items = (places ?? []).map((p: any) => ({
+    id: p.id,
+    name: p.name,
+    image: p.image || p.images?.[0] || '',
+    type: p.type || p.category || 'place',
+    rating: p.rating,
+    href: `/place/${p.id}`,
+  }))
+
+  if (items.length === 0) return null
+
+  return <NearbySection title={`Top Places in ${destinationName}`} items={items} />
+}
+```
+
+Create `DestinationTopActivities.tsx`:
+
+```tsx
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '../NearbySection'
+
+interface DestinationTopActivitiesProps {
+  destinationName: string
+}
+
+export function DestinationTopActivities({ destinationName }: DestinationTopActivitiesProps) {
+  const { data: activities } = useQuery({
+    queryKey: ['destination-activities', destinationName],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/suggest?destination=${encodeURIComponent(destinationName)}&category=sightseeing`
+      )
+      if (!res.ok) return []
+      return res.json()
+    },
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const items = (activities ?? []).slice(0, 8).map((a: any) => ({
+    id: a.id,
+    name: a.name,
+    image: a.imageUrl || a.imageUrls?.[0] || '',
+    type: a.category || 'activity',
+    rating: a.rating,
+    href: `/activity/${a.id}`,
+  }))
+
+  if (items.length === 0) return null
+
+  return <NearbySection title={`Top Activities in ${destinationName}`} items={items} />
+}
+```
+
+Create `DestinationWhereToStay.tsx`:
+
+```tsx
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { NearbySection } from '../NearbySection'
+
+interface DestinationWhereToStayProps {
+  destinationName: string
+  latitude: number
+  longitude: number
+}
+
+export function DestinationWhereToStay({ destinationName, latitude, longitude }: DestinationWhereToStayProps) {
+  const { data: hotels } = useQuery({
+    queryKey: ['destination-hotels', destinationName],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/places?q=${encodeURIComponent(destinationName + ' hotel')}&lat=${latitude}&lng=${longitude}&limit=8&category=hotel`
+      )
+      if (!res.ok) return []
+      return res.json()
+    },
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const items = (hotels ?? []).map((h: any) => ({
+    id: h.id,
+    name: h.name,
+    image: h.image || h.images?.[0] || '',
+    type: 'hotel',
+    rating: h.rating,
+    href: `/hotel/${h.id}`,
+  }))
+
+  if (items.length === 0) return null
+
+  return <NearbySection title={`Where to Stay in ${destinationName}`} items={items} />
+}
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/entity/destination/
+git commit -m "feat(destination): add Overview, QuickFacts, Trips, TopPlaces, TopActivities, WhereToStay sections (TRA-279)"
+```
+
+---
+
+### Task 19: Enhance existing destination page
+
+**Files:**
+- Modify: `apps/web/app/(main)/destination/[name]/page.tsx`
+
+- [ ] **Step 1: Read the existing destination page**
+
+Read `apps/web/app/(main)/destination/[name]/page.tsx` fully to understand the current implementation before modifying.
+
+- [ ] **Step 2: Full rewrite — replace existing client page with server component**
+
+The existing page is a `'use client'` component using `use(params)`, Nominatim geocoding, and lucide-react icons. **Completely replace it** with a server component page + separate `DestinationDetailClient.tsx`. The Nominatim/geocoding logic moves to the `/api/destinations/[name]` endpoint (Task 17). Trip matching logic is now in `DestinationTrips` component. All lucide-react icons are dropped.
+
+Create a server component page:
+
+```tsx
+import { Metadata } from 'next'
+import { DestinationDetailClient } from './DestinationDetailClient'
+
+interface PageProps {
+  params: Promise<{ name: string }>
+}
+
+async function fetchDestination(name: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/destinations/${encodeURIComponent(name)}`, {
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { name } = await params
+  const destination = await fetchDestination(name)
+  const displayName = destination?.name ?? decodeURIComponent(name)
+
+  return {
+    title: `${displayName}${destination?.country ? `, ${destination.country}` : ''} | Travyl`,
+    description: destination?.description?.slice(0, 160) || `Plan your trip to ${displayName} with Travyl`,
+    alternates: { canonical: `/destination/${name}` },
+    openGraph: {
+      type: 'website',
+      title: displayName,
+      description: destination?.description?.slice(0, 160),
+      images: destination?.image ? [{ url: destination.image }] : [],
+    },
+  }
+}
+
+export default async function DestinationDetailPage({ params }: PageProps) {
+  const { name } = await params
+  const destination = await fetchDestination(name)
+
+  return <DestinationDetailClient initialDestination={destination} slug={name} />
+}
+```
+
+- [ ] **Step 3: Create DestinationDetailClient**
+
+Create `apps/web/app/(main)/destination/[name]/DestinationDetailClient.tsx`:
+
+```tsx
+'use client'
+
+import type { DestinationDetail } from '@travyl/shared'
+import { EntityHero } from '@/components/entity/EntityHero'
+import { EntityActionsBar } from '@/components/entity/EntityActionsBar'
+import { EntityBreadcrumb } from '@/components/entity/EntityBreadcrumb'
+import { EntityMap } from '@/components/entity/EntityMap'
+import { EntityError } from '@/components/entity/EntityError'
+import { DestinationOverview } from '@/components/entity/destination/DestinationOverview'
+import { DestinationQuickFacts } from '@/components/entity/destination/DestinationQuickFacts'
+import { DestinationTrips } from '@/components/entity/destination/DestinationTrips'
+import { DestinationTopPlaces } from '@/components/entity/destination/DestinationTopPlaces'
+import { DestinationTopActivities } from '@/components/entity/destination/DestinationTopActivities'
+import { DestinationWhereToStay } from '@/components/entity/destination/DestinationWhereToStay'
+
+interface DestinationDetailClientProps {
+  initialDestination: DestinationDetail | null
+  slug: string
+}
+
+export function DestinationDetailClient({ initialDestination, slug }: DestinationDetailClientProps) {
+  const destination = initialDestination
+
+  if (!destination) {
+    return <EntityError type="destination" variant="404" />
+  }
+
+  const images = [destination.image, ...(destination.images ?? [])].filter(Boolean)
+  const overline = ['DESTINATION', destination.country].filter(Boolean).join(' · ')
+
+  return (
+    <div className="min-h-screen bg-white">
+      <EntityBreadcrumb
+        items={[{ label: 'Explore', href: '/' }]}
+        current={destination.name}
+      />
+
+      <EntityHero
+        images={images}
+        title={destination.name}
+        overline={overline}
+      />
+
+      <EntityActionsBar
+        entityId={slug}
+        entityType="destination"
+        entityName={destination.name}
+        variant="destination"
+      />
+
+      <DestinationOverview
+        description={destination.description}
+        tags={destination.tags}
+      />
+
+      <DestinationQuickFacts
+        country={destination.country}
+        language={destination.language}
+        currency={destination.currency}
+        timezone={destination.timezone}
+        bestTimeToVisit={destination.bestTimeToVisit}
+        budgetLevel={destination.budgetLevel}
+      />
+
+      <DestinationTrips destinationName={destination.name} />
+
+      <DestinationTopPlaces
+        destinationName={destination.name}
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+      />
+
+      <DestinationTopActivities destinationName={destination.name} />
+
+      <DestinationWhereToStay
+        destinationName={destination.name}
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+      />
+
+      <EntityMap
+        latitude={destination.latitude}
+        longitude={destination.longitude}
+        name={destination.name}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/\(main\)/destination/
+git commit -m "feat(destination): enhance /destination/[name] with entity shell and rich sections (TRA-279)"
+```
+
+---
+
+## Chunk 6: Navigation Wiring & Final Integration
+
+### Task 20: Wire navigation links from existing pages
+
+**Files:**
+- Modify: `apps/web/components/PlaceDetailOverlay.tsx` (or wherever place cards link)
+- Modify: `apps/web/components/calendar/SuggestionCard.tsx`
+- Modify: `apps/web/components/calendar/ForYouPanel.tsx`
+
+- [ ] **Step 1: Read existing click handlers**
+
+Read `SuggestionCard.tsx`, `ForYouPanel.tsx`, and the `/places` page to understand current click behavior. Identify where to add navigation links to the new detail pages.
+
+- [ ] **Step 2: Add link to suggestion cards**
+
+In `SuggestionCard.tsx`, add an "Open detail" link/icon that navigates to `/activity/{id}` (using `next/link` or `router.push`). Keep the existing click-to-open-drawer behavior but add a secondary navigation action.
+
+- [ ] **Step 3: Add links from place browse cards**
+
+In the `/places` page's card components, make cards link to `/place/{id}` when clicked. If the current behavior opens an overlay, add the link as a "View full page" action inside the overlay.
+
+- [ ] **Step 4: Run typecheck and verify**
+
+Run: `npm run typecheck`
+Manually navigate to each of the 4 new routes to verify rendering.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(nav): wire entity detail page links from suggestion cards and browse pages (TRA-279)"
+```
+
+---
+
+### Task 21: Final typecheck and cleanup
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `npm run typecheck`
+Fix any errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Fix any lint errors.
+
+- [ ] **Step 3: Manual smoke test**
+
+Visit each route and verify:
+- `/place/test-id` — renders place detail or 404
+- `/hotel/test-id` — renders hotel detail or 404
+- `/activity/test-id` — renders activity detail or 404
+- `/destination/paris` — renders enhanced destination page
+- All pages show correct metadata in page title
+- Skeleton/error states work
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git commit -m "fix(entity): typecheck and lint cleanup (TRA-279)"
+```

--- a/docs/superpowers/specs/2026-03-25-spotlight-intent-parsing-design.md
+++ b/docs/superpowers/specs/2026-03-25-spotlight-intent-parsing-design.md
@@ -1,0 +1,370 @@
+# Spotlight Intent Parsing — Design Spec
+
+**Date:** 2026-03-25
+**Feature:** Query intent parsing for Spotlight Search
+**Status:** Approved
+
+---
+
+## Problem
+
+When users type natural language queries like "bakersfield restaurants" or "restaurants in bakersfield" into the Spotlight search, the system passes the entire raw string as the destination to the discover Lambda. This means:
+
+- The destination card shows "bakersfield restaurants" as a place name
+- SerpAPI receives `destination = "bakersfield restaurants"` + `category = "dining"` — doubling the intent
+- The DynamoDB cache key becomes `discover:bakersfield restaurants` instead of `discover:bakersfield`
+- No entity type scoping happens automatically — the user has to manually set a scope pill
+
+The root cause is the absence of a query understanding layer. The system routes the raw string everywhere instead of first determining what the user means.
+
+---
+
+## Goal
+
+Parse the user's natural language search query into a structured `ParsedIntent` object **before** any API calls fire, so that:
+
+1. The discover Lambda receives a clean location string (`"bakersfield"`) not the full query
+2. The entity type is extracted and used to auto-set the scope filter where a scope exists
+3. Novel / ambiguous queries fall back to a Claude Haiku LLM call for structured extraction
+4. LLM responses are session-cached so repeated phrases don't re-hit the API
+
+---
+
+## Architecture
+
+```
+User types query
+      ↓
+parseQueryIntent(query, token)   [apps/web/lib/parseQueryIntent.ts]
+  ├─ Phase 1: Regex + synonym table  →  fast match, zero latency
+  └─ Phase 2: no match → /api/parse-intent → Claude Haiku (Anthropic direct API)
+      ↓
+ParsedIntent { location?, entityType?, intent, rawQuery }
+      ↓
+useSpotlightSearch.ts
+  ├─ passes location (not rawQuery) to /api/discover
+  ├─ auto-sets scope from entityType (only for scopes that exist in SearchScope)
+  └─ still passes rawQuery to entity-search and context-search unchanged
+```
+
+The `parseQueryIntent` function is the single source of truth for intent. Everything downstream consumes its output.
+
+---
+
+## `ParsedIntent` Type
+
+```ts
+// apps/web/lib/parseQueryIntent.ts
+
+export type SearchIntent =
+  | 'discover'       // user wants to explore a destination
+  | 'entity-search'  // user wants a specific entity type in a location
+  | 'create-trip'    // user wants to start a trip
+  | 'route'          // user wants A-to-B routing
+  | 'unknown'        // no structured intent detected
+
+export interface ParsedIntent {
+  intent: SearchIntent
+  location?: string        // title-cased place name, e.g. "Bakersfield" — normalized at parse time
+  entityType?: 'restaurant' | 'hotel' | 'activity' | 'flight'
+  rawQuery: string         // always the original unmodified query
+}
+
+export async function parseQueryIntent(query: string, token: string): Promise<ParsedIntent>
+```
+
+---
+
+## `entityType` → `SearchScope` Mapping
+
+The existing `SearchScope` type is `'trips' | 'restaurants' | 'activities' | 'commands' | null`. Only two entity types map to existing scope values:
+
+| entityType | SearchScope auto-set |
+|---|---|
+| `'restaurant'` | `'restaurants'` |
+| `'activity'` | `'activities'` |
+| `'hotel'` | no auto-scope (hotel scope does not exist) |
+| `'flight'` | no auto-scope (flight scope does not exist) |
+
+For `hotel` and `flight` intents, the location is still extracted and passed to discover — the scope pill is just not set. Do **not** extend `SearchScope` in this feature.
+
+---
+
+## Phase 1: Regex + Synonym Table
+
+Lives in `apps/web/lib/parseQueryIntent.ts`. Runs synchronously, no I/O.
+
+### Synonym Map
+
+```ts
+const ENTITY_SYNONYMS: Record<string, ParsedIntent['entityType']> = {
+  // restaurant
+  restaurant: 'restaurant', restaurants: 'restaurant',
+  food: 'restaurant', dining: 'restaurant', eat: 'restaurant',
+  eats: 'restaurant', cafe: 'restaurant', cafes: 'restaurant',
+  bar: 'restaurant', bars: 'restaurant', brunch: 'restaurant',
+  lunch: 'restaurant', dinner: 'restaurant',
+
+  // hotel
+  hotel: 'hotel', hotels: 'hotel', stay: 'hotel',
+  lodging: 'hotel', accommodation: 'hotel', accommodations: 'hotel',
+  hostel: 'hotel', hostels: 'hotel', motel: 'hotel', motels: 'hotel',
+  airbnb: 'hotel', resort: 'hotel', resorts: 'hotel',
+
+  // activity
+  activity: 'activity', activities: 'activity',
+  attraction: 'activity', attractions: 'activity',
+  sights: 'activity', sightseeing: 'activity',
+  tour: 'activity', tours: 'activity',
+  museum: 'activity', museums: 'activity', park: 'activity', parks: 'activity',
+
+  // flight
+  flight: 'flight', flights: 'flight', fly: 'flight',
+  airline: 'flight', airlines: 'flight',
+}
+```
+
+Note: `'things to do'` is handled as a dedicated pattern (see Priority 4 below) because it is a multi-word phrase that would otherwise conflict with the `X to Y` route pattern.
+
+**Location normalization:** `parseQueryIntent` is responsible for title-casing the extracted location before returning it (e.g. `"bakersfield"` → `"Bakersfield"`, `"new york"` → `"New York"`). This ensures consistent casing regardless of whether Phase 1 or Phase 2 produced the result. The LLM prompt instructs Haiku to return location in title case. Phase 1 applies `toTitleCase(location)` to the regex capture before returning.
+
+### Patterns (evaluated in strict priority order)
+
+| Priority | Pattern | Example Input | Output |
+|---|---|---|---|
+| 1 | `trip to X` | "trip to paris" | `{ intent: 'create-trip', location: 'paris' }` |
+| 2 | `new trip` / `create trip` | "create trip" | `{ intent: 'create-trip' }` |
+| 3 | `[entity] in [city]` | "restaurants in bakersfield" | `{ intent: 'entity-search', entityType: 'restaurant', location: 'bakersfield' }` |
+| 4 | `things to do in [city]` | "things to do in nyc" | `{ intent: 'entity-search', entityType: 'activity', location: 'nyc' }` |
+| 5 | `[city] [entity]` | "bakersfield restaurants" | `{ intent: 'entity-search', entityType: 'restaurant', location: 'bakersfield' }` |
+| 6 | `X to Y` (generic route) | "la to sf" | `{ intent: 'route', location: 'sf' }` |
+| 7 | bare location word(s), no entity keyword | "bakersfield" | `{ intent: 'discover', location: 'bakersfield' }` |
+| — | no match | "good vibes only" | `{ intent: 'unknown', rawQuery }` → Phase 2 |
+
+**Important:** Patterns 3 and 4 must be evaluated **before** Pattern 6 to prevent "things to do in nyc" from being misclassified as a route (origin: "things", destination: "do in nyc").
+
+If any pattern matches, return immediately without calling any API.
+
+---
+
+## Phase 2: LLM Fallback
+
+Only fires when Phase 1 returns `intent: 'unknown'`.
+
+### Session Cache (checked before firing)
+
+Before making the API call, check `sessionStorage` for a cached result:
+
+```ts
+const CACHE_KEY = (q: string) => `parse-intent:${q.toLowerCase().trim()}`
+```
+
+If found, return cached `ParsedIntent` immediately. Store the API response to cache on success.
+
+### API Route
+
+**`apps/web/app/api/parse-intent/route.ts`**
+
+- Accepts `GET /api/parse-intent?q=<query>`
+- Requires `Authorization: Bearer <token>` header (validated against Supabase session)
+- Calls Claude Haiku (`claude-haiku-4-5-20251001`) via Anthropic SDK (`@anthropic-ai/sdk`)
+- Returns `ParsedIntent` JSON on success
+- Returns `{ intent: 'unknown', rawQuery: q }` on any error (never throws to client)
+
+**Auth failure:** If the `Authorization` header is missing or invalid, return the same graceful fallback shape with status 200 (not 401) — this ensures the client always gets a usable `ParsedIntent` and never surfaces an auth error in the search UI.
+
+**Error response (all failure modes):** `{ intent: 'unknown', location: null, entityType: null, rawQuery: "<q>" }` with status 200. The client always gets a usable `ParsedIntent` — errors degrade gracefully to raw query pass-through.
+
+### LLM Prompt
+
+```
+You are a travel search intent parser. Extract structured intent from a search query.
+
+Return ONLY valid JSON — no explanation, no markdown, no code fences.
+
+Schema:
+{
+  "intent": "discover" | "entity-search" | "create-trip" | "route" | "unknown",
+  "location": string | null,
+  "entityType": "restaurant" | "hotel" | "activity" | "flight" | null
+}
+
+Rules:
+- "discover": user wants to explore a destination with no specific entity type
+- "entity-search": user wants a specific category of place in a location
+- "create-trip": user wants to plan or start a trip
+- "route": user mentions two places (origin to destination)
+- "unknown": none of the above
+
+Query: "<user_query>"
+```
+
+### Dependency
+
+`@anthropic-ai/sdk` must be added to `apps/web/package.json` (not shared — this is web-only).
+
+### Environment Variable
+
+`ANTHROPIC_API_KEY` — server-side only, never exposed to the client. Must be set in `.env.local` for development and in the production deployment environment.
+
+---
+
+## Changes to `useSpotlightSearch.ts`
+
+### 1. Intent parsing query (replaces manual regex memos)
+
+Use `useQuery` for the async intent parse so React Query handles deduplication and caching:
+
+```ts
+const { data: parsedIntent, isLoading: intentLoading } = useQuery({
+  queryKey: ['parse-intent', debouncedQuery],
+  queryFn: () => parseQueryIntent(debouncedQuery, token!),
+  enabled: debouncedQuery.length >= 3 && !!token,
+  staleTime: Infinity, // intent for a given query never changes
+})
+```
+
+**Replaces `createTripIntent` and `routeIntent` memos.** These two `useMemo` blocks and the `actionResults` memo that feeds them must be replaced by a single `actionResults` driven by `parsedIntent`:
+
+```ts
+const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
+  if (!parsedIntent) return {}
+  const actions: SpotlightResult[] = []
+
+  if (parsedIntent.intent === 'create-trip') {
+    actions.push({
+      id: 'create-trip',
+      type: 'action',
+      title: parsedIntent.location
+        ? `Create trip to ${parsedIntent.location}`
+        : 'Create New Trip',
+      subtitle: 'Start planning a new adventure',
+      href: '',
+      score: 100,
+      metadata: { prefillDestination: parsedIntent.location ?? '' },
+    })
+  }
+
+  if (parsedIntent.intent === 'route' && discoverData?.route) {
+    const { origin, destination } = discoverData.route
+    actions.push({
+      id: 'create-trip-route',
+      type: 'action',
+      title: `Plan trip: ${origin} to ${destination}`,
+      subtitle: 'Start planning with destinations pre-filled',
+      href: '',
+      score: 100,
+      metadata: { prefillDestination: destination, origin },
+    })
+  }
+
+  return actions.length ? { action: actions } : {}
+}, [parsedIntent, discoverData?.route])
+```
+
+Note: the route action still depends on `discoverData?.route` because the Lambda's route parsing (`X to Y` extraction) is what populates the origin/destination pair in the response. The client's `parsedIntent.intent === 'route'` is the gate; the Lambda still provides the actual place names.
+
+### 2. Discover query — use parsed location
+
+```ts
+const discoverLocation = parsedIntent?.location ?? debouncedQuery
+
+const { data: discoverData } = useQuery({
+  queryKey: ['discover', discoverLocation],   // keyed on location, not raw query
+  queryFn: () => fetchDiscover(discoverLocation, token!),
+  enabled: shouldSearch && !scope && parsedIntent !== undefined,
+  staleTime: 60_000,
+})
+```
+
+This ensures "bakersfield restaurants" and "restaurants in bakersfield" both resolve to the same `['discover', 'bakersfield']` cached entry.
+
+### 3. Auto-scope from entityType
+
+```ts
+const ENTITY_TYPE_TO_SCOPE: Partial<Record<string, SearchScope>> = {
+  restaurant: 'restaurants',
+  activity: 'activities',
+}
+
+useEffect(() => {
+  if (parsedIntent?.entityType && scope === null) {
+    const autoScope = ENTITY_TYPE_TO_SCOPE[parsedIntent.entityType]
+    if (autoScope) setScope(autoScope)
+  }
+}, [parsedIntent?.entityType, scope, setScope])
+```
+
+The user can still manually override the auto-set scope via the scope pill UI — this effect only fires when `scope` is `null`.
+
+### 5. isLoading includes intentLoading
+
+The `isLoading` value returned from `useSpotlightSearch` must include the intent query's loading state:
+
+```ts
+isLoading: tripSearchLoading || entityLoading || discoverLoading || intentLoading
+```
+
+This covers the window where `parsedIntent` is being resolved (Phase 2 LLM call) but the discover query hasn't fired yet. Without it, the UI shows no loading indicator for up to ~500ms during Phase 2 resolution.
+
+### 4. Interaction with `@scope` prefix typing
+
+`SpotlightInput.tsx` already sets scope via `@restaurants` / `@activities` prefix — this takes priority because it calls `setScope` directly. The auto-scope effect only fires when `scope === null`, so a manually typed prefix always wins.
+
+---
+
+## Changes to `services/discover.ts`
+
+None required. The Lambda's `parseQuery()` function is left intact as a safety net for callers that bypass the intent layer. With the new client-side parsing, the Lambda will receive clean location strings in the common case and its own route detection becomes a fallback only.
+
+---
+
+## Deployment Notes
+
+- `/api/parse-intent` is a Next.js API route — no new Lambda or SST resource needed
+- `ANTHROPIC_API_KEY` must be set:
+  - Locally: `apps/web/.env.local`
+  - Production: in the deployment environment (user will provide the key value — do not commit it)
+- Install `@anthropic-ai/sdk` in `apps/web`: `npm install --workspace=apps/web @anthropic-ai/sdk`
+
+---
+
+## What Is Not Changing
+
+- `useContextSearch` — still receives the raw query (vector search works better with natural language)
+- `fetchEntitySearch` — still receives the raw query (Postgres full-text handles it well)
+- `SearchScope` type — not extended in this feature
+- `services/discover.ts` Lambda — no redeployment required
+- Scope pill UI — users can still manually override auto-detected scope
+
+---
+
+## Testing
+
+- Unit tests for `parseQueryIntent` (Phase 1 only — no I/O) covering:
+  - All 7 pattern priorities, including "things to do in X" before route pattern
+  - Synonym variants for each entity type
+  - Edge cases: "new trip", bare city name, no-match fallback
+- Test that Phase 2 is NOT called when Phase 1 matches
+- Test session cache hit prevents duplicate LLM calls
+- Test Phase 2 failure returns `{ intent: 'unknown', rawQuery }` gracefully
+- Manual QA:
+  - "bakersfield restaurants" → destination card "Bakersfield", scope auto-set to restaurants
+  - "restaurants in bakersfield" → same as above
+  - "things to do in nyc" → destination "NYC", scope auto-set to activities
+  - "hotel in miami" → destination "Miami", no scope set (hotel not in SearchScope)
+  - "flights to london" → destination "London", no scope set
+  - "somewhere to eat in bakersfield" → Haiku extracts restaurant + bakersfield
+  - Existing: trip search, commands, entity search — no regressions
+
+---
+
+## Success Criteria
+
+1. "bakersfield restaurants" → destination card shows "Bakersfield", scope auto-set to restaurants
+2. "restaurants in bakersfield" → identical result to above (same React Query cache entry)
+3. "things to do in nyc" → destination "NYC", scope auto-set to activities
+4. Novel phrasing ("somewhere to eat in bakersfield") → Haiku returns structured intent correctly
+5. LLM is not called when Phase 1 matches
+6. Phase 2 failure degrades gracefully — raw query passed to discover, no crash
+7. No regressions on existing trip search, entity search, and command search

--- a/docs/superpowers/specs/2026-03-26-entity-detail-pages-design.md
+++ b/docs/superpowers/specs/2026-03-26-entity-detail-pages-design.md
@@ -1,0 +1,434 @@
+# Entity Detail Pages — Design Spec
+
+**Date:** 2026-03-26
+**Routes:** `/place/[id]`, `/hotel/[id]`, `/activity/[id]`, `/destination/[name]`
+
+## Goal
+
+Give every entity type (places, hotels, activities, destinations) a dedicated, shareable detail page with a consistent layout shell and type-specific content sections.
+
+## Architecture: Shared Entity Shell + Type-Specific Sections (Option A)
+
+All four routes share a common layout shell. Type-specific content lives in dedicated section components per entity type.
+
+### Shared Components
+
+| Component | Purpose |
+|-----------|---------|
+| `EntityHero` | Full-bleed image carousel (16:9), bottom gradient, Lustria title, overline (type + location), rating/price badges, dot indicators |
+| `EntityActionsBar` | "Add to Trip" dropdown, favorite heart toggle, share button |
+| `EntityMap` | Leaflet map with marker, address text, Google Maps external link |
+| `EntityBreadcrumb` | Hierarchical breadcrumb (e.g. Places > Paris > Sandrini's) |
+| `NearbySection` | Horizontal scroll of related entity cards |
+
+### Shared Shell Layout
+
+```
+EntityBreadcrumb
+EntityHero
+EntityActionsBar
+-- Type-specific sections --
+EntityMap
+NearbySection
+```
+
+---
+
+## Route 1: Place Detail (`/place/[id]`)
+
+**For:** Restaurants, cafes, bars, shops, markets.
+
+**Sections (in order):**
+
+1. **About** — Description text + tags as pills
+2. **Quick Info** — 2-column grid: hours, price level (dots), phone (tap-to-call), website (external link), typical visit duration, admission fee
+3. **Tips** — Bulleted list of visitor tips
+4. **Accessibility** — Pill badges (wheelchair accessible, family friendly, etc.)
+
+**Data source:** `PlaceItem` interface via `/api/places`. New `/api/places/[id]` endpoint for single-place fetch.
+
+**Type definition (existing):**
+```typescript
+interface PlaceItem {
+  id: string
+  name: string
+  image: string
+  images?: string[]
+  type: 'destination' | 'attraction' | 'restaurant' | 'experience' | 'event'
+  rating: number
+  tagline: string
+  category: string
+  description?: string
+  tags?: string[]
+  latitude?: number
+  longitude?: number
+  priceLevel?: 1 | 2 | 3 | 4
+  hours?: string
+  phone?: string
+  website?: string
+  reviewCount?: number
+  address?: string
+  bestTimeToVisit?: string
+  duration?: string
+  admissionFee?: string
+  tips?: string[]
+  accessibility?: string[]
+  nearbyPlaces?: string[]
+}
+```
+
+---
+
+## Route 2: Hotel Detail (`/hotel/[id]`)
+
+**For:** Hotels, hostels, resorts, Airbnbs.
+
+**Sections (in order):**
+
+1. **Overview** — Description, star rating display, guest rating score, tags as pills
+2. **Stay Details** — 2-column grid: address, price per night, check-in/out times, phone, website
+3. **Guest Ratings** — Overall score + 5 subcategory bars (cleanliness, service, location, comfort, value) with visual progress bars and review count
+4. **Rooms** — Card per room type: photo, room name, bed config, size, max guests, price/night, feature list, amenity chips
+5. **Amenities** — Grouped by category (Room, Dining, Wellness, Services) with icon per item
+
+**Data source:** `HotelSearchResult` / `MockHotelDetail` interfaces. New `/api/hotels/[id]` endpoint. Existing `HotelSection` and `HotelListView` components have much of this UI — extract and adapt.
+
+**Key types (existing):**
+```typescript
+interface HotelData {
+  name: string
+  address: string | null
+  latitude: number | null
+  longitude: number | null
+  check_in: string
+  check_out: string
+  price_per_night: number | null
+  total_price: number | null
+  currency: string | null
+  rating: number | null
+  star_rating: number | null
+  image_url: string | null
+  booking_ref: string | null
+  offer_id: string | null
+}
+
+interface RoomType {
+  type: string
+  beds: string
+  size: string
+  guests: number
+  price: number
+  features?: string[]
+  image: string
+  images?: string[]
+  amenities?: string[]
+}
+```
+
+---
+
+## Route 3: Activity Detail (`/activity/[id]`)
+
+**For:** Tours, experiences, attractions, events.
+
+**Sections (in order):**
+
+1. **About** — Description, AI recommendation reason (if source: 'ai', shown in a tinted callout card), tags as pills
+2. **Details** — 2-column grid: duration, price per person, meeting point, available times, group size, languages
+3. **What's Included** — Checklist with check/cross icons for included/not-included items
+4. **Tips** — Bulleted visitor tips
+5. **Accessibility** — Pill badges
+
+**Data source:** `SuggestionCard` interface via `/api/suggest`. New `/api/activities/[id]` endpoint. Extend `SuggestionCard` with optional fields:
+
+See standalone `ActivityDetail` type in the Type Definitions section below.
+
+---
+
+## Route 4: Destination Detail (`/destination/[name]`)
+
+**For:** Cities, regions, countries.
+
+**Enhances** the existing `/destination/[name]` page which currently only shows matching user trips.
+
+**Sections (in order):**
+
+1. **Overview** — Description text, tags as pills (Europe, Culture, Romance, etc.)
+2. **Quick Facts** — 2-column grid: country, language, currency, timezone, best time to visit, budget level
+3. **Your Trips Here** — Existing trip cards for this destination + "Plan a new trip to [destination]" CTA
+4. **Top Places** — Horizontal scroll of PlaceCards, "View all places in [destination]" link
+5. **Top Activities** — Horizontal scroll of ActivityCards, "View all activities in [destination]" link
+6. **Where to Stay** — Horizontal scroll of HotelCards, "View all hotels in [destination]" link
+
+**Actions bar difference:** Shows "Plan a Trip" button instead of "Add to Trip".
+
+**Data source:** New `/api/destinations/[name]` endpoint for metadata (description, quick facts). Top places/activities/hotels from existing `/api/places` and `/api/suggest` endpoints filtered by destination. Existing trip query for user's trips.
+
+**New type:**
+```typescript
+interface DestinationDetail {
+  name: string
+  country: string
+  description: string
+  language: string
+  currency: string
+  timezone: string
+  bestTimeToVisit: string
+  budgetLevel: 1 | 2 | 3 | 4
+  tags: string[]
+  image: string
+  images?: string[]
+  latitude: number
+  longitude: number
+  population?: string
+}
+```
+
+---
+
+## New API Endpoints
+
+| Endpoint | Method | Source | Cache |
+|----------|--------|-------|-------|
+| `/api/places/[id]` | GET | Existing places API, fetch by ID | 1h browser, 24h stale |
+| `/api/hotels/[id]` | GET | Foursquare/SerpAPI enrichment | 1h browser, 24h stale |
+| `/api/activities/[id]` | GET | SerpAPI + enrichment | 1h browser, 24h stale |
+| `/api/destinations/[name]` | GET | Hardcoded metadata + aggregation | 1h browser, 24h stale |
+
+---
+
+## Design System Application
+
+All pages follow the Travyl product design system (Context B):
+
+- **Hero:** Full-bleed photography, `object-fit: cover`, bottom gradient `linear-gradient(to top, #0f1d30 0%, transparent 60%)`, white text only on photos
+- **Title:** Lustria serif, `text-4xl font-serif font-normal tracking-wide`, white on hero
+- **Overline:** Satoshi, uppercase, `text-xs font-medium tracking-widest`, `rgba(255,255,255,0.7)` on hero
+- **Section headings:** Lustria, `text-2xl font-serif font-normal text-[#1e3a5f]`
+- **Body/UI text:** Satoshi, `font-sans`, Gray[900] for primary, Gray[500] for secondary
+- **Cards:** `rounded-xl border border-gray-200` with hover `border-gray-300`
+- **CTAs:** Blue[600] `#003594` primary, Amber `#F59E0B` for prominent actions
+- **Tags/pills:** `rounded-full bg-gray-100 text-gray-600 text-xs px-3 py-1`
+- **Icons:** iconoir-react (not lucide — per project convention)
+- **Rating badges:** Navy bg with white text, `rounded-lg`
+- **Price dots:** Filled/unfilled circles for price level visualization
+- **Map:** Leaflet with navy-tinted marker
+
+---
+
+## File Structure
+
+```
+apps/web/
+  app/(main)/
+    place/[id]/page.tsx          # Place detail route
+    hotel/[id]/page.tsx          # Hotel detail route
+    activity/[id]/page.tsx       # Activity detail route
+    destination/[name]/page.tsx  # Enhanced destination route (existing)
+  app/api/
+    places/[id]/route.ts         # Single place API
+    hotels/[id]/route.ts         # Single hotel API
+    activities/[id]/route.ts     # Single activity API
+    destinations/[name]/route.ts # Destination metadata API
+  components/entity/
+    EntityHero.tsx               # Shared hero with image carousel
+    EntityActionsBar.tsx         # Shared actions (add to trip, fav, share)
+    EntityMap.tsx                # Shared Leaflet map section
+    EntityBreadcrumb.tsx         # Shared breadcrumb
+    NearbySection.tsx            # Shared horizontal scroll of related cards
+    EntitySection.tsx            # Shared section wrapper (heading + content)
+    EntityQuickInfo.tsx          # Shared 2-col info grid
+    EntityTagList.tsx            # Shared tag pills display
+  components/entity/place/
+    PlaceAbout.tsx
+    PlaceQuickInfo.tsx
+    PlaceTips.tsx
+    PlaceAccessibility.tsx
+  components/entity/hotel/
+    HotelOverview.tsx
+    HotelStayDetails.tsx
+    HotelGuestRatings.tsx
+    HotelRooms.tsx
+    HotelAmenities.tsx
+  components/entity/activity/
+    ActivityAbout.tsx
+    ActivityDetails.tsx
+    ActivityInclusions.tsx
+    ActivityTips.tsx
+    ActivityAccessibility.tsx
+  components/entity/destination/
+    DestinationOverview.tsx
+    DestinationQuickFacts.tsx
+    DestinationTrips.tsx
+    DestinationTopPlaces.tsx
+    DestinationTopActivities.tsx
+    DestinationWhereToStay.tsx
+
+packages/shared/src/
+  types/index.ts                 # Add ActivityDetail, DestinationDetail types
+```
+
+---
+
+## Image Strategy
+
+All entity pages use real photography sourced from:
+1. **Foursquare API** — primary source for place/hotel photos (already integrated)
+2. **SerpAPI google_images** — enrichment for suggestions (already integrated)
+3. **Unsplash fallbacks** — high-quality travel photography when API images unavailable, using curated category-based URLs (existing pattern in `HotelListView`)
+
+Hero images are `object-fit: cover` in 16:9 containers. Carousel supports 1-10 images with dot indicators and arrow navigation on hover.
+
+---
+
+## States
+
+### Loading
+Each page renders a skeleton matching its layout: hero placeholder (gray shimmer, 16:9), action bar placeholders, then type-specific section skeletons (text lines, info grid cells, card placeholders). Use Tailwind `animate-pulse` on `bg-gray-200` blocks.
+
+### Error (404)
+If the API returns no data, show a centered empty state: illustration placeholder, "We couldn't find this [place/hotel/activity/destination]" heading, and a "Browse [entity type]" link back to the relevant listing page.
+
+### Error (500 / network)
+Show a centered error state with "Something went wrong" and a "Try again" button that refetches.
+
+### Empty optional sections
+Sections with no data (tips, accessibility, rooms, amenities, inclusions) are hidden entirely — no empty placeholders.
+
+---
+
+## SEO & Metadata
+
+All four pages use Next.js `generateMetadata` for server-side meta tags:
+
+- `title`: "[Entity Name] - [Location] | Travyl"
+- `description`: First 160 chars of description or tagline
+- `og:image`: First image from the entity's images array
+- `og:type`: "website"
+- Canonical URL: the page's own URL
+
+Pages are server components that fetch initial data server-side (via direct API call, not React Query) for SSR. Client-side React Query hydrates from that initial data for interactivity.
+
+---
+
+## Auth
+
+All four pages are **public** — viewable without login. Auth-gated interactions:
+- "Add to Trip" button: shows login prompt if unauthenticated
+- "Favorite" heart: shows login prompt if unauthenticated
+- "Your Trips Here" section on destination page: hidden if unauthenticated
+
+---
+
+## Responsive Behavior
+
+- **Hero:** Full-width at all breakpoints. 16:9 on desktop, 4:3 on mobile for taller image.
+- **Quick Info / Details grids:** 2 columns on `md+`, 1 column on mobile.
+- **Horizontal scroll sections (NearbySection, Top Places, etc.):** Snap-scroll on mobile, arrow navigation on desktop.
+- **EntityActionsBar:** Horizontal row on desktop, stacked or sticky bottom bar on mobile.
+- **Section headings and body:** Scale down one step on mobile (h2 from 22px to 20px, body stays 14px).
+
+---
+
+## Nearby / Related Entities
+
+`NearbySection` fetches related entities using a proximity query: `/api/places?lat={lat}&lng={lng}&limit=8&exclude={currentId}`. For hotels and activities, the same pattern applies to their respective APIs. The component accepts a generic `items` prop with `{ id, name, image, type, rating, href }` shape so it works across all entity types.
+
+---
+
+## Image Normalization
+
+Each entity type maps its image fields to a common `EntityHero` prop:
+
+| Entity Type | Primary Image | Image Array | Normalized to |
+|-------------|--------------|-------------|---------------|
+| PlaceItem | `image` | `images` | `images: [image, ...(images ?? [])]` |
+| HotelData | `image_url` | `images` | `images: [image_url, ...(images ?? [])]` |
+| ActivityDetail | `imageUrl` | `imageUrls` | `images: [imageUrl, ...(imageUrls ?? [])]` |
+| DestinationDetail | `image` | `images` | `images: [image, ...(images ?? [])]` |
+
+Each page normalizes before passing to `EntityHero`. No normalization layer in the shared component itself.
+
+---
+
+## Existing Component Migration
+
+The existing `EntityHero`, `EntityActionsBar`, `EntityBreadcrumb`, `EntitySection`, and `EntityMap` components in `apps/web/components/entity/` were built for the trip hotel detail context and do NOT match this spec. They will be **replaced** with new implementations matching the designs above. Key changes:
+- All icons migrated from `lucide-react` to `iconoir-react`
+- `EntityHero`: simple carousel -> full-bleed hero with gradient, Lustria title, overline, badges
+- `EntityActionsBar`: edit/remove/share -> add-to-trip/favorite/share
+- `EntityBreadcrumb`: back link -> hierarchical breadcrumb
+
+---
+
+## Data Source Strategy
+
+### Places (`/api/places/[id]`)
+Fetches from existing backend places API by ID. The `/api/places` route already returns `PlaceItem` — the single-entity endpoint filters to one result.
+
+### Hotels (`/api/hotels/[id]`)
+Uses Foursquare `venues/{id}` endpoint for single-venue lookup (the integration already exists in `services/lib/foursquare.ts`). Falls back to SerpAPI `google_local` search by name + coordinates if Foursquare has no match. Hotel IDs are Foursquare venue IDs (strings), resolving the `HotelSearchResult.id` number mismatch — the detail page uses Foursquare string IDs as canonical.
+
+### Activities (`/api/activities/[id]`)
+Activity IDs are SerpAPI `place_id` values (prefixed `serp-`). The endpoint re-fetches from SerpAPI using `place_id` for stable lookups. Extended fields (meetingPoint, groupSize, languages, inclusions) are populated from SerpAPI structured data when available, with graceful `undefined` fallback for fields not returned.
+
+### Destinations (`/api/destinations/[name]`)
+Hardcoded metadata for ~100 popular destinations (matching the existing 99-city lookup table in `/api/places`). For unknown destinations, falls back to Nominatim geocoding for coordinates + basic info, with description set to `null` (the Overview section hides if no description).
+
+---
+
+## Type Definitions
+
+`ActivityDetail` is a standalone interface (not extending `SuggestionCard`) to avoid coupling:
+
+```typescript
+interface ActivityDetail {
+  id: string
+  name: string
+  category: ActivityCategory
+  imageUrl: string
+  imageUrls?: string[]
+  duration: number
+  price: number | null
+  currency: string
+  rating: number | null
+  location: string
+  latitude: number
+  longitude: number
+  description: string
+  source: 'ai' | 'search'
+  relevanceScore: number
+  reason?: string
+  // Extended fields
+  meetingPoint?: string
+  availableTimes?: string[]
+  groupSize?: number
+  languages?: string[]
+  included?: string[]
+  notIncluded?: string[]
+  tips?: string[]
+  accessibility?: string[]
+  address?: string
+  phone?: string
+  website?: string
+}
+```
+
+---
+
+## Destination Slug Normalization
+
+Destination routes use URL-safe slugs: lowercase, hyphens for spaces, no special characters. Example: "New York" -> `/destination/new-york`. The API endpoint normalizes input: `decodeURIComponent(slug).replace(/-/g, ' ')` for lookup. Display name uses the canonical name from the metadata store.
+
+---
+
+## Navigation / Linking
+
+Entities are linked from:
+- `/places` browse page cards -> `/place/[id]`
+- Trip calendar suggestion cards -> `/activity/[id]` or `/place/[id]`
+- Trip hotels tab -> `/hotel/[id]`
+- Destination page cross-links -> all entity types
+- NearbySection cards -> respective entity detail pages
+- Search results (future) -> any entity type
+- Shareable URLs for direct access

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -547,6 +547,62 @@ export interface RecommendationSection {
   suggestions: SuggestionCard[]
 }
 
+export interface ActivityDetail {
+  id: string
+  name: string
+  category: ActivityCategory
+  imageUrl: string
+  imageUrls?: string[]
+  duration: number
+  price: number | null
+  currency: string
+  rating: number | null
+  location: string
+  latitude: number
+  longitude: number
+  description: string
+  source: 'ai' | 'search'
+  relevanceScore: number
+  reason?: string
+  meetingPoint?: string
+  availableTimes?: string[]
+  groupSize?: number
+  languages?: string[]
+  included?: string[]
+  notIncluded?: string[]
+  tips?: string[]
+  accessibility?: string[]
+  address?: string
+  phone?: string
+  website?: string
+}
+
+export interface DestinationDetail {
+  name: string
+  country: string
+  description: string
+  language: string
+  currency: string
+  timezone: string
+  bestTimeToVisit: string
+  budgetLevel: 1 | 2 | 3 | 4
+  tags: string[]
+  image: string
+  images?: string[]
+  latitude: number
+  longitude: number
+  population?: string
+}
+
+export interface NormalizedEntity {
+  name: string
+  images: string[]
+  overline: string
+  rating: number | null
+  priceLevel?: number | null
+  href: string
+}
+
 export interface UserAwareness {
   userId: string;
   name: string;

--- a/planning/TRA-279.md
+++ b/planning/TRA-279.md
@@ -1,0 +1,19 @@
+# TRA-279 — Entity Detail Pages
+
+## Goal
+Add dedicated detail pages for places, hotels, activities, and destinations with shared layout shell and type-specific sections.
+
+## Linear
+https://linear.app/travyl/issue/TRA-279/entity-detail-pages-place-hotel-activity-destination
+
+## Spec
+`docs/superpowers/specs/2026-03-26-entity-detail-pages-design.md`
+
+## Completed
+- [x] Design spec written and reviewed
+
+## In Progress
+- [ ] Implementation plan
+
+## Known Issues
+- None yet


### PR DESCRIPTION
## Summary

- Add dedicated detail pages for places, hotels, activities, and destinations with shareable URLs and SSR metadata
- Build 12 shared entity components (Hero, ActionsBar, Breadcrumb, Section, Map, QuickInfo, TagList, NearbySection, Skeleton, Error, Tips, Accessibility)
- Add 4 API endpoints for single-entity fetch (`/api/places/[id]`, `/api/hotels/[id]`, `/api/activities/[id]`, `/api/destinations/[name]`)
- Wire navigation links from existing suggestion drawer, place overlay, and hotel cards to new detail pages
- Rewrite `/destination/[name]` with rich sections (overview, quick facts, user trips, top places/activities/hotels)

## New Routes

| Route | Purpose |
|-------|---------|
| `/place/[id]` | Restaurant, cafe, bar, shop detail |
| `/hotel/[id]` | Hotel detail with rooms, ratings, amenities |
| `/activity/[id]` | Tour, experience, attraction detail |
| `/destination/[name]` | City overview with aggregated content |

## Test plan

- [ ] Navigate to `/destination/paris` — verify hero, quick facts, top places/activities/hotels sections render
- [ ] Navigate to `/place/{id}` from the places browse page overlay — verify quick info, tips, map
- [ ] Navigate to `/hotel/{id}` from a trip's hotel card — verify guest ratings, rooms, amenities
- [ ] Navigate to `/activity/{id}` from the calendar suggestion drawer "View full details" link
- [ ] Verify 404 page renders for invalid IDs (e.g. `/place/nonexistent`)
- [ ] Verify page titles and OG metadata render correctly (view source or browser dev tools)
- [ ] Verify "Add to Trip" and "Favorite" buttons prompt sign-in when logged out
- [ ] Test responsive layout — hero aspect ratio changes from 4:3 (mobile) to 16:9 (desktop)

Closes TRA-279