### PR TITLE
Feat: Add Privacy Policy, Terms of Service, About Us pages — fix footer links (TRA-273)

### DIFF
--- a/apps/web/app/(main)/about/page.tsx
+++ b/apps/web/app/(main)/about/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "About Us",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-16 text-foreground">
+      <h1 className="text-4xl font-bold mb-6" style={{ fontFamily: "var(--font-brand)" }}>
+        About Travyl
+      </h1>
+
+      <div className="space-y-6 text-[15px] leading-relaxed text-foreground/85">
+        <p className="text-lg text-foreground/90">
+          Travyl is a collaborative travel planning platform that helps you go from idea to
+          itinerary in minutes.
+        </p>
+
+        <p>
+          We believe trip planning should be exciting, not exhausting. Whether you&apos;re mapping
+          out a solo backpacking adventure, coordinating a family vacation, or organizing a group
+          trip with friends, Travyl gives you everything in one place: destinations, day-by-day
+          itineraries, hotels, flights, restaurants, packing lists, and budgets.
+        </p>
+
+        <p>
+          Built for real collaboration, Travyl lets you plan together in real time. Invite your
+          travel partners, edit the calendar simultaneously, vote on activities, and keep everyone on
+          the same page — literally.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3 text-foreground">What makes Travyl different</h2>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>
+            <strong>AI-powered planning</strong> — Tell us where you want to go and we&apos;ll
+            generate a personalized itinerary with activities, restaurants, and logistics tailored to
+            your preferences.
+          </li>
+          <li>
+            <strong>Real-time collaboration</strong> — Plan together on a shared calendar. See
+            changes as they happen, no refresh needed.
+          </li>
+          <li>
+            <strong>Everything in one place</strong> — Hotels, flights, restaurants, activities,
+            packing lists, budgets, and notes. No more juggling 10 tabs and a shared spreadsheet.
+          </li>
+          <li>
+            <strong>Works everywhere</strong> — Available on web, iOS, and Android. Your trips sync
+            across all your devices.
+          </li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3 text-foreground">Get in touch</h2>
+        <p>
+          Have questions, feedback, or partnership inquiries? Reach out at{" "}
+          <a href="mailto:hello@gotravyl.com" className="text-[#1e3a5f] dark:text-[#60a5fa] underline">
+            hello@gotravyl.com
+          </a>
+        </p>
+        <p>
+          Follow us on{" "}
+          <a
+            href="https://instagram.com/travyl"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#1e3a5f] dark:text-[#60a5fa] underline"
+          >
+            Instagram
+          </a>{" "}
+          for travel inspiration and product updates.
+        </p>
+
+        <div className="mt-10 pt-6 border-t border-foreground/10">
+          <p className="text-sm text-muted-foreground">
+            <Link href="/privacy" className="underline hover:text-foreground transition-colors">Privacy Policy</Link>
+            {" "}&middot;{" "}
+            <Link href="/terms" className="underline hover:text-foreground transition-colors">Terms of Service</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(main)/privacy/page.tsx
+++ b/apps/web/app/(main)/privacy/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-16 text-foreground">
+      <h1 className="text-4xl font-bold mb-2" style={{ fontFamily: "var(--font-brand)" }}>
+        Privacy Policy
+      </h1>
+      <p className="text-sm text-muted-foreground mb-10">Last updated: March 26, 2026</p>
+
+      <div className="space-y-8 text-[15px] leading-relaxed text-foreground/85">
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">1. Introduction</h2>
+          <p>
+            Travyl (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) operates the website at{" "}
+            <strong>gotravyl.com</strong> and the Travyl mobile applications for iOS and Android
+            (collectively, the &quot;Service&quot;). This Privacy Policy explains how we collect,
+            use, disclose, and safeguard your information when you use our Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">2. Information We Collect</h2>
+
+          <h3 className="text-base font-semibold mt-4 mb-2 text-foreground">2.1 Account Information</h3>
+          <p>When you create an account, we collect:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Email address</li>
+            <li>Display name</li>
+            <li>Profile photo (optional)</li>
+            <li>Authentication data from third-party providers if you sign in via Google, Apple, Facebook, or Microsoft</li>
+          </ul>
+
+          <h3 className="text-base font-semibold mt-4 mb-2 text-foreground">2.2 Trip &amp; Travel Data</h3>
+          <p>When you use Travyl to plan trips, we collect:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Trip details: destinations, dates, budget, number of travelers</li>
+            <li>Itinerary activities: names, times, locations, estimated costs, and notes</li>
+            <li>Packing lists, budget entries, and saved places</li>
+            <li>Travel preferences: travel style, pace, budget range, and cabin class</li>
+          </ul>
+
+          <h3 className="text-base font-semibold mt-4 mb-2 text-foreground">2.3 Usage Data</h3>
+          <p>We automatically collect:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Interaction data (e.g., which suggestions you view, dismiss, or add to your trip) to improve recommendations</li>
+            <li>Device and browser information for compatibility and debugging</li>
+            <li>Audit logs of itinerary changes for collaborative editing features</li>
+          </ul>
+
+          <h3 className="text-base font-semibold mt-4 mb-2 text-foreground">2.4 Cookies &amp; Local Storage</h3>
+          <p>We use:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li><strong>Essential cookies</strong>: Supabase authentication session tokens (required for sign-in)</li>
+            <li><strong>Local storage</strong>: Theme preference (light/dark) and language selection</li>
+          </ul>
+          <p className="mt-2">We do not use advertising or third-party tracking cookies.</p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">3. How We Use Your Information</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>To provide and maintain the Service, including trip planning and itinerary generation</li>
+            <li>To personalize recommendations based on your travel preferences and past interactions</li>
+            <li>To enable real-time collaborative trip editing with other users you invite</li>
+            <li>To send transactional emails (e.g., trip invitations, password resets)</li>
+            <li>To improve the Service through aggregated, anonymized usage analytics</li>
+            <li>To detect and prevent fraud or abuse</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">4. Third-Party Services</h2>
+          <p>
+            We use the following third-party services to operate Travyl. These services may process
+            your data as described:
+          </p>
+          <ul className="list-disc pl-6 mt-2 space-y-2">
+            <li>
+              <strong>Supabase</strong> — Database hosting, user authentication, and real-time
+              collaboration. Your account data, trips, and activities are stored in Supabase&apos;s
+              PostgreSQL database.
+            </li>
+            <li>
+              <strong>Amazon Web Services (AWS)</strong> — Cloud infrastructure including AI-powered
+              features (Amazon Bedrock for trip enrichment and recommendations), caching (DynamoDB),
+              email delivery (SES), and content delivery (CloudFront). Trip context data is processed
+              by AWS services to generate personalized suggestions.
+            </li>
+            <li>
+              <strong>Foursquare, SerpAPI, TripAdvisor</strong> — Location and venue data providers.
+              When you search for destinations or activities, we send location queries (coordinates,
+              place names) to these services to retrieve venue information. We do not send your
+              personal data to these providers.
+            </li>
+            <li>
+              <strong>Pexels</strong> — Destination photography. We fetch images based on destination
+              names. No personal data is shared.
+            </li>
+            <li>
+              <strong>Google, Apple, Facebook, Microsoft</strong> — OAuth authentication providers. If you
+              choose to sign in with these services, we receive your name, email, and profile photo
+              as authorized by you during the sign-in flow.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">5. Data Sharing &amp; Collaboration</h2>
+          <p>
+            <strong>Trip collaborators:</strong> When you invite someone to collaborate on a trip,
+            they can view and edit trip details, itinerary, packing lists, and budget. You control
+            who has access and can revoke access at any time.
+          </p>
+          <p className="mt-2">
+            <strong>Public/link-shared trips:</strong> If you set a trip&apos;s visibility to
+            &quot;link&quot; or &quot;public,&quot; anyone with the link can view (but not edit) the
+            trip. You can change visibility or revoke shared links at any time.
+          </p>
+          <p className="mt-2">
+            We do not sell your personal information to third parties. We do not share your data with
+            advertisers.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">6. Data Retention</h2>
+          <p>
+            We retain your account data for as long as your account is active. Trip data is retained
+            until you delete it. Recommendation cache data expires automatically (typically within 6
+            hours). Interaction data used for personalization expires within 30 days.
+          </p>
+          <p className="mt-2">
+            You can delete your account and all associated data by contacting us at the email below.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">7. Data Security</h2>
+          <p>
+            We implement industry-standard security measures including encrypted connections (TLS),
+            row-level security policies on all database tables, hashed passwords (handled by
+            Supabase Auth), and access-controlled AWS infrastructure. However, no method of
+            transmission over the Internet is 100% secure.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">8. Your Rights</h2>
+          <p>Depending on your jurisdiction, you may have the right to:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Access the personal data we hold about you</li>
+            <li>Request correction of inaccurate data</li>
+            <li>Request deletion of your data</li>
+            <li>Export your trip data</li>
+            <li>Withdraw consent for optional data processing</li>
+          </ul>
+          <p className="mt-2">To exercise these rights, contact us at the email below.</p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">9. Children&apos;s Privacy</h2>
+          <p>
+            Travyl is not intended for children under 13. We do not knowingly collect personal
+            information from children under 13. If you believe we have collected data from a child,
+            please contact us.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">10. Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy from time to time. We will notify you of material
+            changes by posting the new policy on this page and updating the &quot;Last updated&quot;
+            date.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">11. Contact Us</h2>
+          <p>
+            If you have questions about this Privacy Policy or your data, contact us at:{" "}
+            <a href="mailto:privacy@gotravyl.com" className="text-[#1e3a5f] dark:text-[#60a5fa] underline">
+              privacy@gotravyl.com
+            </a>
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(main)/terms/page.tsx
+++ b/apps/web/app/(main)/terms/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-16 text-foreground">
+      <h1 className="text-4xl font-bold mb-2" style={{ fontFamily: "var(--font-brand)" }}>
+        Terms of Service
+      </h1>
+      <p className="text-sm text-muted-foreground mb-10">Last updated: March 26, 2026</p>
+
+      <div className="space-y-8 text-[15px] leading-relaxed text-foreground/85">
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">1. Acceptance of Terms</h2>
+          <p>
+            By accessing or using Travyl (&quot;the Service&quot;), operated at{" "}
+            <strong>gotravyl.com</strong> and through our iOS and Android mobile applications, you
+            agree to be bound by these Terms of Service. If you do not agree, do not use the
+            Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">2. Description of Service</h2>
+          <p>
+            Travyl is a collaborative travel planning platform. The Service allows you to create
+            trips, build day-by-day itineraries, discover destinations and activities, collaborate
+            with other users in real time, and organize travel logistics including packing lists,
+            budgets, and saved places.
+          </p>
+          <p className="mt-2">
+            Travyl does not directly sell or book flights, hotels, or other travel services. When
+            booking links are provided, they redirect to third-party providers. We are not
+            responsible for the accuracy, availability, or pricing of third-party travel services.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">3. User Accounts</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>You must be at least 13 years old to create an account.</li>
+            <li>You are responsible for maintaining the security of your account credentials.</li>
+            <li>You may sign up using email/password or through Google, Apple, Facebook, or Microsoft authentication.</li>
+            <li>You agree to provide accurate and current information when creating your account.</li>
+            <li>We reserve the right to suspend or terminate accounts that violate these terms.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">4. User Content</h2>
+          <p>
+            &quot;User Content&quot; includes trips, itineraries, activities, notes, packing lists,
+            budget entries, saved places, and any other content you create or upload through the
+            Service.
+          </p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>
+              <strong>Ownership:</strong> You retain ownership of your User Content. By using the
+              Service, you grant us a limited, non-exclusive license to store, display, and transmit
+              your content as necessary to operate the Service (e.g., showing your trip to
+              collaborators you invite).
+            </li>
+            <li>
+              <strong>Shared content:</strong> When you invite collaborators to a trip or set a trip
+              to &quot;public&quot; or &quot;link&quot; visibility, you grant those users permission
+              to view and (if granted editor access) modify the trip content.
+            </li>
+            <li>
+              <strong>Deletion:</strong> You may delete your trips and content at any time. Deleted
+              content is removed from our active systems, though it may persist in backups for a
+              limited period.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">5. Acceptable Use</h2>
+          <p>You agree not to:</p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Use the Service for any unlawful purpose</li>
+            <li>Upload content that is defamatory, obscene, or infringes on intellectual property rights</li>
+            <li>Attempt to gain unauthorized access to other users&apos; accounts or data</li>
+            <li>Use automated scripts, bots, or scrapers to access the Service</li>
+            <li>Interfere with or disrupt the Service&apos;s infrastructure</li>
+            <li>Impersonate another person or entity</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">6. AI-Generated Content</h2>
+          <p>
+            Travyl uses artificial intelligence (powered by AWS Bedrock) to generate trip
+            recommendations, activity suggestions, packing list suggestions, and destination
+            enrichment data. This content is provided for informational purposes only.
+          </p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>AI-generated suggestions may contain inaccuracies regarding prices, hours, availability, or other details.</li>
+            <li>You are responsible for verifying the accuracy of any information before making travel decisions or bookings.</li>
+            <li>We do not guarantee the accuracy, completeness, or timeliness of AI-generated content.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">7. Third-Party Services</h2>
+          <p>
+            The Service integrates with third-party providers for venue data (Foursquare,
+            TripAdvisor, SerpAPI), images (Pexels), mapping, weather, and other travel information.
+            We are not responsible for the content, accuracy, or availability of these third-party
+            services.
+          </p>
+          <p className="mt-2">
+            Links to external booking sites (airlines, hotels, etc.) are provided as a convenience.
+            Your transactions with third-party providers are solely between you and those providers.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">8. Intellectual Property</h2>
+          <p>
+            The Travyl name, logo, and all related branding, designs, and software are the property
+            of Travyl and are protected by applicable intellectual property laws. You may not copy,
+            modify, distribute, or create derivative works of the Service without our prior written
+            consent.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">9. Limitation of Liability</h2>
+          <p>
+            To the maximum extent permitted by law, Travyl and its operators shall not be liable for
+            any indirect, incidental, special, consequential, or punitive damages resulting from your
+            use of the Service, including but not limited to:
+          </p>
+          <ul className="list-disc pl-6 mt-2 space-y-1">
+            <li>Travel plans that do not proceed as expected</li>
+            <li>Inaccurate information from AI-generated content or third-party data providers</li>
+            <li>Loss of data due to service interruptions</li>
+            <li>Unauthorized access to your account</li>
+          </ul>
+          <p className="mt-2">
+            The Service is provided &quot;as is&quot; and &quot;as available&quot; without warranties
+            of any kind, express or implied.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">10. Account Termination</h2>
+          <p>
+            You may delete your account at any time by contacting us. We may suspend or terminate
+            your account if you violate these terms or engage in activity that harms the Service or
+            other users. Upon termination, your right to use the Service ceases immediately.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">11. Changes to These Terms</h2>
+          <p>
+            We may update these Terms of Service from time to time. We will notify you of material
+            changes by posting the updated terms on this page and updating the &quot;Last
+            updated&quot; date. Continued use of the Service after changes constitutes acceptance of
+            the new terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">12. Governing Law</h2>
+          <p>
+            These Terms shall be governed by and construed in accordance with the laws of the State
+            of California, without regard to its conflict of law provisions.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3 text-foreground">13. Contact Us</h2>
+          <p>
+            If you have questions about these Terms of Service, contact us at:{" "}
+            <a href="mailto:legal@gotravyl.com" className="text-[#1e3a5f] dark:text-[#60a5fa] underline">
+              legal@gotravyl.com
+            </a>
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/config/homeData.ts
+++ b/packages/shared/src/config/homeData.ts
@@ -99,17 +99,9 @@ export function getCyclicGradient(index: number) {
 // ─── Footer ──────────────────────────────────────────────────
 export const FOOTER_COLUMNS = [
   {
-    heading: 'Products',
-    links: [
-      { label: 'Download App', href: '/download' },
-      { label: 'Help Center', href: '/help' },
-    ],
-  },
-  {
     heading: 'Company',
     links: [
       { label: 'About Us', href: '/about' },
-      { label: 'Careers', href: '/careers' },
       { label: 'Privacy Policy', href: '/privacy' },
       { label: 'Terms of Service', href: '/terms' },
     ],


### PR DESCRIPTION
## Summary
- Add `/privacy` page — accurate Privacy Policy covering all data collection, third-party services (Supabase, AWS, Foursquare, TripAdvisor, SerpAPI, Pexels), OAuth providers (Google, Apple, Facebook, Microsoft), cookies, collaborative features, and user rights
- Add `/terms` page — Terms of Service covering accounts, content ownership, AI-generated content disclaimers, acceptable use, liability limitations, and governing law
- Add `/about` page — company description, differentiators, and contact info
- Remove broken footer links: Download App, Help Center, Careers
- Consolidate footer to single "Company" column: About Us, Privacy Policy, Terms of Service

## Verification
- [x] `/privacy` loads — 0 errors, accurate content verified against codebase
- [x] `/terms` loads — 0 errors, all claims verified
- [x] `/about` loads — 0 errors
- [x] Footer shows only valid links (About Us, Privacy Policy, Terms of Service)
- [x] OAuth providers list includes all 4 (Google, Apple, Facebook, Microsoft) — verified against login page
- [x] No payment processing claims verified — no Stripe/PayPal in codebase

## Test plan
- [ ] Click each footer link — verify no 404s
- [ ] Read Privacy Policy — verify data practices match actual app behavior
- [ ] Read Terms of Service — verify claims are accurate
- [ ] Check mobile footer renders correctly with updated links