### PR TITLE
fix(realtime): replace hand-rolled Yjs sync with @supabase-labs/y-supabase

### DIFF
--- a/apps/web/components/calendar/CalendarDashboard.tsx
+++ b/apps/web/components/calendar/CalendarDashboard.tsx
@@ -113,7 +113,7 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
     ...rawMutations,
     getActivity: (id) => activities.find((a) => a.id === id),
   })
-  const { collaborators, setCurrentView, setSelectedDay } = useCollaboratorPresence({ tripId, userId, userName, disabled: isSharedView })
+  const { collaborators, setSelectedEvent, setCurrentView, setSelectedDay } = useCollaboratorPresence({ tripId, userId, userName, disabled: isSharedView })
   const isLoading = tripLoading || syncLoading
   const error = tripError || syncError
 
@@ -216,6 +216,11 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
   useEffect(() => {
     setCurrentView(viewMode)
   }, [viewMode, setCurrentView])
+
+  // Sync selected activity to presence
+  useEffect(() => {
+    setSelectedEvent(selectedEventId ?? null)
+  }, [selectedEventId, setSelectedEvent])
 
   // Sync selected day to presence
   useEffect(() => {

--- a/apps/web/components/calendar/hooks/useYjsSync.ts
+++ b/apps/web/components/calendar/hooks/useYjsSync.ts
@@ -144,9 +144,10 @@ export function useYjsSync(
       events: Y.YEvent<any>[],
       transaction: Y.Transaction,
     ) => {
-      // Only flush local changes. Remote updates (from broadcast) and hydration
-      // transactions (initial DB load) must not be re-persisted here.
-      const isRemote = transaction.origin === 'remote' || transaction.origin === 'hydration'
+      // Only flush local changes to Supabase. Remote updates from y-supabase
+      // (origin='remote') and persistence hydration (origin=SupabasePersistence
+      // instance) have non-null origins. Local user edits have origin=null.
+      const isRemote = transaction.origin !== null && transaction.origin !== undefined
 
       if (!isRemote) {
         for (const event of events) {
@@ -201,6 +202,49 @@ export function useYjsSync(
     }
   }, [activitiesMap, scheduleFlush, flush])
 
+  // ── Supabase Realtime Postgres Changes ──────────────────
+  // Receive activity changes persisted by OTHER clients.
+  // Uses application-level activity.id (UUID) to update our local Yjs map,
+  // bypassing the Y.Map internal-ID incompatibility that breaks Yjs delta sync.
+  useEffect(() => {
+    const channel = supabase
+      .channel(`activity-pg:${tripId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'activity', filter: `trip_id=eq.${tripId}` },
+        (payload) => {
+          const id: string | undefined =
+            (payload.new as any)?.id ?? (payload.old as any)?.id
+          if (!id) return
+          // Skip activities with pending local edits to avoid overwriting unsaved changes
+          if (dirtyRef.current.has(id)) return
+
+          activitiesMap.doc?.transact(() => {
+            if (payload.eventType === 'DELETE') {
+              activitiesMap.delete(id)
+              return
+            }
+            const row = payload.new as ActivityRow
+            const cal = toCalendarActivity(row, tripStartDateRef.current)
+            let yMap = activitiesMap.get(cal.id)
+            if (!yMap) {
+              yMap = new Y.Map<unknown>()
+              activitiesMap.set(cal.id, yMap)
+            }
+            for (const key of CALENDAR_ACTIVITY_KEYS) {
+              const val = (cal as any)[key]
+              if (val !== undefined) yMap.set(key, val)
+            }
+          }, 'remote')
+        },
+      )
+      .subscribe()
+
+    return () => {
+      channel.unsubscribe()
+    }
+  }, [tripId, activitiesMap])
+
   // ── Tab refocus reconciliation ───────────────────────────
   useEffect(() => {
     if (readOnly) return
@@ -249,7 +293,7 @@ export function useYjsSync(
             activitiesMap.delete(key)
           }
         })
-      })
+      }, 'remote')
     }
 
     document.addEventListener('visibilitychange', handleVisibilityChange)

--- a/apps/web/components/calendar/providers/YjsTripProvider.tsx
+++ b/apps/web/components/calendar/providers/YjsTripProvider.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react'
 import * as Y from 'yjs'
+import { SupabaseProvider } from '@supabase-labs/y-supabase'
 import { supabase } from '@travyl/shared'
 
 interface YjsTripContextValue {
@@ -38,10 +39,6 @@ export function YjsTripProvider({ tripId, children }: YjsTripProviderProps) {
     'connected' | 'reconnecting' | 'disconnected'
   >('disconnected')
 
-  // One Y.Doc per tripId, created synchronously during render so it is
-  // immediately available to context consumers without waiting for an effect.
-  // Replacing docRef here (not in an effect) means consumers always see the
-  // correct doc on the very first render — no second doc swapped in later.
   const docRef = useRef<Y.Doc | null>(null)
   const docTripIdRef = useRef<string>('')
   if (docTripIdRef.current !== tripId) {
@@ -51,70 +48,33 @@ export function YjsTripProvider({ tripId, children }: YjsTripProviderProps) {
   }
   const doc = docRef.current!
 
-  // Destroy the doc when the component unmounts (tripId-change destroys happen in render body above)
   useEffect(() => {
     return () => { docRef.current?.destroy() }
   }, [])
 
   useEffect(() => {
-    let isMounted = true
+    const provider = new SupabaseProvider(`trip:${tripId}`, doc, supabase, {
+      awareness: true,
+      persistence: {
+        table: 'yjs_documents',
+        roomColumn: 'room',
+        stateColumn: 'state',
+        storeTimeout: 1000,
+      },
+    })
 
-    // Load persisted Yjs state from Supabase
-    supabase
-      .from('yjs_documents')
-      .select('content')
-      .eq('id', tripId)
-      .maybeSingle()
-      .then(({ data }) => {
-        if (data?.content && isMounted) {
-          Y.applyUpdate(doc, new Uint8Array(data.content as number[]), 'hydration')
-        }
-      })
+    provider.on('status', (status) => {
+      if (status === 'connected') setConnectionStatus('connected')
+      else if (status === 'connecting') setConnectionStatus('reconnecting')
+      else if (status === 'disconnected') setConnectionStatus('disconnected')
+    })
 
-    // Subscribe to realtime updates from other clients
-    const channel = supabase.channel(`trip:${tripId}`)
-
-    channel
-      .on('broadcast', { event: 'yjs-update' }, ({ payload }) => {
-        if (payload?.update) {
-          Y.applyUpdate(doc, new Uint8Array(payload.update as number[]), 'remote')
-        }
-      })
-      .subscribe((status) => {
-        if (!isMounted) return
-        if (status === 'SUBSCRIBED') setConnectionStatus('connected')
-        else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT')
-          setConnectionStatus('reconnecting')
-        else if (status === 'CLOSED') setConnectionStatus('disconnected')
-      })
-
-    // Broadcast local updates + debounced persist
-    let persistTimeout: ReturnType<typeof setTimeout>
-    const onUpdate = (update: Uint8Array, origin: unknown) => {
-      if (origin === 'remote' || origin === 'hydration') return
-
-      channel.send({
-        type: 'broadcast',
-        event: 'yjs-update',
-        payload: { update: Array.from(update) },
-      })
-
-      clearTimeout(persistTimeout)
-      persistTimeout = setTimeout(() => {
-        const state = Y.encodeStateAsUpdate(doc)
-        supabase
-          .from('yjs_documents')
-          .upsert({ id: tripId, content: Array.from(state) })
-      }, 1000)
-    }
-
-    doc.on('update', onUpdate)
+    provider.on('error', (err) => {
+      console.error('[YjsTripProvider]', err.message)
+    })
 
     return () => {
-      isMounted = false
-      clearTimeout(persistTimeout)
-      doc.off('update', onUpdate)
-      channel.unsubscribe()
+      provider.destroy()
     }
   }, [tripId, doc])
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
+    "@supabase-labs/y-supabase": "^0.1.0",
     "@supabase/ssr": "^0.9.0",
     "@travyl/shared": "*",
     "@types/leaflet": "^1.9.21",
@@ -28,7 +29,6 @@
     "react-dom": "^19.2.3",
     "react-leaflet": "^5.0.0",
     "react-responsive-masonry": "^2.7.1",
-    "y-supabase": "^0.0.4-7-alpha",
     "yjs": "^13.6.30"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       "name": "@travyl/web",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.80.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
+        "@supabase-labs/y-supabase": "^0.1.0",
         "@supabase/ssr": "^0.9.0",
         "@travyl/shared": "*",
         "@types/leaflet": "^1.9.21",
@@ -98,7 +98,6 @@
         "react-dom": "^19.2.3",
         "react-leaflet": "^5.0.0",
         "react-responsive-masonry": "^2.7.1",
-        "y-supabase": "^0.0.4-7-alpha",
         "yjs": "^13.6.30"
       },
       "devDependencies": {
@@ -247,26 +246,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -6848,10 +6827,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase-labs/y-supabase": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@supabase-labs/y-supabase/-/y-supabase-0.1.0.tgz",
+      "integrity": "sha512-1ItaKbcImgy7ueYfJcyVYihqCKi9RAee9MKBV8wcCqSMNsrWvw4ibhW8ai91kWsewsiWzIDXVPONgcUcxagk9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.99.0",
+        "y-protocols": "^1.0.7",
+        "yjs": "^13.6.29"
+      }
+    },
     "node_modules/@supabase/auth-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
-      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.0.tgz",
+      "integrity": "sha512-pdT3ye3UVRN1Cg0wom6BmyY+XTtp5DiJaYnPi6j8ht5i8Lq8kfqxJMJz9GI9YDKk3w1nhGOPnh6Qz5qpyYm+1w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6861,9 +6851,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
-      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.0.tgz",
+      "integrity": "sha512-keLg79RPwP+uiwHuxFPTFgDRxPV46LM4j/swjyR2GKJgWniTVSsgiBHfbIBDcrQwehLepy09b/9QSHUywtKRWQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6872,10 +6862,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
-      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.0.tgz",
+      "integrity": "sha512-xYNvNbBJaXOGcrZ44wxwp5830uo1okMHGS8h8dm3u4f0xcZ39yzbryUsubTJW41MG2gbL/6U57cA4Pi6YMZ9pA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6885,12 +6881,12 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
-      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.0.tgz",
+      "integrity": "sha512-2AZs00zzEF0HuCKY8grz5eCYlwEfVi5HONLZFoNR6aDfxQivl8zdQYNjyFoqN2MZiVhQHD7u6XV/xHwM8mCEHw==",
       "license": "MIT",
       "dependencies": {
-        "@types/phoenix": "^1.6.6",
+        "@supabase/phoenix": "^0.4.0",
         "@types/ws": "^8.18.1",
         "tslib": "2.8.1",
         "ws": "^8.18.2"
@@ -6912,9 +6908,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
-      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.0.tgz",
+      "integrity": "sha512-d4EeuK6RNIgYNA2MU9kj8lQrLm5AzZ+WwpWjGkii6SADQNIGTC/uiaTRu02XJ5AmFALQfo8fLl9xuCkO6Xw+iQ==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -6925,16 +6921,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.98.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
-      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.0.tgz",
+      "integrity": "sha512-r0tlcukejJXJ1m/2eG/Ya5eYs4W8AC7oZfShpG3+SIo/eIU9uIt76ZeYI1SoUwUmcmzlAbgch+HDZDR/toVQPQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.98.0",
-        "@supabase/functions-js": "2.98.0",
-        "@supabase/postgrest-js": "2.98.0",
-        "@supabase/realtime-js": "2.98.0",
-        "@supabase/storage-js": "2.98.0"
+        "@supabase/auth-js": "2.100.0",
+        "@supabase/functions-js": "2.100.0",
+        "@supabase/postgrest-js": "2.100.0",
+        "@supabase/realtime-js": "2.100.0",
+        "@supabase/storage-js": "2.100.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -7471,12 +7467,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
-      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
-      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.17",
@@ -11279,15 +11269,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/exec-async": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
@@ -13719,19 +13700,6 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -18854,12 +18822,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -20350,23 +20312,6 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/y-supabase": {
-      "version": "0.0.4-7-alpha",
-      "resolved": "https://registry.npmjs.org/y-supabase/-/y-supabase-0.0.4-7-alpha.tgz",
-      "integrity": "sha512-T1y8tJuXN1FKHYdQrj/qaQpLp6x7apgoR7wPx7q1OmfQFe3AkPcQKOORkbOFNociwX3F95gdkOjrEsrT2X2zOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/realtime-js": "^2.6.0",
-        "@supabase/supabase-js": "^2.7.0",
-        "debug": "^4.3.2",
-        "events": "^3.3.0",
-        "y-protocols": "^1.0.5",
-        "y-supabase": "^0.0.4-4-alpha"
-      },
-      "peerDependencies": {
-        "yjs": "^13.5.6"
       }
     },
     "node_modules/y18n": {

--- a/supabase/migrations/20260326000004_yjs_documents_y_supabase.sql
+++ b/supabase/migrations/20260326000004_yjs_documents_y_supabase.sql
@@ -1,0 +1,11 @@
+-- supabase/migrations/20260326000004_yjs_documents_y_supabase.sql
+-- Adapt yjs_documents for @supabase-labs/y-supabase library.
+-- The library stores base64-encoded Yjs state in a text column, keyed by room name.
+-- Table had zero rows so this is a safe schema change.
+
+-- 1. Rename id → room to match library default
+ALTER TABLE yjs_documents RENAME COLUMN id TO room;
+
+-- 2. Drop old jsonb content column, add text state column
+ALTER TABLE yjs_documents DROP COLUMN content;
+ALTER TABLE yjs_documents ADD COLUMN state text;


### PR DESCRIPTION
## Summary
- Swap broken `y-supabase` (0.0.4-alpha) for `@supabase-labs/y-supabase` (0.1.0) — community-maintained, modern ESM, proper Supabase SDK compatibility
- `YjsTripProvider` now uses `SupabaseProvider` with built-in broadcast, DB persistence, awareness protocol, and auto-reconnect
- DB migration: rename `yjs_documents` columns (`id`→`room`, `content` jsonb→`state` text) to match library defaults
- Add Postgres Changes listener in `useYjsSync` for cross-client activity row sync
- Wire `setSelectedEvent` in `CalendarDashboard` so collaborators see highlighted activity cards
- Fix `useYjsSync` origin check to handle y-supabase provider origins (non-null = remote)

## Test plan
- [ ] Open trip calendar in two browser tabs with different users
- [ ] Drag an activity in one tab — verify it moves in the other tab
- [ ] Click an activity — verify collaborator avatar appears on the card in the other tab
- [ ] Refresh page — verify activities persist and reload from `yjs_documents`
- [ ] Check browser console for `[YjsTripProvider]` error messages