### PR TITLE
feat: add natural language place search endpoint (GET /places/search)

### DIFF
--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -130,45 +130,39 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    // If search query provided, geocode it first to get coordinates
-    let searchLat = lat
-    let searchLng = lng
-    if (q) {
-      // Check if the query matches a known city first (instant, no API call)
-      const knownCity = KNOWN_CITIES[q.toLowerCase()]
-      if (knownCity) {
-        searchLat = knownCity.lat
-        searchLng = knownCity.lng
+    let data: BackendPlace[]
+
+    // Natural language queries go through the NLP search endpoint (SerpAPI google_local).
+    // Known city names still use geocode + nearby for structured backend results.
+    const isNlpQuery = q && !KNOWN_CITIES[q.toLowerCase()]
+
+    if (isNlpQuery) {
+      const nlpRes = await fetch(
+        `${API_URL}/places/search?q=${encodeURIComponent(q)}&category=${category}&limit=${limit}`,
+        { headers: { Accept: 'application/json' } }
+      )
+      if (nlpRes.ok) {
+        const nlpData = await nlpRes.json()
+        data = (nlpData.results ?? []).map((r: any) => ({
+          id: r.id,
+          name: r.name,
+          lat: r.latitude,
+          lng: r.longitude,
+          category: r.category,
+          rating: r.rating ?? 0,
+          description: r.description,
+          photo_url: r.imageUrl,
+          address: r.location,
+          price_level: r.price != null
+            ? (r.price <= 15 ? '$' : r.price <= 35 ? '$$' : r.price <= 60 ? '$$$' : '$$$$')
+            : null,
+        }))
       } else {
-        try {
-          const geoRes = await fetch(
-            `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=1`,
-            {
-              headers: {
-                'Accept-Language': 'en',
-                'User-Agent': 'Travyl/1.0 (travel planning app)',
-              },
-              signal: AbortSignal.timeout(5000),
-            }
-          )
-          const geoData = await geoRes.json()
-          if (geoData.length > 0) {
-            searchLat = geoData[0].lat
-            searchLng = geoData[0].lon
-          }
-        } catch (err) {
-          console.warn('[places] Geocoding failed for query:', q, err)
-        }
+        data = await fetchNearby(q, lat, lng, category, limit)
       }
+    } else {
+      data = await fetchNearby(q, lat, lng, category, limit)
     }
-
-    const res = await fetch(
-      `${API_URL}/api/places/nearby?lat=${searchLat}&lng=${searchLng}&category=${category}&limit=${limit}`,
-      { headers: { Accept: 'application/json' } }
-    )
-    if (!res.ok) return NextResponse.json([])
-
-    const data: BackendPlace[] = await res.json()
 
     // Map to PlaceItem format (categories must match PLACE_COLLECTIONS in shared)
     const requestedCat = category
@@ -200,6 +194,45 @@ export async function GET(req: NextRequest) {
     console.error('[places] Route error:', err)
     return NextResponse.json([])
   }
+}
+
+async function fetchNearby(
+  q: string | null,
+  defaultLat: string,
+  defaultLng: string,
+  category: string,
+  limit: string,
+): Promise<BackendPlace[]> {
+  let searchLat = defaultLat
+  let searchLng = defaultLng
+  if (q) {
+    const knownCity = KNOWN_CITIES[q.toLowerCase()]
+    if (knownCity) {
+      searchLat = knownCity.lat
+      searchLng = knownCity.lng
+    } else {
+      try {
+        const geoRes = await fetch(
+          `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=1`,
+          {
+            headers: { 'Accept-Language': 'en', 'User-Agent': 'Travyl/1.0 (travel planning app)' },
+            signal: AbortSignal.timeout(5000),
+          }
+        )
+        const geoData = await geoRes.json()
+        if (geoData.length > 0) {
+          searchLat = geoData[0].lat
+          searchLng = geoData[0].lon
+        }
+      } catch {}
+    }
+  }
+  const res = await fetch(
+    `${API_URL}/api/places/nearby?lat=${searchLat}&lng=${searchLng}&category=${category}&limit=${limit}`,
+    { headers: { Accept: 'application/json' } }
+  )
+  if (!res.ok) return []
+  return res.json()
 }
 
 function upscaleGoogleImage(url: string | null | undefined): string | null {

--- a/infra/api.ts
+++ b/infra/api.ts
@@ -137,3 +137,8 @@ api.route('GET /parse-intent', {
     },
   ],
 })
+
+api.route('GET /places/search', {
+  handler: 'services/place-search.handler',
+  link: [supabaseSecretKey, supabaseUrl, serpApiKey],
+})

--- a/planning/TRA-282.md
+++ b/planning/TRA-282.md
@@ -1,0 +1,13 @@
+# TRA-282: Natural Language Place Search (Lambda NLP Search)
+
+## Goal
+Add a `GET /places/search` Lambda endpoint that accepts free-text queries and returns place results using SerpAPI's `google_local` engine — no geocoding needed.
+
+## Linear
+https://linear.app/travyl/issue/TRA-282
+
+## Completed
+- [x] New Lambda handler `services/place-search.ts`
+- [x] SST route `GET /places/search` in `infra/api.ts`
+- [x] Frontend `/api/places` route updated to use NLP search for non-city queries
+- [x] Fallback to geocode + nearby if NLP search fails

--- a/services/place-search.ts
+++ b/services/place-search.ts
@@ -1,0 +1,107 @@
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { Resource } from 'sst'
+import { validateAuth } from './lib/auth'
+import type { SuggestionCard } from './lib/types'
+
+const SERPAPI_BASE = 'https://serpapi.com/search.json'
+
+interface SerpLocalResult {
+  place_id?: string
+  title: string
+  thumbnail?: string
+  rating?: number
+  price?: string
+  description?: string
+  address?: string
+  gps_coordinates?: { latitude: number; longitude: number }
+  images?: string[]
+}
+
+function mapPrice(price: string | undefined): number | null {
+  if (!price) return null
+  const map: Record<string, number> = { '$': 10, '$$': 25, '$$$': 50, '$$$$': 100 }
+  return map[price] ?? null
+}
+
+function upscaleImage(url: string): string {
+  return url.replace(/w\d+-h\d+/, 'w1024-h1024')
+}
+
+function toSuggestionCard(place: SerpLocalResult, category: string, index: number): SuggestionCard {
+  return {
+    id: `serp-${place.place_id ?? index}`,
+    name: place.title,
+    category,
+    imageUrl: upscaleImage(place.images?.[0] ?? place.thumbnail ?? ''),
+    duration: 2,
+    price: mapPrice(place.price),
+    currency: 'USD',
+    rating: place.rating ?? null,
+    location: place.address ?? '',
+    latitude: place.gps_coordinates?.latitude ?? 0,
+    longitude: place.gps_coordinates?.longitude ?? 0,
+    description: place.description ?? '',
+    source: 'search',
+    relevanceScore: Math.max(0, 1 - index * 0.05),
+  }
+}
+
+/**
+ * GET /places/search?q={query}&category={optional}&limit={optional}
+ *
+ * Natural language place search. Passes the raw query directly to SerpAPI's
+ * google_local engine — no geocoding or destination extraction needed.
+ * Queries like "hidden gem restaurant in Sedona" or "rooftop bars in Bangkok"
+ * work natively.
+ */
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    await validateAuth(event.headers.authorization)
+
+    const q = event.queryStringParameters?.q
+    if (!q) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'q parameter required' }) }
+    }
+
+    const category = event.queryStringParameters?.category
+    const limit = Math.min(parseInt(event.queryStringParameters?.limit ?? '20', 10), 40)
+
+    // Build the search query — prepend category if provided and not already in the query
+    const searchQuery = category && !q.toLowerCase().includes(category.toLowerCase())
+      ? `${category} ${q}`
+      : q
+
+    const url = new URL(SERPAPI_BASE)
+    url.searchParams.set('engine', 'google_local')
+    url.searchParams.set('q', searchQuery)
+    url.searchParams.set('api_key', Resource.SerpApiKey.value)
+
+    const res = await fetch(url.toString(), {
+      headers: { Accept: 'application/json' },
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.error(`[place-search] SerpAPI error: ${res.status} ${body}`)
+      return { statusCode: 502, body: JSON.stringify({ error: 'Upstream search failed' }) }
+    }
+
+    const data = await res.json()
+    const results = (data.local_results ?? [])
+      .slice(0, limit)
+      .map((place: SerpLocalResult, i: number) =>
+        toSuggestionCard(place, category ?? 'search', i),
+      )
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ results }),
+    }
+  } catch (err: any) {
+    if (err.message === 'Invalid token' || err.message?.includes('Authorization')) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('[place-search] error:', err)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+}


### PR DESCRIPTION
## Summary

- New Lambda handler `services/place-search.ts` — passes raw text queries to SerpAPI `google_local` engine
- New SST route `GET /places/search` wired in `infra/api.ts`
- Frontend `/api/places` updated to route NLP queries through the new endpoint, with fallback to geocode + nearby

## Why

The frontend currently geocodes search queries via Nominatim then calls `/api/places/nearby`. This only works for city names. Natural language queries like "rooftop bars in Bangkok" or "family restaurants near Colosseum" fail because Nominatim can't geocode them. SerpAPI's `google_local` engine handles these natively.

## How it works

```
Frontend: /api/places?q=hidden+gem+restaurant+in+Sedona
  → detects non-city query (not in KNOWN_CITIES)
  → calls Lambda: GET /places/search?q=hidden+gem+restaurant+in+Sedona
  → SerpAPI google_local returns real Sedona restaurants
  → maps SuggestionCard[] → PlaceItem[] for UI

Known city queries still use the fast geocode + nearby path.
```

## Test plan

- [ ] Deploy Lambda: `AWS_PROFILE=525610233002_AdministratorAccess npx sst deploy --stage production`
- [ ] Test NLP search: `curl "https://yqtl1xdcea.execute-api.us-east-1.amazonaws.com/places/search?q=hidden+gem+restaurant+in+Sedona&limit=5"` (with auth header)
- [ ] Verify known city queries still work: `/api/places?q=paris&category=sightseeing`
- [ ] Verify NLP queries work in ForYou panel: type "jazz bars in New Orleans" and press Enter
- [ ] Verify fallback: if NLP search fails, geocode + nearby should still work

Closes TRA-282