### PR TITLE
fix: add missing /api/exchange-rates proxy route

### DIFF
--- a/apps/web/app/api/exchange-rates/route.ts
+++ b/apps/web/app/api/exchange-rates/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server'
+import { errorResponse, jsonResponse, requireParam, MissingParamError, CACHE_24H } from '@/app/api/lib/response'
+
+export async function GET(req: NextRequest) {
+  try {
+    const base = requireParam(req.nextUrl.searchParams, 'base', 'e.g. USD')
+    const res = await fetch(
+      `https://api.frankfurter.app/latest?from=${encodeURIComponent(base)}`,
+      CACHE_24H
+    )
+    if (!res.ok) return errorResponse('Exchange rate fetch failed', 502)
+    const data = (await res.json()) as { rates: Record<string, number> }
+    return jsonResponse({ rates: data.rates }, 86400)
+  } catch (err) {
+    if (err instanceof MissingParamError) return errorResponse(err.message, 400)
+    return errorResponse('Internal error', 500)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the missing `/api/exchange-rates` Next.js API route that proxies to [frankfurter.app](https://www.frankfurter.app)
- Used by `useExchangeRates` hook (called in `TripMagazineHero`) — was causing 404 errors on trip pages
- Route was only present locally on main, never landed on develop