### PR TITLE
Add SST Nextjs deployment + GitHub Actions CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Deploy with SST
+        run: npx sst deploy --stage production

--- a/infra/web.ts
+++ b/infra/web.ts
@@ -22,7 +22,17 @@ import {
   openchargeApiKey,
 } from './secrets'
 
-export const web = new sst.x.DevCommand('TravylWeb', {
+export const site = new sst.aws.Nextjs('TravylWeb', {
+  path: 'apps/web',
+  environment: {
+    NEXT_PUBLIC_SUPABASE_URL: supabaseUrl.value,
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: supabasePublishableKey.value,
+    NEXT_PUBLIC_RECOMMENDATION_API_URL: api.url,
+    PEXELS_API_KEY: pexels.value,
+  },
+})
+
+export const web = new sst.x.DevCommand('TravylWebDev', {
   dev: {
     command: 'npm run web',
     directory: 'apps/web',

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -31,6 +31,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "SupabasePublishableKey": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
     "SupabaseSecretKey": {
       "type": "sst.sst.Secret"
       "value": string
@@ -43,6 +47,10 @@ declare module "sst" {
       "configSet": string
       "sender": string
       "type": "sst.aws.Email"
+    }
+    "TravylWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
     }
     "UserInteractions": {
       "name": string

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -14,10 +14,11 @@ export default $config({
     const storage = await import('./infra/storage')
     const events = await import('./infra/events')
     const api = await import('./infra/api')
-    await import('./infra/web')
+    const web = await import('./infra/web')
 
     return {
       apiUrl: api.api.url,
+      siteUrl: web.site.url,
     }
   },
 })


### PR DESCRIPTION
## Summary
- Replaces Amplify hosting with `sst.aws.Nextjs` (CloudFront + Lambda via OpenNext)
- Adds GitHub Actions deploy workflow triggered on push to `develop`
- Uses OIDC auth to AWS account via `TravylGitHubDeploy` IAM role
- Passes Supabase env vars from SST secrets to frontend build, fixing the "Disconnected — changes may not sync" error

## Test plan
- [ ] Merge PR and verify GitHub Actions workflow triggers
- [ ] Confirm SST deploy succeeds on Ubuntu runner
- [ ] Verify CloudFront URL serves the site with working Supabase realtime connection