### PR TITLE
fix(infra): use SupabaseAnonKey for frontend env

### DIFF
--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -1,6 +1,7 @@
 // ─── Supabase ────────────────────────────────────────────────
 export const supabaseSecretKey = new sst.Secret('SupabaseSecretKey')
 export const supabaseUrl = new sst.Secret('SupabaseUrl')
+export const supabaseAnonKey = new sst.Secret('SupabaseAnonKey')
 export const supabasePublishableKey = new sst.Secret('SupabasePublishableKey')
 
 // ─── Search & Location ──────────────────────────────────────

--- a/infra/web.ts
+++ b/infra/web.ts
@@ -28,6 +28,7 @@ export const site = new sst.aws.Nextjs('TravylWeb', {
     NEXT_PUBLIC_SUPABASE_URL: supabaseUrl.value,
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: supabasePublishableKey.value,
     NEXT_PUBLIC_RECOMMENDATION_API_URL: api.url,
+    SUPABASE_SECRET_KEY: supabaseSecretKey.value,
     PEXELS_API_KEY: pexels.value,
   },
 })

--- a/infra/web.ts
+++ b/infra/web.ts
@@ -1,7 +1,7 @@
 import { api } from './api'
 import {
   supabaseUrl,
-  supabasePublishableKey,
+  supabaseAnonKey,
   supabaseSecretKey,
   serpApiKey,
   pexels,
@@ -26,7 +26,7 @@ export const site = new sst.aws.Nextjs('TravylWeb', {
   path: 'apps/web',
   environment: {
     NEXT_PUBLIC_SUPABASE_URL: supabaseUrl.value,
-    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: supabasePublishableKey.value,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: supabaseAnonKey.value,
     NEXT_PUBLIC_RECOMMENDATION_API_URL: api.url,
     SUPABASE_SECRET_KEY: supabaseSecretKey.value,
     PEXELS_API_KEY: pexels.value,
@@ -43,7 +43,7 @@ export const web = new sst.x.DevCommand('TravylWebDev', {
     // Public (browser-safe)
     NEXT_PUBLIC_RECOMMENDATION_API_URL: api.url,
     NEXT_PUBLIC_SUPABASE_URL: supabaseUrl.value,
-    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: supabasePublishableKey.value,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: supabaseAnonKey.value,
 
     // Server-only — Supabase
     SUPABASE_SECRET_KEY: supabaseSecretKey.value,


### PR DESCRIPTION
Fixes disconnected Supabase realtime — Supabase v2 client expects JWT anon key, not sb_publishable_ prefix.