### PR TITLE
fix(infra): set both Supabase anon key env vars for production

### DIFF
--- a/infra/web.ts
+++ b/infra/web.ts
@@ -27,6 +27,7 @@ export const site = new sst.aws.Nextjs('TravylWeb', {
   environment: {
     NEXT_PUBLIC_SUPABASE_URL: supabaseUrl.value,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: supabaseAnonKey.value,
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: supabaseAnonKey.value,
     NEXT_PUBLIC_RECOMMENDATION_API_URL: api.url,
     SUPABASE_SECRET_KEY: supabaseSecretKey.value,
     PEXELS_API_KEY: pexels.value,


### PR DESCRIPTION
Fixes disconnected Supabase realtime — sets both NEXT_PUBLIC_SUPABASE_ANON_KEY and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY to the JWT anon key, covering all code paths that read these env vars.