### PR TITLE
fix: deployment infra fixes + duplicate Supabase client

### DIFF
--- a/packages/shared/src/services/supabase.ts
+++ b/packages/shared/src/services/supabase.ts
@@ -12,15 +12,32 @@ const supabasePublishableKey =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
   'placeholder';
 
-// Default client (localStorage-based — fine for mobile, overridden for web)
-export let supabase: SupabaseClient = createClient(supabaseUrl, supabasePublishableKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
+// Lazy-initialized default client. On web, configureSupabase() replaces this
+// before first use, avoiding a duplicate GoTrue instance.
+let _client: SupabaseClient | null = null;
+
+function getDefaultClient(): SupabaseClient {
+  if (!_client) {
+    _client = createClient(supabaseUrl, supabasePublishableKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    });
+  }
+  return _client;
+}
+
+// Proxy that lazily resolves to the configured (or default) client.
+// This lets `configureSupabase` swap the underlying client before any
+// Supabase call happens, preventing duplicate GoTrue auth instances.
+export const supabase: SupabaseClient = new Proxy({} as SupabaseClient, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getDefaultClient(), prop, receiver);
   },
 });
 
 export function configureSupabase(client: SupabaseClient) {
-  supabase = client;
+  _client = client;
 }


### PR DESCRIPTION
## Summary
- Fix /api/suggest 404: proxy path corrected from `/api/places/suggest` to `/suggest` (matching API Gateway route)
- Fix Supabase env vars: use `supabaseAnonKey` (JWT format) instead of `supabasePublishableKey` (`sb_publishable_` prefix rejected by Supabase v2 client)
- Fix duplicate GoTrue instances: lazy-init shared Supabase client via Proxy to prevent two auth instances competing on the same storage key
- Pass `SUPABASE_SECRET_KEY` to Next.js server environment

## Test plan
- [ ] Deploy to production, verify `/api/suggest` returns suggestions (not 404)
- [ ] Verify no "multiple GoTrue instances" warning in browser console
- [ ] Verify trip pages load itinerary data correctly
- [ ] Verify auth session persists across page navigations