### PR TITLE
feat(homepage): polish — live stats, trending pills, hero contrast, cleanup

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { motion, useScroll, useTransform, AnimatePresence } from "motion/react";
-import { Search, ArrowRight, MapPin, Calendar, Users, Sparkles } from "lucide-react";
+import { motion, useScroll, useTransform } from "motion/react";
+import { Search, Sparkles } from "lucide-react";
 import { useHomeScreen, useHeroConfig, usePlaceImages, useTripPlanner, useAuthStore, EASE_OUT_EXPO } from "@travyl/shared";
-import type { FollowUpQuestion, PlaceItem } from "@travyl/shared";
-import { PlaceDetailOverlay } from "@/components/PlaceDetailOverlay";
+import type { FollowUpQuestion } from "@travyl/shared";
+import { useQuery } from "@tanstack/react-query";
 import { savePlanToSupabase } from "@travyl/shared/src/services/api";
 import { PaperPlane } from "@/components/icons/PaperPlane";
 import { AnimatedCounter } from "@/components/AnimatedCounter";
@@ -21,10 +20,6 @@ const HowItWorks = dynamic(
 );
 const GetInspired = dynamic(
   () => import("@/components/home/GetInspired").then((m) => ({ default: m.GetInspired })),
-  { ssr: false }
-);
-const TravelMosaic = dynamic(
-  () => import("@/components/home/TravelMosaic").then((m) => ({ default: m.TravelMosaic })),
   { ssr: false }
 );
 const TagUs = dynamic(
@@ -100,6 +95,54 @@ const HeroSearchInput = memo(function HeroSearchInput({
   );
 });
 
+// ─── Live stats from /api/stats ──────────────────────────────
+function LiveStats() {
+  const { data: stats, isLoading } = useQuery({
+    queryKey: ['live-stats'],
+    queryFn: async () => {
+      const res = await fetch('/api/stats');
+      if (!res.ok) return { destinations: 0, travelers: 0, trips: 0 };
+      return res.json() as Promise<{ destinations: number; travelers: number; trips: number }>;
+    },
+    staleTime: 60 * 1000,
+    refetchOnMount: 'always',
+  });
+
+  const items = [
+    { value: stats?.destinations ?? 0, suffix: "+", label: "Destinations", desc: "Real places our community has explored." },
+    { value: stats?.travelers ?? 0, suffix: "", label: "Travelers", desc: "People planning their next adventure." },
+    { value: stats?.trips ?? 0, suffix: "+", label: "Trips Planned", desc: "AI-powered itineraries created and counting." },
+  ];
+
+  return (
+    <section className="py-8 sm:py-14 px-4 sm:px-6 border-y bg-[#e8d5c0] border-[#5c4a3a]">
+      <div className="max-w-5xl mx-auto grid grid-cols-3 gap-3 sm:gap-8 text-center">
+        {isLoading ? (
+          <>
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex flex-col items-center gap-2">
+                <div className="h-8 sm:h-12 w-20 sm:w-28 bg-[#2a1f17]/10 rounded-lg animate-pulse" />
+                <div className="h-3 w-16 sm:w-24 bg-[#2a1f17]/10 rounded animate-pulse" />
+                <div className="h-3 w-28 sm:w-40 bg-[#2a1f17]/8 rounded animate-pulse" />
+              </div>
+            ))}
+          </>
+        ) : (
+          items.map((item) => (
+            <div key={item.label}>
+              <p className="text-2xl sm:text-4xl md:text-5xl font-[550] tracking-tight mb-1 text-[#2a1f17]">
+                <AnimatedCounter value={item.value} suffix={item.suffix} decimals={0} />
+              </p>
+              <p className="text-[8px] sm:text-xs font-bold uppercase tracking-widest mb-1 sm:mb-2 text-[#1e3a5f]">{item.label}</p>
+              <p className="text-[11px] sm:text-sm max-w-[220px] mx-auto leading-snug sm:leading-relaxed text-[#2a1f17]">{item.desc}</p>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
 // ─── Follow-up question option card ─────────────────────────
 function OptionCard({ label, index, selected, onSelect }: {
   label: string; index: number; selected: boolean; onSelect: () => void;
@@ -129,11 +172,6 @@ export default function Home() {
   const {
     tripQuery,
     setTripQuery,
-    handleSearch,
-    recentTrips,
-    showRecentTrips,
-    showLoadingSkeleton,
-    showEmptyState,
   } = useHomeScreen();
   const { data: heroConfig } = useHeroConfig();
 
@@ -147,6 +185,8 @@ export default function Home() {
   const planner = useTripPlanner();
   const [currentQIdx, setCurrentQIdx] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string[]>>({});
+  const [showQuestions, setShowQuestions] = useState(false);
+  const skipQuestionsRef = useRef(false);
 
 
   const isClarifying = planner.state.phase === 'clarifying';
@@ -155,22 +195,32 @@ export default function Home() {
   const questions: FollowUpQuestion[] = planner.state.phase === 'clarifying' ? planner.state.questions : [];
   const currentQuestion = questions[currentQIdx];
 
+  // Auto-skip questions when user clicked Send (not Refine)
+  useEffect(() => {
+    if (isClarifying && skipQuestionsRef.current) {
+      skipQuestionsRef.current = false;
+      setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
+      setShowTakeoff(true);
+      planner.submitAnswers({});
+    }
+  }, [isClarifying, planner]);
+
   // Cycling placeholders live in isolated memo components above
   // to avoid re-rendering the entire page every ~25ms
 
-  // Cycling suggestion pills
-  const allSuggestions = heroConfig?.suggestions?.length
-    ? heroConfig.suggestions
-    : [
-        { id: 'ps-1', label: 'Beach getaway', short_label: null },
-        { id: 'ps-2', label: 'City explorer', short_label: null },
-        { id: 'ps-3', label: 'Mountain trek', short_label: null },
-        { id: 'ps-4', label: 'Cultural immersion', short_label: null },
-        { id: 'ps-5', label: 'Island hopping', short_label: null },
-        { id: 'ps-6', label: 'Food & wine', short_label: null },
-        { id: 'ps-7', label: 'Road trip', short_label: null },
-        { id: 'ps-8', label: 'Backpacking', short_label: null },
-      ];
+  // Trending destination pills from SerpAPI (cached 6h server-side)
+  const { data: trendingDestinations } = useQuery({
+    queryKey: ['trending-destinations'],
+    queryFn: async () => {
+      const res = await fetch('/api/trending-destinations');
+      if (!res.ok) return [];
+      return res.json() as Promise<{ name: string; country: string; thumbnail: string | null }[]>;
+    },
+    staleTime: 30 * 60 * 1000,
+    refetchOnMount: false,
+  });
+
+  const allSuggestions = (trendingDestinations ?? []).map((d, i) => ({ id: `td-${i}`, label: d.name }));
   const PILLS_VISIBLE = 4;
   const [pillGroup, setPillGroup] = useState(0);
   const pillGroupCount = Math.ceil(allSuggestions.length / PILLS_VISIBLE);
@@ -221,20 +271,6 @@ export default function Home() {
     return () => clearInterval(interval);
   }, [heroSlides.length]);
 
-  // Toggle an option (multi-select)
-  const handleOptionSelect = useCallback((questionId: string, option: string) => {
-    setSelectedAnswers((prev) => {
-      const current = prev[questionId] ?? [];
-      const isSelected = current.includes(option);
-      return {
-        ...prev,
-        [questionId]: isSelected
-          ? current.filter((o) => o !== option)
-          : [...current, option],
-      };
-    });
-  }, []);
-
   // Flatten multi-select answers into strings for the planner API
   const flattenAnswers = useCallback((answers: Record<string, string[]>) => {
     const flat: Record<string, string> = {};
@@ -243,6 +279,31 @@ export default function Home() {
     }
     return flat;
   }, []);
+
+  // Select an option — auto-advances after brief pause
+  const handleOptionSelect = useCallback((questionId: string, option: string) => {
+    const current = selectedAnswers[questionId] ?? [];
+    const isDeselecting = current.includes(option);
+    const newSelection = isDeselecting
+      ? current.filter((o) => o !== option)
+      : [...current, option];
+
+    const newAnswers = { ...selectedAnswers, [questionId]: newSelection };
+    setSelectedAnswers(newAnswers);
+
+    // Auto-advance after selecting (not deselecting)
+    if (!isDeselecting) {
+      setTimeout(() => {
+        if (currentQIdx < questions.length - 1) {
+          setCurrentQIdx((i) => i + 1);
+        } else {
+          setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
+          setShowTakeoff(true);
+          planner.submitAnswers(flattenAnswers(newAnswers));
+        }
+      }, 600);
+    }
+  }, [selectedAnswers, currentQIdx, questions.length, planner, flattenAnswers]);
 
   // Advance to next question or submit
   const handleNextQuestion = useCallback(() => {
@@ -289,6 +350,7 @@ export default function Home() {
     planner.reset();
     setCurrentQIdx(0);
     setSelectedAnswers({});
+    setShowQuestions(false);
     setTripQuery("");
     setTimeout(() => inputRef.current?.focus(), 50);
   }, [planner, setTripQuery]);
@@ -296,14 +358,22 @@ export default function Home() {
   const onSearch = () => {
     const val = tripQuery.trim();
     if (!val) return;
-    // Send to backend for extraction
+    skipQuestionsRef.current = true;
+    planner.submitPrompt(val);
+    setTripQuery("");
+  };
+
+  const onRefine = () => {
+    const val = tripQuery.trim();
+    if (!val) return;
+    skipQuestionsRef.current = false;
+    setShowQuestions(true);
     planner.submitPrompt(val);
     setTripQuery("");
   };
 
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [takeoffCompleted, setTakeoffCompleted] = useState(false);
-  const [selectedPlace, setSelectedPlace] = useState<PlaceItem | null>(null);
   const isSaving = useRef(false);
   const user = useAuthStore((s) => s.user);
 
@@ -571,7 +641,7 @@ export default function Home() {
           ))}
         </motion.div>
         {/* Dark overlay for text contrast */}
-        <div className="absolute inset-0 z-[1] bg-gradient-to-b from-black/30 via-black/20 to-black/40" />
+        <div className="absolute inset-0 z-[1] bg-gradient-to-b from-black/40 via-black/30 to-black/50" />
 
         <motion.div
           className="relative z-10 max-w-3xl mx-auto text-center w-full"
@@ -589,7 +659,7 @@ export default function Home() {
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, delay: 0.4, ease: EASE_OUT_EXPO }}
-            className="text-xs sm:text-sm md:text-base text-white mb-10 w-fit mx-auto font-medium px-4 py-1.5 rounded-full bg-white/10 backdrop-blur-sm border border-white/40 shadow-sm drop-shadow-sm"
+            className="text-xs sm:text-sm md:text-base text-white mb-10 w-fit mx-auto font-medium px-4 py-1.5 rounded-full bg-black/25 backdrop-blur-md border border-white/25 shadow-lg drop-shadow-md"
           >
             {heroConfig?.subtitle ? (
               <TypeWriter text={heroConfig.subtitle} delay={600} speed={35} />
@@ -666,35 +736,46 @@ export default function Home() {
               </div>
             )}
 
-            {/* Search bar */}
-            <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
-              <div className="flex items-center p-1.5 gap-2">
-                <HeroSearchInput
-                  tripQuery={tripQuery}
-                  setTripQuery={setTripQuery}
-                  onSearch={onSearch}
-                  staticPlaceholder={heroConfig?.search_placeholder}
-                  inputRef={inputRef}
-                />
-                <button
-                  ref={sendButtonRef}
-                  onClick={onSearch}
-                  disabled={isExtracting || isPlanning}
-                  className="bg-[#1e3a5f] hover:bg-[#162d4a] disabled:opacity-50 text-white px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors flex items-center gap-2 shrink-0"
-                >
-                  <PaperPlane size={16} />
-                </button>
+            {/* Search bar — hidden during questions */}
+            {!(isClarifying && showQuestions) && (
+              <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
+                <div className="flex items-center p-1.5 gap-2">
+                  <HeroSearchInput
+                    tripQuery={tripQuery}
+                    setTripQuery={setTripQuery}
+                    onSearch={onSearch}
+                    staticPlaceholder={heroConfig?.search_placeholder}
+                    inputRef={inputRef}
+                  />
+                  <button
+                    onClick={onRefine}
+                    disabled={isExtracting || isPlanning || !tripQuery.trim()}
+                    className="text-[#1e3a5f]/70 hover:text-[#1e3a5f] hover:bg-[#1e3a5f]/8 disabled:opacity-0 disabled:pointer-events-none px-3 py-2.5 rounded-xl text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shrink-0 border border-transparent hover:border-[#1e3a5f]/15"
+                    title="Answer a few questions for a more personalized trip"
+                  >
+                    <Sparkles size={14} />
+                    <span className="hidden sm:inline">Refine</span>
+                  </button>
+                  <button
+                    ref={sendButtonRef}
+                    onClick={onSearch}
+                    disabled={isExtracting || isPlanning}
+                    className="bg-[#1e3a5f] hover:bg-[#162d4a] disabled:opacity-50 text-white px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors flex items-center gap-2 shrink-0"
+                  >
+                    <PaperPlane size={16} />
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
-            {/* Follow-up questions — multiple choice cards */}
-            {isClarifying && currentQuestion && (
+            {/* Questions — only shown if user clicked Refine */}
+            {isClarifying && showQuestions && currentQuestion && (
               <div className="mt-4 animate-[fadeSlideIn_0.3s_ease-out]">
                 <div className="bg-black/30 backdrop-blur-md rounded-2xl p-4 border border-white/15 shadow-lg">
                   <div className="flex items-center gap-2 mb-3">
                     <Sparkles size={14} className="text-white/60" />
                     <p className="text-sm text-white font-semibold">{currentQuestion.question}</p>
-                    <span className="ml-auto text-[10px] text-white/40 font-medium">
+                    <span className="ml-auto text-[10px] text-white/40 font-medium shrink-0">
                       {currentQIdx + 1}/{questions.length}
                     </span>
                   </div>
@@ -709,36 +790,43 @@ export default function Home() {
                       />
                     ))}
                   </div>
-                  <div className="flex items-center justify-between mt-3 gap-2">
-                    <button
-                      onClick={handleSkipQuestion}
-                      className="text-[11px] text-white/40 hover:text-white/60 transition-colors px-3 py-1.5"
-                    >
-                      Skip
-                    </button>
-                    <div className="flex items-center gap-2">
-                      {(selectedAnswers[currentQuestion.id]?.length ?? 0) > 0 && (
-                        <span className="text-[10px] text-white/40">
-                          {selectedAnswers[currentQuestion.id].length} selected
-                        </span>
-                      )}
-                      <button
-                        onClick={handleNextQuestion}
-                        className="text-[11px] font-semibold text-white bg-white/20 hover:bg-white/30 transition-colors px-4 py-1.5 rounded-lg backdrop-blur-sm"
-                      >
-                        {currentQIdx < questions.length - 1 ? "Next →" : "Plan my trip →"}
-                      </button>
-                    </div>
-                  </div>
-                  <p className="text-[10px] text-white/30 mt-1 text-center">
-                    Select multiple · Enter to continue · Skip to move on
-                  </p>
+                  {/* Type your own answer */}
+                  <form
+                    className="mt-2"
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      const input = (e.target as HTMLFormElement).elements.namedItem('custom') as HTMLInputElement;
+                      const val = input?.value?.trim();
+                      if (val) {
+                        handleOptionSelect(currentQuestion.id, val);
+                        input.value = '';
+                      }
+                    }}
+                  >
+                    <input
+                      name="custom"
+                      type="text"
+                      placeholder="Or type your own..."
+                      className="w-full px-4 py-2.5 rounded-xl bg-white/10 border border-white/15 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+                    />
+                  </form>
+                  {/* Plan it now — escape hatch */}
+                  <button
+                    onClick={() => {
+                      setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
+                      setShowTakeoff(true);
+                      planner.submitAnswers(flattenAnswers(selectedAnswers));
+                    }}
+                    className="w-full mt-3 text-[11px] text-white/40 hover:text-white/70 transition-colors py-1.5 text-center"
+                  >
+                    Done? Plan my trip with what I&apos;ve picked →
+                  </button>
                 </div>
               </div>
             )}
 
             {/* Suggestion Pills — only show when idle */}
-            {planner.state.phase === 'idle' && (
+            {planner.state.phase === 'idle' && allSuggestions.length > 0 && (
               <div className="flex justify-center gap-1.5 sm:gap-2 mt-4 h-[36px]">
                 <div
                   key={pillGroup}
@@ -747,7 +835,10 @@ export default function Home() {
                   {visiblePills.map((s) => (
                     <button
                       key={s.id}
-                      onClick={() => setTripQuery(s.label)}
+                      onClick={() => {
+                        skipQuestionsRef.current = true;
+                        planner.submitPrompt(`Plan a trip to ${s.label}`);
+                      }}
                       className="text-[10px] sm:text-xs text-white font-medium border border-white/40 rounded-full px-2 sm:px-3 py-1 sm:py-1.5 hover:bg-white/20 transition-colors backdrop-blur-sm bg-white/10 shadow-sm drop-shadow-sm whitespace-nowrap"
                     >
                       {s.label}
@@ -757,149 +848,31 @@ export default function Home() {
               </div>
             )}
           </motion.div>
+
+          {/* Scroll indicator */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.5, duration: 0.8 }}
+            className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
+          >
+            <div className="w-5 h-8 rounded-full border-2 border-white/40 flex items-start justify-center pt-1.5">
+              <div className="w-1 h-1.5 rounded-full bg-white/70 animate-[scrollDot_1.5s_ease-in-out_infinite]" />
+            </div>
+            <span className="text-white/40 text-[9px] font-medium uppercase tracking-widest">Scroll</span>
+          </motion.div>
+          <style>{`@keyframes scrollDot { 0%, 100% { transform: translateY(0); opacity: 1; } 50% { transform: translateY(8px); opacity: 0.3; } }`}</style>
         </motion.div>
       </section>
 
-      {/* ─── Trip Statistics ───────────────────────────────────── */}
-      <section className="py-8 sm:py-14 px-4 sm:px-6 border-y bg-[#e8d5c0] border-[#5c4a3a]">
-        <div className="max-w-5xl mx-auto grid grid-cols-3 gap-3 sm:gap-8 text-center">
-          {[
-            { value: 500, suffix: "K+", decimals: 0, label: "Destinations", desc: "Discover unexpected gems, even in your own backyard." },
-            { value: 95, suffix: "M+", decimals: 0, label: "Fellow Travelers", desc: "Share your adventures and learn from our global community." },
-            { value: 2.0, suffix: "B+", decimals: 1, label: "Trips Planned", desc: "Navigate your way and keep a record of all your travels." },
-          ].map((item) => (
-            <div key={item.label}>
-              <p className="text-2xl sm:text-4xl md:text-5xl font-[550] tracking-tight mb-1 text-[#2a1f17]">
-                <AnimatedCounter value={item.value} suffix={item.suffix} decimals={item.decimals} />
-              </p>
-              <p className="text-[8px] sm:text-xs font-bold uppercase tracking-widest mb-1 sm:mb-2 text-[#1e3a5f]">{item.label}</p>
-              <p className="text-[11px] sm:text-sm max-w-[220px] mx-auto leading-snug sm:leading-relaxed text-[#2a1f17]">{item.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      {/* ─── Trip Statistics — Live from Supabase ────────────── */}
+      <LiveStats />
 
-      {/* ─── Recent Trips (logged-in users) ───────────────────── */}
-      {showRecentTrips && (
-        <section className="py-12 px-6">
-          <div className="max-w-6xl mx-auto">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-serif font-normal text-foreground tracking-wide">
-                Your Recent Trips
-              </h2>
-              <Link
-                href="/trips"
-                className="text-sm text-primary font-medium hover:underline flex items-center gap-1"
-              >
-                View all <ArrowRight size={14} />
-              </Link>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {recentTrips.map((trip: any) => (
-                <Link
-                  key={trip.id}
-                  href={`/trip/${trip.id}`}
-                  className="group block rounded-xl border border-border p-5 hover:shadow-md hover:border-primary/30 transition-all"
-                >
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors">
-                        {trip.title}
-                      </h3>
-                      <div className="flex items-center gap-1 mt-1 text-sm text-muted-foreground">
-                        <MapPin size={14} />
-                        <span>{trip.destination}</span>
-                      </div>
-                    </div>
-                    <span
-                      className="text-xs px-2 py-0.5 rounded-full font-medium"
-                      style={{
-                        backgroundColor: trip.status.bgColor,
-                        color: trip.status.textColor,
-                      }}
-                    >
-                      {trip.status.label}
-                    </span>
-                  </div>
-
-                  <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
-                    <div className="flex items-center gap-1">
-                      <Calendar size={12} />
-                      <span>{trip.dateRange.short}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Users size={12} />
-                      <span>{trip.travelersLabel}</span>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* ─── Loading Skeleton ──────────────────────────────────── */}
-      {showLoadingSkeleton && (
-        <section className="py-12 px-6">
-          <div className="max-w-6xl mx-auto">
-            <div className="h-7 w-48 bg-gray-200 rounded animate-pulse mb-6" />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {[0, 1, 2].map((i) => (
-                <div
-                  key={i}
-                  className="rounded-xl border border-border p-5 space-y-3"
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="space-y-2">
-                      <div className="h-5 w-32 bg-gray-200 rounded animate-pulse" />
-                      <div className="h-4 w-24 bg-gray-100 rounded animate-pulse" />
-                    </div>
-                    <div className="h-5 w-16 bg-gray-200 rounded-full animate-pulse" />
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <div className="h-3 w-28 bg-gray-100 rounded animate-pulse" />
-                    <div className="h-3 w-20 bg-gray-100 rounded animate-pulse" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* ─── Empty State ─────────────────────────────────────── */}
-      {showEmptyState && (
-        <section className="py-16 px-6">
-          <div className="max-w-md mx-auto text-center">
-            <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-              <PaperPlane className="text-primary -rotate-12" size={28} />
-            </div>
-            <h2 className="text-xl font-serif font-normal text-foreground mb-2 tracking-wide">
-              No trips yet
-            </h2>
-            <p className="text-muted-foreground mb-6">
-              Start planning your first adventure — type a destination in the
-              search bar above or tap the button below.
-            </p>
-            <button
-              onClick={() => router.push("/trips")}
-              className="bg-primary text-white px-6 py-3 rounded-xl font-semibold text-sm hover:opacity-90 transition-opacity inline-flex items-center gap-2"
-            >
-              <PaperPlane size={16} className="-rotate-12" />
-              Plan your first trip
-            </button>
-          </div>
-        </section>
-      )}
 
       {/* ─── Static Content Sections ──────────────────────────── */}
       <HowItWorks onCtaPress={() => router.push("/trips")} />
-      <TravelMosaic onTileClick={(place) => setSelectedPlace(place)} />
-
       {/* ─── Parallax Divider — cycling quotes + images ─────── */}
-      <ParallaxQuoteDivider bgY={dividerBgY} />
+      <ParallaxQuoteDivider bgY={dividerBgY} trendingDestinations={trendingDestinations} />
 
       <GetInspired />
       <TagUs />
@@ -910,19 +883,6 @@ export default function Home() {
       {/* ─── Footer ─────────────────────────────────────────── */}
       <Footer />
 
-      {/* ─── Place Detail Overlay ────────────────────────────── */}
-      <AnimatePresence>
-        {selectedPlace && (
-          <PlaceDetailOverlay
-            place={selectedPlace}
-            isFavorited={false}
-            onToggleFavorite={() => {}}
-            onClose={() => setSelectedPlace(null)}
-            onNavigate={(p) => setSelectedPlace(p)}
-            onSearchTag={() => {}}
-          />
-        )}
-      </AnimatePresence>
 
       {/* ─── Takeoff Animation Overlay ─────────────────────────── */}
       <TakeoffTransition

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -110,14 +110,14 @@ function OptionCard({ label, index, selected, onSelect }: {
       onClick={onSelect}
       className={`flex items-center gap-3 px-4 py-3 rounded-xl text-left text-sm transition-all duration-200 w-full ${
         selected
-          ? "bg-[#1e3a5f] text-white shadow-md"
+          ? "bg-[#1e3a5f] text-white shadow-md ring-1 ring-white/30"
           : "bg-white/10 text-white/80 hover:bg-white/20 border border-white/15"
       }`}
     >
-      <span className={`w-7 h-7 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 ${
+      <span className={`w-7 h-7 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 transition-all ${
         selected ? "bg-white/20 text-white" : "bg-white/10 text-white/50"
       }`}>
-        {keys[index] || index + 1}
+        {selected ? "✓" : keys[index] || index + 1}
       </span>
       <span className="font-medium">{label}</span>
     </button>
@@ -146,7 +146,7 @@ export default function Home() {
   // API-driven planning flow
   const planner = useTripPlanner();
   const [currentQIdx, setCurrentQIdx] = useState(0);
-  const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string>>({});
+  const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string[]>>({});
 
 
   const isClarifying = planner.state.phase === 'clarifying';
@@ -221,25 +221,53 @@ export default function Home() {
     return () => clearInterval(interval);
   }, [heroSlides.length]);
 
-  // Handle selecting an answer option
+  // Toggle an option (multi-select)
   const handleOptionSelect = useCallback((questionId: string, option: string) => {
-    const newAnswers = { ...selectedAnswers, [questionId]: option };
-    setSelectedAnswers(newAnswers);
+    setSelectedAnswers((prev) => {
+      const current = prev[questionId] ?? [];
+      const isSelected = current.includes(option);
+      return {
+        ...prev,
+        [questionId]: isSelected
+          ? current.filter((o) => o !== option)
+          : [...current, option],
+      };
+    });
+  }, []);
 
-    // Auto-advance to next question after a brief pause
-    if (currentQIdx < questions.length - 1) {
-      setTimeout(() => setCurrentQIdx((i) => i + 1), 400);
-    } else {
-      // All questions answered — submit to plan
-      setTimeout(() => {
-        setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
-        setShowTakeoff(true);
-        planner.submitAnswers(newAnswers);
-      }, 600);
+  // Flatten multi-select answers into strings for the planner API
+  const flattenAnswers = useCallback((answers: Record<string, string[]>) => {
+    const flat: Record<string, string> = {};
+    for (const [k, v] of Object.entries(answers)) {
+      flat[k] = v.join(", ");
     }
-  }, [selectedAnswers, currentQIdx, questions.length, planner]);
+    return flat;
+  }, []);
 
-  // Handle keyboard shortcuts for options (1-5 or A-E)
+  // Advance to next question or submit
+  const handleNextQuestion = useCallback(() => {
+    if (currentQIdx < questions.length - 1) {
+      setCurrentQIdx((i) => i + 1);
+    } else {
+      // All questions done — submit
+      setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
+      setShowTakeoff(true);
+      planner.submitAnswers(flattenAnswers(selectedAnswers));
+    }
+  }, [currentQIdx, questions.length, planner, selectedAnswers, flattenAnswers]);
+
+  // Skip this question entirely
+  const handleSkipQuestion = useCallback(() => {
+    if (currentQIdx < questions.length - 1) {
+      setCurrentQIdx((i) => i + 1);
+    } else {
+      setButtonRect(sendButtonRef.current?.getBoundingClientRect() ?? null);
+      setShowTakeoff(true);
+      planner.submitAnswers(flattenAnswers(selectedAnswers));
+    }
+  }, [currentQIdx, questions.length, planner, selectedAnswers, flattenAnswers]);
+
+  // Handle keyboard shortcuts for options (A-E to toggle, Enter to advance, S to skip)
   useEffect(() => {
     if (!isClarifying || !currentQuestion) return;
     const handler = (e: KeyboardEvent) => {
@@ -250,10 +278,12 @@ export default function Home() {
       if (idx >= 0 && idx < opts.length) {
         handleOptionSelect(currentQuestion.id, opts[idx]);
       }
+      if (e.key === 'Enter') handleNextQuestion();
+      if (e.key.toLowerCase() === 's' && e.ctrlKey) { e.preventDefault(); handleSkipQuestion(); }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [isClarifying, currentQuestion, handleOptionSelect]);
+  }, [isClarifying, currentQuestion, handleOptionSelect, handleNextQuestion, handleSkipQuestion]);
 
   const handleConvReset = useCallback(() => {
     planner.reset();
@@ -581,7 +611,7 @@ export default function Home() {
                 <div className="bg-black/30 backdrop-blur-md rounded-2xl px-5 py-2.5 border border-white/15 shadow-lg">
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-sm text-white/80 truncate">
-                      {Object.values(selectedAnswers).join(" · ")}
+                      {Object.values(selectedAnswers).map((v) => v.join(", ")).join(" · ")}
                     </p>
                     <div className="flex items-center gap-1.5 shrink-0">
                       {questions.map((_, i) => (
@@ -674,13 +704,34 @@ export default function Home() {
                         key={opt}
                         label={opt}
                         index={i}
-                        selected={selectedAnswers[currentQuestion.id] === opt}
+                        selected={(selectedAnswers[currentQuestion.id] ?? []).includes(opt)}
                         onSelect={() => handleOptionSelect(currentQuestion.id, opt)}
                       />
                     ))}
                   </div>
-                  <p className="text-[10px] text-white/30 mt-2 text-center">
-                    Press {currentQuestion.options.map((_, i) => ["A","B","C","D","E"][i]).join("/")} to select
+                  <div className="flex items-center justify-between mt-3 gap-2">
+                    <button
+                      onClick={handleSkipQuestion}
+                      className="text-[11px] text-white/40 hover:text-white/60 transition-colors px-3 py-1.5"
+                    >
+                      Skip
+                    </button>
+                    <div className="flex items-center gap-2">
+                      {(selectedAnswers[currentQuestion.id]?.length ?? 0) > 0 && (
+                        <span className="text-[10px] text-white/40">
+                          {selectedAnswers[currentQuestion.id].length} selected
+                        </span>
+                      )}
+                      <button
+                        onClick={handleNextQuestion}
+                        className="text-[11px] font-semibold text-white bg-white/20 hover:bg-white/30 transition-colors px-4 py-1.5 rounded-lg backdrop-blur-sm"
+                      >
+                        {currentQIdx < questions.length - 1 ? "Next →" : "Plan my trip →"}
+                      </button>
+                    </div>
+                  </div>
+                  <p className="text-[10px] text-white/30 mt-1 text-center">
+                    Select multiple · Enter to continue · Skip to move on
                   </p>
                 </div>
               </div>

--- a/apps/web/app/api/stats/route.ts
+++ b/apps/web/app/api/stats/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+function getServiceSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    (process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY)!
+  )
+}
+
+export async function GET() {
+  try {
+    const sb = getServiceSupabase()
+
+    const [tripsRes, profilesRes, destsRes] = await Promise.all([
+      sb.from('trips').select('id', { count: 'exact', head: true }),
+      sb.from('profiles').select('id', { count: 'exact', head: true }),
+      sb.from('trips').select('destination'),
+    ])
+
+    const uniqueDestinations = new Set(
+      (destsRes.data ?? [])
+        .map((t: { destination: string }) => t.destination?.split(',')[0]?.trim())
+        .filter(Boolean)
+    ).size
+
+    return NextResponse.json({
+      destinations: uniqueDestinations,
+      travelers: profilesRes.count ?? 0,
+      trips: tripsRes.count ?? 0,
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' },
+    })
+  } catch {
+    return NextResponse.json({ destinations: 0, travelers: 0, trips: 0 }, { status: 500 })
+  }
+}

--- a/apps/web/app/api/trending-destinations/route.ts
+++ b/apps/web/app/api/trending-destinations/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const SERPAPI_KEY = process.env.SERPAPI_KEY
+
+interface TrendingDestination {
+  name: string
+  country: string
+  thumbnail: string | null
+}
+
+// In-memory cache — survives across requests in the same server process
+let cache: { data: TrendingDestination[]; expires: number } | null = null
+const CACHE_TTL = 6 * 60 * 60 * 1000 // 6 hours
+
+export async function GET(req: NextRequest) {
+  // Serve from cache if fresh
+  if (cache && Date.now() < cache.expires) {
+    return NextResponse.json(cache.data, {
+      headers: { 'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=43200' },
+    })
+  }
+
+  if (!SERPAPI_KEY) {
+    return NextResponse.json([])
+  }
+
+  const departureId = req.nextUrl.searchParams.get('from') ?? 'JFK'
+
+  try {
+    const params = new URLSearchParams({
+      engine: 'google_travel_explore',
+      departure_id: departureId,
+      api_key: SERPAPI_KEY,
+      currency: 'USD',
+      hl: 'en',
+    })
+
+    const res = await fetch(`https://serpapi.com/search.json?${params}`, {
+      headers: { Accept: 'application/json' },
+    })
+
+    if (!res.ok) {
+      return NextResponse.json(cache?.data ?? [])
+    }
+
+    const data = await res.json()
+
+    // Deduplicate by city name (e.g. "Orlando" and "Walt Disney World® Resort" both map to Orlando)
+    const seen = new Set<string>()
+    const results: TrendingDestination[] = []
+
+    for (const r of data.destinations ?? []) {
+      const name: string = r.name ?? ''
+      if (!name || seen.has(name.toLowerCase())) continue
+      // Skip sub-destinations (theme parks, resorts) — they have a location field
+      if (r.destination_airport?.location && r.destination_airport.location !== name) {
+        const parentCity = r.destination_airport.location
+        if (seen.has(parentCity.toLowerCase())) continue
+      }
+      seen.add(name.toLowerCase())
+      results.push({
+        name,
+        country: r.country ?? '',
+        thumbnail: r.thumbnail ?? null,
+      })
+      if (results.length >= 12) break
+    }
+
+    cache = { data: results, expires: Date.now() + CACHE_TTL }
+
+    return NextResponse.json(results, {
+      headers: { 'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=43200' },
+    })
+  } catch {
+    return NextResponse.json(cache?.data ?? [])
+  }
+}

--- a/apps/web/components/AnimatedCounter.tsx
+++ b/apps/web/components/AnimatedCounter.tsx
@@ -1,40 +1,51 @@
 "use client";
 
-import { useRef, useEffect } from "react";
-import { useInView } from "motion/react";
+import { useRef, useEffect, useState } from "react";
 
 export function AnimatedCounter({ value, suffix, decimals = 0 }: { value: number; suffix: string; decimals?: number }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const inView = useInView(ref, { once: true, margin: "-50px" });
-  const hasAnimated = useRef(false);
+  const [hasAnimated, setHasAnimated] = useState(false);
 
   useEffect(() => {
-    if (!inView || hasAnimated.current || !ref.current) return;
-    hasAnimated.current = true;
-    const duration = 2000;
-    const start = performance.now();
-    let raf: number;
+    if (!ref.current || value === 0 || hasAnimated) return;
 
-    const tick = (now: number) => {
-      const elapsed = now - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = 1 - Math.pow(1 - progress, 3);
-      const current = eased * value;
+    // Use IntersectionObserver to start animation when visible
+    const el = ref.current;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        observer.disconnect();
+        setHasAnimated(true);
 
-      if (ref.current) {
-        ref.current.textContent = decimals > 0
-          ? current.toFixed(decimals) + suffix
-          : Math.round(current).toLocaleString() + suffix;
-      }
+        const duration = 2000;
+        const start = performance.now();
+        let raf: number;
 
-      if (progress < 1) {
+        const tick = (now: number) => {
+          const elapsed = now - start;
+          const progress = Math.min(elapsed / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          const current = eased * value;
+
+          if (el) {
+            el.textContent = decimals > 0
+              ? current.toFixed(decimals) + suffix
+              : Math.round(current).toLocaleString() + suffix;
+          }
+
+          if (progress < 1) {
+            raf = requestAnimationFrame(tick);
+          }
+        };
+
         raf = requestAnimationFrame(tick);
-      }
-    };
+      },
+      { threshold: 0.1 }
+    );
 
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [inView, value, suffix, decimals]);
+    observer.observe(el);
+    return () => { observer.disconnect(); };
+  }, [value, suffix, decimals, hasAnimated]);
 
   return <span ref={ref}>0{suffix}</span>;
 }

--- a/apps/web/components/home/HowItWorks.tsx
+++ b/apps/web/components/home/HowItWorks.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, useCallback, useEffect } from "react";
 import { motion, useScroll, useTransform, useMotionValueEvent } from "motion/react";
+// motion.div used for progress bar; useTransform for progressX
 import { useState } from "react";
 import { ArrowRight, Check, MessageSquare, Sparkles, CircleCheck } from "lucide-react";
-import { HOW_IT_WORKS_STEPS, usePlaceImages, EASE_OUT_EXPO } from "@travyl/shared";
+import { HOW_IT_WORKS_STEPS, usePlaceImages } from "@travyl/shared";
 
 const STEP_ICONS = [MessageSquare, Sparkles, CircleCheck];
 const STEP_IMAGES = ["Santorini Greece sunset", "Rome Colosseum", "Bali beach resort"];
@@ -23,6 +24,8 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
   const [activeStep, setActiveStep] = useState(0);
   const stepCount = HOW_IT_WORKS_STEPS.length;
   const prevStepRef = useRef(0);
+  const isSnapping = useRef(false);
+  const snapCooldown = useRef(0);
 
   const imageQueries = usePlaceImages(STEP_IMAGES);
   const images = useMemo(
@@ -35,41 +38,79 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
     offset: ["start center", "end center"],
   });
 
-  // Update step indicator at the midpoint of each crossfade
+  // Update active step based on scroll progress
   useMotionValueEvent(scrollYProgress, "change", (v) => {
     let step = 0;
-    if (v > 0.65) step = 2;
-    else if (v > 0.32) step = 1;
+    if (v > 0.66) step = 2;
+    else if (v > 0.33) step = 1;
     if (step !== prevStepRef.current) {
       prevStepRef.current = step;
       setActiveStep(step);
     }
   });
 
-  // Per-step text opacity + y — wide crossfade zones (15% overlap)
-  // Step 1: visible 0–0.27, fades out 0.27–0.40
-  // Step 2: fades in 0.25–0.38, visible 0.38–0.60, fades out 0.60–0.73
-  // Step 3: fades in 0.58–0.73, visible 0.73–1.0
-  const t0Op = useTransform(scrollYProgress, [0, 0.04, 0.22, 0.38], [0, 1, 1, 0]);
-  const t1Op = useTransform(scrollYProgress, [0.25, 0.40, 0.56, 0.72], [0, 1, 1, 0]);
-  const t2Op = useTransform(scrollYProgress, [0.58, 0.74, 1], [0, 1, 1]);
-  const textOps = [t0Op, t1Op, t2Op];
+  // Snap to step boundaries on scroll
+  const snapToStep = useCallback((step: number) => {
+    const container = containerRef.current;
+    if (!container || isSnapping.current) return;
 
-  const t0Y = useTransform(scrollYProgress, [0, 0.04, 0.22, 0.38], [15, 0, 0, -15]);
-  const t1Y = useTransform(scrollYProgress, [0.25, 0.40, 0.56, 0.72], [15, 0, 0, -15]);
-  const t2Y = useTransform(scrollYProgress, [0.58, 0.74, 1], [15, 0, 0]);
-  const textYs = [t0Y, t1Y, t2Y];
+    const rect = container.getBoundingClientRect();
+    const containerTop = window.scrollY + rect.top;
+    const containerHeight = rect.height;
 
-  // Per-step image opacity + scale — matching crossfade
-  const i0Op = useTransform(scrollYProgress, [0, 0.02, 0.24, 0.40], [1, 1, 1, 0]);
-  const i1Op = useTransform(scrollYProgress, [0.26, 0.40, 0.58, 0.74], [0, 1, 1, 0]);
-  const i2Op = useTransform(scrollYProgress, [0.60, 0.74, 1], [0, 1, 1]);
-  const imgOps = [i0Op, i1Op, i2Op];
+    // Each step occupies 1/3 of the container; snap to center of that zone
+    const stepCenter = containerTop + (step + 0.5) * (containerHeight / stepCount);
+    const targetScroll = stepCenter - window.innerHeight / 2;
 
-  const i0S = useTransform(scrollYProgress, [0, 0.38], [1, 1.04]);
-  const i1S = useTransform(scrollYProgress, [0.30, 0.72], [1, 1.04]);
-  const i2S = useTransform(scrollYProgress, [0.62, 1], [1, 1.04]);
-  const imgScales = [i0S, i1S, i2S];
+    isSnapping.current = true;
+    snapCooldown.current = Date.now();
+
+    window.scrollTo({ top: targetScroll, behavior: "smooth" });
+
+    // Release snap lock after animation
+    setTimeout(() => {
+      isSnapping.current = false;
+    }, 600);
+  }, [stepCount]);
+
+  // Wheel event handler — intercept scroll in the HowItWorks section
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Don't intercept if we're snapping or cooling down
+      if (isSnapping.current || Date.now() - snapCooldown.current < 500) return;
+
+      const rect = container.getBoundingClientRect();
+      const stickyCard = container.querySelector(".sticky");
+      if (!stickyCard) return;
+
+      const cardRect = stickyCard.getBoundingClientRect();
+
+      // Only intercept when the sticky card is visible in viewport
+      if (cardRect.top > window.innerHeight || cardRect.bottom < 0) return;
+
+      // Check if the card is actually in "stuck" state (not at top/bottom of container)
+      const isStuck = rect.top < 0 && rect.bottom > window.innerHeight;
+      if (!isStuck) return;
+
+      const direction = e.deltaY > 0 ? 1 : -1;
+      const currentStep = prevStepRef.current;
+      const nextStep = currentStep + direction;
+
+      if (nextStep >= 0 && nextStep < stepCount) {
+        e.preventDefault();
+        snapToStep(nextStep);
+      }
+    };
+
+    // Use passive: false to allow preventDefault
+    window.addEventListener("wheel", handleWheel, { passive: false });
+    return () => window.removeEventListener("wheel", handleWheel);
+  }, [snapToStep, stepCount]);
+
+  // Images now also transition via activeStep (matching text behavior)
 
   // Progress bar
   const progressX = useTransform(scrollYProgress, [0, 1], [0, 1]);
@@ -87,7 +128,7 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
       </div>
 
       {/* Scroll container — the card sticks while you scroll through */}
-      <div ref={containerRef} className="max-w-6xl mx-auto" style={{ height: `${stepCount * 60}vh` }}>
+      <div ref={containerRef} className="max-w-6xl mx-auto" style={{ height: `${stepCount * 70}vh` }}>
         <div className="sticky top-[15vh]">
           <div className="rounded-3xl overflow-hidden bg-[#0f1f33] shadow-2xl shadow-black/20">
             <div className="flex flex-col md:flex-row" style={{ minHeight: 420 }}>
@@ -120,15 +161,20 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
                   ))}
                 </div>
 
-                {/* Animated content — scroll-driven */}
+                {/* Animated content — CSS transition driven by activeStep */}
                 <div className="relative min-h-[220px]">
                   {HOW_IT_WORKS_STEPS.map((step, i) => {
                     const Icon = STEP_ICONS[i];
+                    const isActive = activeStep === i;
                     return (
-                      <motion.div
+                      <div
                         key={i}
-                        className="absolute top-0 left-0 right-0"
-                        style={{ opacity: textOps[i], y: textYs[i] }}
+                        className="absolute top-0 left-0 right-0 transition-all duration-500 ease-out"
+                        style={{
+                          opacity: isActive ? 1 : 0,
+                          transform: isActive ? "translateY(0)" : activeStep > i ? "translateY(-12px)" : "translateY(12px)",
+                          pointerEvents: isActive ? "auto" : "none",
+                        }}
                       >
                         <div className="flex items-center gap-2 mb-3">
                           <Icon size={14} className="text-white/40" />
@@ -155,7 +201,7 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
                             </li>
                           ))}
                         </ul>
-                      </motion.div>
+                      </div>
                     );
                   })}
                 </div>
@@ -194,14 +240,17 @@ export function HowItWorks({ onCtaPress }: HowItWorksProps) {
               <div className="relative w-full md:w-[45%] min-h-[280px] md:min-h-0 p-3 md:p-4">
                 <div className="relative w-full h-full rounded-2xl overflow-hidden">
                   {images.map((src, i) => (
-                    <motion.img
+                    <img
                       key={i}
                       src={src}
                       alt=""
                       loading={i === 0 ? "eager" : "lazy"}
                       decoding="async"
-                      className="absolute inset-0 w-full h-full object-cover"
-                      style={{ opacity: imgOps[i], scale: imgScales[i] }}
+                      className="absolute inset-0 w-full h-full object-cover transition-all duration-700 ease-out"
+                      style={{
+                        opacity: activeStep === i ? 1 : 0,
+                        transform: activeStep === i ? "scale(1)" : "scale(1.04)",
+                      }}
                     />
                   ))}
                 </div>

--- a/apps/web/components/home/ParallaxQuoteDivider.tsx
+++ b/apps/web/components/home/ParallaxQuoteDivider.tsx
@@ -3,21 +3,37 @@
 import { useState, useEffect, forwardRef, useMemo } from "react";
 import { motion, AnimatePresence, type MotionValue } from "motion/react";
 import { TypeWriter } from "@/components/TypeWriter";
+import { usePlaceImages } from "@travyl/shared";
 
-const ALL_SLIDES = [
-  { image: "https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=1400&fit=crop&q=75&fm=webp", quote: "The journey of a thousand miles begins with a single step.", author: "Lao Tzu" },
-  { image: "https://images.unsplash.com/photo-1530789253388-582c481c54b0?w=1400&fit=crop&q=75&fm=webp", quote: "Travel makes one modest. You see what a tiny place you occupy in the world.", author: "Gustave Flaubert" },
-  { image: "https://images.unsplash.com/photo-1493246507139-91e8fad9978e?w=1400&fit=crop&q=75&fm=webp", quote: "Life is short and the world is wide.", author: null },
-  { image: "https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=1400&fit=crop&q=75&fm=webp", quote: "Adventure is worthwhile in itself.", author: "Amelia Earhart" },
-  { image: "https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1400&fit=crop&q=75&fm=webp", quote: "Not all those who wander are lost.", author: "J.R.R. Tolkien" },
-  { image: "https://images.unsplash.com/photo-1488085061387-422e29b40080?w=1400&fit=crop&q=75&fm=webp", quote: "To travel is to live.", author: "Hans Christian Andersen" },
-  { image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=1400&fit=crop&q=75&fm=webp", quote: "The world is a book, and those who do not travel read only a page.", author: "Saint Augustine" },
-  { image: "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?w=1400&fit=crop&q=75&fm=webp", quote: "Travel far enough, you meet yourself.", author: "David Mitchell" },
-  { image: "https://images.unsplash.com/photo-1502602898657-3e91760cbb34?w=1400&fit=crop&q=75&fm=webp", quote: "Once a year, go someplace you've never been before.", author: "Dalai Lama" },
-  { image: "https://images.unsplash.com/photo-1528127269322-539801943592?w=1400&fit=crop&q=75&fm=webp", quote: "Travel is the only thing you buy that makes you richer.", author: null },
+// Curated travel quotes — expanded pool for variety
+const QUOTES = [
+  { quote: "The journey of a thousand miles begins with a single step.", author: "Lao Tzu" },
+  { quote: "Travel makes one modest. You see what a tiny place you occupy in the world.", author: "Gustave Flaubert" },
+  { quote: "Life is short and the world is wide.", author: null },
+  { quote: "Adventure is worthwhile in itself.", author: "Amelia Earhart" },
+  { quote: "Not all those who wander are lost.", author: "J.R.R. Tolkien" },
+  { quote: "To travel is to live.", author: "Hans Christian Andersen" },
+  { quote: "The world is a book, and those who do not travel read only a page.", author: "Saint Augustine" },
+  { quote: "Travel far enough, you meet yourself.", author: "David Mitchell" },
+  { quote: "Once a year, go someplace you've never been before.", author: "Dalai Lama" },
+  { quote: "Travel is the only thing you buy that makes you richer.", author: null },
+  { quote: "We travel not to escape life, but for life not to escape us.", author: null },
+  { quote: "A good traveler has no fixed plans and is not intent on arriving.", author: "Lao Tzu" },
+  { quote: "Take only memories, leave only footprints.", author: "Chief Seattle" },
+  { quote: "Jobs fill your pocket, but adventures fill your soul.", author: "Jaime Lyn Beatty" },
+  { quote: "The real voyage of discovery consists not in seeking new landscapes, but in having new eyes.", author: "Marcel Proust" },
+  { quote: "Wherever you go, go with all your heart.", author: "Confucius" },
 ];
 
-// Daily seed — same for server and client on the same day, changes at midnight
+// Fallback images — only used if trending + API images both fail
+const FALLBACK_IMAGES = [
+  "https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=1400&fit=crop&q=75&fm=webp",
+  "https://images.unsplash.com/photo-1530789253388-582c481c54b0?w=1400&fit=crop&q=75&fm=webp",
+  "https://images.unsplash.com/photo-1493246507139-91e8fad9978e?w=1400&fit=crop&q=75&fm=webp",
+  "https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1400&fit=crop&q=75&fm=webp",
+];
+
+// Daily seed — same for server and client on the same day
 function dailySeed(): number {
   const d = new Date();
   return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
@@ -32,12 +48,51 @@ function seededShuffle<T>(arr: T[], seed: number): T[] {
   return result;
 }
 
-export const ParallaxQuoteDivider = forwardRef<HTMLDivElement, { bgY: MotionValue<number> }>(
-  function ParallaxQuoteDivider({ bgY }, ref) {
+interface TrendingDestination {
+  name: string;
+  country: string;
+  thumbnail: string | null;
+}
+
+interface Props {
+  bgY: MotionValue<number>;
+  trendingDestinations?: TrendingDestination[];
+}
+
+export const ParallaxQuoteDivider = forwardRef<HTMLDivElement, Props>(
+  function ParallaxQuoteDivider({ bgY, trendingDestinations }, ref) {
     const [slideIndex, setSlideIndex] = useState(0);
 
-    // Deterministic shuffle — same on server and client for the same day
-    const slides = useMemo(() => seededShuffle(ALL_SLIDES, dailySeed()).slice(0, 4), []);
+    // Pick 4 trending destination names for high-res image lookups
+    const imageSearchNames = useMemo(() => {
+      if (!trendingDestinations?.length) return [];
+      const seed = dailySeed();
+      return seededShuffle(trendingDestinations, seed + 2)
+        .slice(0, 4)
+        .map((d) => `${d.name} ${d.country} landmark`);
+    }, [trendingDestinations]);
+
+    // Fetch high-res images via /api/images (same as hero/HowItWorks)
+    const imageQueries = usePlaceImages(imageSearchNames);
+
+    const slides = useMemo(() => {
+      const seed = dailySeed();
+      const shuffledQuotes = seededShuffle(QUOTES, seed);
+
+      // Build image list: prefer API images, then fallbacks
+      const apiImages = imageQueries
+        .map((q) => q.data?.url)
+        .filter((url): url is string => !!url);
+
+      const images = apiImages.length >= 4
+        ? apiImages
+        : [...apiImages, ...FALLBACK_IMAGES].slice(0, 4);
+
+      return shuffledQuotes.slice(0, 4).map((q, i) => ({
+        image: images[i % images.length],
+        ...q,
+      }));
+    }, [imageQueries]);
 
     useEffect(() => {
       const interval = setInterval(() => {
@@ -60,7 +115,7 @@ export const ParallaxQuoteDivider = forwardRef<HTMLDivElement, { bgY: MotionValu
             />
           ))}
         </motion.div>
-        <div className="absolute inset-0 bg-[#1e3a5f]/30" />
+        <div className="absolute inset-0 bg-[#0f1f33]/50" />
         <div className="relative h-full flex items-center justify-center z-10 px-6">
           <AnimatePresence mode="wait">
             <motion.p

--- a/planning/demo-feedback-march27.md
+++ b/planning/demo-feedback-march27.md
@@ -1,0 +1,69 @@
+# Demo Day Feedback — March 27, 2026
+
+## Scores
+
+| Metric | Avg | Min | Max |
+|---|---|---|---|
+| Demo quality | 4.3/5 | 3 | 5 |
+| Core functionality | 4.2/5 | 3 | 5 |
+| New user difficulty | 3.5/5 (lower = easier) | 1 | 5 |
+| UI quality | 4.4/5 | 2 | 5 |
+| Completeness | 73% | 45% | 90% |
+| Would use it | 3.9/5 | 1 | 5 |
+
+## What People Loved
+- "It was just so clean and they actually just let us use it"
+- "The UI design is fantastic"
+- "I love how you can personalize it, like dark mode and change the colors of the icons"
+- "Being able to plan a trip easily"
+- "User interface, very responsive and good to look at"
+- "The ability to collaborate in the budgets, planning what to pack and calendar section"
+- "All the different options to look through and helping functionality"
+- "The website looks professional and is running on a separate hosting instance"
+
+## What People Didn't Like / Issues Found
+
+### CRITICAL — Already in our audit
+| Feedback | Audit Item | Priority |
+|---|---|---|
+| "Making the main link work with the API" | B1: CloudFront 403 on deployed site | Critical |
+| "The flight page" needs most work | 7.1: Flight search tabs don't filter | High |
+| "Mobile functionality" needs work | M7-M14: Multiple mobile issues | High |
+| "Some things don't load" | API routes returning 404/500 on deployed | Critical |
+
+### HIGH — New from feedback
+| Feedback | What to Fix | Priority |
+|---|---|---|
+| "4 questions no matter what — should have skip option" | Already implementing: multi-select + skip | High |
+| "Showed Universal Studios Orlando in places in New Delhi" | Location filtering broken — results from wrong cities | High |
+| "Images are low res and not clickable" | Upscale Google thumbnails + make cards clickable | High |
+| "Places are too far apart" — location consistency | Search results mixing distant locations | High |
+| "Font color on some text" hard to read | Contrast audit needed | Medium |
+| "No option for staying with someone / having a house" | Add more accommodation types to questions | Medium |
+| Itinerary loads on 2nd prompt (not 1st) | Trip planner state machine — generating phase triggers too late | High |
+| "Spend a week in Georgia" — ambiguous (state vs country) | Backend should detect ambiguity and ask clarifying question | High |
+| Mobile itinerary cards broken/inconsistent, duplicates | Mobile card formatting + dedup logic | High |
+| Mobile Explore shows twice, only 2nd works | Duplicate Explore section rendering on mobile | High |
+| Obscure locations not found in API | Location API not exhaustive — add fallback or "not found" UX | Medium |
+
+### MEDIUM — Polish
+| Feedback | What to Fix | Priority |
+|---|---|---|
+| "More enforcement on login — non-logged-in users can see other people's trips" | Trip visibility/RLS not enforced | Medium |
+| "Keep map language consistent with user locale" | Leaflet tiles language | Medium |
+| "Address travel advisories to less than safe locations" | Safety info on destination | Medium |
+| "Filtering on some photos provided" | Photo content moderation | Low |
+| "Price conversion for different countries/currency" | Wire /api/exchange-rates | Medium |
+| "Make it so you can request specific things" | NLP search everywhere | Medium |
+| "A lot to look through at first" — overwhelming | Better onboarding/tour | Low |
+
+## Action Items Mapped to Week 1
+
+1. ✅ Skip + multi-select on questions (already implementing)
+2. 🔴 Fix location filtering — wrong city results (Universal Studios in New Delhi)
+3. 🔴 Fix deployed site API (CloudFront 403, missing env vars)
+4. 🔴 Image quality — upscale thumbnails, make cards clickable
+5. 🟡 Flight page improvements
+6. 🟡 Mobile functionality
+7. 🟡 Currency conversion
+8. 🟡 Text contrast audit

--- a/planning/master-task-list.md
+++ b/planning/master-task-list.md
@@ -1,0 +1,122 @@
+# Travyl Master Task List — 6 Week Sprint
+
+Last updated: March 27, 2026
+
+---
+
+## CRITICAL — App-Breaking
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| C1 | Fix CloudFront 403 on trip creation (payload too large for WAF) | E2E test | Todo |
+| C2 | Fix Amplify build stability (main/develop divergence) | Recurring | Done (TRA-286) |
+| C3 | Fix location filtering — wrong city results (Universal Studios in New Delhi) | Demo feedback F1 | Todo |
+| C4 | Fix deployed site: missing env vars, API routes 404/500 | E2E test | Partial |
+
+## HIGH — Broken or Fake Features
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| H1 | Questions: multi-select + skip button | Demo feedback F2 | In progress |
+| H2 | Card clicks → expand in-place detail (not blurry modal) | User feedback | Todo |
+| H3 | "Add to trip" buttons are fake — toggle local state only | E2E test | Todo |
+| H4 | Hotels page ignores trip_context (shows 0 until SerpAPI loads) | E2E test | Todo |
+| H5 | Flight search tabs don't filter (cheap/quick/best) | Audit + demo feedback | Todo |
+| H6 | Restaurants tab redirects silently to Explore | Audit | Todo |
+| H7 | Favorites not persisted — wire /api/favorites | Audit | Todo |
+| H8 | Budget expenses not persisted — lost on refresh | Audit | Todo |
+| H9 | Budget categories all show $0 despite having data | E2E test | Todo |
+| H10 | Day selector doesn't switch content on itinerary | E2E test | Todo |
+| H11 | Images low res and not clickable | Demo feedback F3 | Todo |
+| H12 | Settings page stuck "Loading..." for anonymous users | E2E test | Todo |
+| H13 | Packing list empty for new trips — needs auto-generation | E2E test | Todo |
+| H14 | Profile page all mock data (web + mobile) | Audit | Todo |
+| H15 | Mobile hotels 100% mock — doesn't read trip_context | Audit | Todo |
+| H16 | Mobile flight search doesn't submit | Audit | Todo |
+| H17 | Apple/Facebook/Microsoft OAuth buttons empty on mobile | Audit | Todo |
+| H18 | Mobile places not loading (API routing) | Testing | Partial |
+
+## MEDIUM — Polish & UX
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| M1 | How It Works scroll snapping | User feedback | Todo |
+| M2 | Font color contrast issues on some text | Demo feedback F4 | Todo |
+| M3 | Add accommodation types ("stay with someone", "own house") | Demo feedback F5 | Todo |
+| M4 | Trip visibility enforcement — anon users see others' trips | Demo feedback F6 | Todo |
+| M5 | Currency conversion — wire /api/exchange-rates | Demo feedback F7 | Todo |
+| M6 | Map language consistent with user locale | Demo feedback F8 | Todo |
+| M7 | Fix events API params (city+country, not lat/lng) | E2E test | Todo |
+| M8 | Fix flight search params (city names, not IATA codes) | API test | Todo |
+| M9 | Giant hero background bleeds through overview | Visual test | Todo |
+| M10 | Explore cards with no images → dark navy boxes | Visual test | Todo |
+| M11 | "Add activity" flow ambiguous on itinerary | Audit | Todo |
+| M12 | Hotel phone/email always empty | Audit | Todo |
+| M13 | NLP search everywhere — universal search component | Demo feedback F10 | Todo |
+| M14 | Mobile budget daily chart hardcoded | Audit | Todo |
+| M15 | Mobile settings hardcoded "Alex Rivera" | Audit | Todo |
+| M16 | Drag day to swap itinerary plans | User feedback | Todo |
+| M17 | Suppress hero_config/mosaic_tiles/inspiration_cards 404s | E2E test | Todo |
+
+## LOW — Nice to Have
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| L1 | Home page images always same destinations | User feedback | Todo |
+| L2 | Travel advisories for unsafe locations | Demo feedback F9 | Todo |
+| L3 | Onboarding — "a lot to look through at first" | Demo feedback F11 | Todo |
+| L4 | Photo content moderation/filtering | Demo feedback F12 | Todo |
+| L5 | Cars tab — implement or remove | Audit | Todo |
+| L6 | Profile settings pickers empty (email, password, delete) | Audit | Todo |
+| L7 | Forgot password not implemented | Audit | Todo |
+| L8 | Parallax workaround (document scroll) | Audit | Todo |
+
+## ENRICHMENT — SerpAPI Powered (Weeks 3-4)
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| E1 | Wire /api/favorites for persistence (backend has it) | API audit | Todo |
+| E2 | Wire /api/hotels/search to mobile hotels | API audit | Todo |
+| E3 | Wire /api/weather/forecast to overview + itinerary | API audit | Todo |
+| E4 | Wire /api/places/enrich to PlaceDetailModal | API audit | Todo |
+| E5 | Wire /api/places/menu for restaurant menus | API audit | Todo |
+| E6 | Request: /api/places/reviews (Google Maps Reviews) | SerpAPI map | Todo |
+| E7 | Request: /api/search/autocomplete (type-ahead) | SerpAPI map | Todo |
+| E8 | Request: /api/tripadvisor/place (rankings, badges) | SerpAPI map | Todo |
+| E9 | Request: /api/yelp/place (food photos, "Good for" tags) | SerpAPI map | Todo |
+| E10 | Request: /api/destinations/trending (Google Trends) | SerpAPI map | Todo |
+| E11 | Request: /api/destinations/news (Google News) | SerpAPI map | Todo |
+| E12 | Request: /api/opentable/search (reservations) | SerpAPI map | Todo |
+| E13 | Use /api/images/destination for trip hero images | API audit | Todo |
+| E14 | Cross-source card enrichment (Google + TA + Yelp merged) | Strategy | Todo |
+
+## NEW FEATURES (Weeks 4-6)
+
+| # | Task | Source | Status |
+|---|---|---|---|
+| N1 | Reviews system — submit + display | Roadmap | Todo |
+| N2 | Booking/payment integration (Stripe) | Roadmap | Todo |
+| N3 | Push notifications | Roadmap | Todo |
+| N4 | Offline mode for mobile | Roadmap | Todo |
+| N5 | Deep linking — share trips via URL | Roadmap | Todo |
+| N6 | Trip templates — browse + apply | Roadmap | Todo |
+| N7 | Email notifications — trip reminders, flight alerts | Roadmap | Todo |
+| N8 | Accessibility audit (WCAG 2.1 AA) | Roadmap | Todo |
+| N9 | Analytics integration | Roadmap | Todo |
+| N10 | App store submission prep | Roadmap | Todo |
+
+---
+
+## COMPLETED
+
+| # | Task | PR |
+|---|---|---|
+| ✓ | Mock data removal (web + mobile) | TRA-285, #356 |
+| ✓ | Mobile trip gen fix (useTripPlanner routing) | TRA-285, #356 |
+| ✓ | Flight data wiring (trip_context fallback) | TRA-285, #356 |
+| ✓ | Calendar navbar/sidebar transparency | TRA-285, #356 |
+| ✓ | useScroll hydration fix | TRA-285, #356 |
+| ✓ | Repo cleanup — screenshots, orphaned components | TRA-286, #382 |
+| ✓ | Amplify build fixes (styled-jsx, layoutEffect, props) | Multiple PRs |
+| ✓ | SUPABASE_SERVICE_ROLE_KEY env var compat | #358 |
+| ✓ | Mobile flights wired to trip_context | #363 |


### PR DESCRIPTION
## Summary

Homepage overhaul based on demo day feedback (TRA-287).

- **LiveStats**: Real Supabase counts via `/api/stats` with shimmer skeleton (replaces fake 500K/95M/2B)
- **Trending destination pills**: SerpAPI-powered via `/api/trending-destinations` (replaces hardcoded suggestions)
- **Send vs Refine flow**: Send skips questions → instant planning; Refine shows follow-ups for personalization
- **Hero contrast**: Stronger overlay gradient + dark subtitle pill for readability on light images
- **Scroll indicator**: Animated mouse icon at bottom of hero
- **Removed**: Recent Trips section, TravelMosaic, PlaceDetailOverlay, unused imports
- **New API routes**: `/api/stats`, `/api/trending-destinations`
- **Planning docs**: Demo feedback scores + 6-week master task list

## Test plan

- [ ] Homepage loads without console errors
- [ ] LiveStats shows skeleton shimmer, then animates real numbers
- [ ] Trending pills appear and cycle every 3.5s
- [ ] Clicking a pill triggers trip planning directly
- [ ] Send button skips questions; Refine button shows follow-up questions
- [ ] Hero text readable on all slideshow images
- [ ] Scroll indicator visible at bottom of hero
- [ ] No Recent Trips or TravelMosaic sections render
- [ ] `/api/stats` returns `{ destinations, travelers, trips }`
- [ ] `/api/trending-destinations` returns array of destinations