### PR TITLE
fix: scope trips query to current user, tighten RLS policies

### DIFF
--- a/apps/web/app/api/trips/route.ts
+++ b/apps/web/app/api/trips/route.ts
@@ -27,10 +27,11 @@ export async function GET(req: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
 
   if (user) {
-    // Logged in: RLS returns only their trips
+    // Logged in: return only trips owned by this user
     const { data, error } = await supabase
       .from('trips')
       .select('*')
+      .eq('user_id', user.id)
       .order('created_at', { ascending: false })
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })

--- a/packages/shared/src/hooks/useTrips.ts
+++ b/packages/shared/src/hooks/useTrips.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchTrips } from '../services/api';
+import { fetchTrips, fetchCollaboratorTrips } from '../services/api';
 import { supabase } from '../services/supabase';
+import { useAuthStore } from '../stores/authStore';
 import type { Trip } from '../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -42,37 +43,61 @@ export async function saveAnonTripId(tripId: string): Promise<void> {
   } catch {}
 }
 
-async function fetchTripsWithAnonymous(): Promise<Trip[]> {
-  const anonIds = await getAnonTripIds();
+async function fetchTripsForUser(userId: string): Promise<Trip[]> {
+  const [owned, collaborated] = await Promise.all([
+    fetchTrips(userId),
+    fetchCollaboratorTrips(userId),
+  ]);
 
-  // Web: use API route for anonymous trips
-  if (anonIds.length > 0 && typeof (globalThis as any).document !== 'undefined') {
-    try {
-      const res = await fetch(`/api/trips?ids=${anonIds.join(',')}`);
-      if (res.ok) return res.json() as Promise<Trip[]>;
-    } catch {}
+  // Merge and deduplicate by id
+  const seen = new Set<string>();
+  const merged: Trip[] = [];
+  for (const trip of [...owned, ...collaborated]) {
+    if (!seen.has(trip.id)) {
+      seen.add(trip.id);
+      merged.push(trip);
+    }
+  }
+  return merged;
+}
+
+async function fetchTripsWithAnonymous(userId: string | null): Promise<Trip[]> {
+  // Anonymous users: fetch by stored trip IDs via API route (service key)
+  if (!userId) {
+    const anonIds = await getAnonTripIds();
+
+    // Web: use API route for anonymous trips
+    if (anonIds.length > 0 && typeof (globalThis as any).document !== 'undefined') {
+      try {
+        const res = await fetch(`/api/trips?ids=${anonIds.join(',')}`);
+        if (res.ok) return res.json() as Promise<Trip[]>;
+      } catch {}
+    }
+
+    // Mobile/fallback: fetch specific trip IDs directly from Supabase
+    if (anonIds.length > 0) {
+      try {
+        const { data, error } = await supabase
+          .from('trips')
+          .select('*')
+          .in('id', anonIds)
+          .order('created_at', { ascending: false });
+        if (!error && data?.length) return data as Trip[];
+      } catch {}
+    }
+
+    return [];
   }
 
-  // Mobile/fallback: fetch specific trip IDs directly from Supabase
-  if (anonIds.length > 0) {
-    try {
-      const { data, error } = await supabase
-        .from('trips')
-        .select('*')
-        .in('id', anonIds)
-        .order('created_at', { ascending: false });
-      if (!error && data?.length) return data as Trip[];
-    } catch {}
-  }
-
-  // Default: use Supabase directly (RLS filters for logged-in users)
-  return fetchTrips();
+  // Logged-in users: fetch own + collaborated trips
+  return fetchTripsForUser(userId);
 }
 
 export function useTrips() {
+  const user = useAuthStore((s) => s.user);
   return useQuery({
-    queryKey: ['trips'],
-    queryFn: fetchTripsWithAnonymous,
+    queryKey: ['trips', user?.id ?? 'anon'],
+    queryFn: () => fetchTripsWithAnonymous(user?.id ?? null),
     enabled: true,
   });
 }

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -1,13 +1,26 @@
 import { supabase } from './supabase';
 import type { Trip, Profile, SavedItem, MosaicTile, InspirationCard, ExplorePlaceRow, HeroConfig, Activity, ItineraryDayWithActivities, Flight, Hotel, TripCollaborator, TripNote, Visibility, LinkPermission, CollaboratorRole } from '../types';
 
-export async function fetchTrips(): Promise<Trip[]> {
+export async function fetchTrips(userId: string): Promise<Trip[]> {
   const { data, error } = await supabase
     .from('trips')
     .select('*')
+    .eq('user_id', userId)
     .order('created_at', { ascending: false });
   if (error) throw error;
   return data ?? [];
+}
+
+export async function fetchCollaboratorTrips(userId: string): Promise<Trip[]> {
+  const { data, error } = await supabase
+    .from('trips')
+    .select('*, trip_collaborators!inner(*)')
+    .eq('trip_collaborators.user_id', userId)
+    .eq('trip_collaborators.invite_status', 'accepted')
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  // Strip the join column before returning
+  return (data ?? []).map(({ trip_collaborators: _tc, ...trip }) => trip as Trip);
 }
 
 export async function fetchSavedItems(): Promise<SavedItem[]> {
@@ -553,7 +566,7 @@ export async function savePlanToSupabase(
   // 1. Create trip
   const tripInsert: Record<string, unknown> = {
     user_id: user?.id || null,
-    visibility: user?.id ? 'private' : 'public',
+    visibility: 'private',
     title: `${dest.city}, ${dest.country}`,
     destination: `${dest.city}, ${dest.country}`,
     start_date: ext.dates.start,

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -1,6 +1,7 @@
 export { supabase, configureSupabase } from './supabase';
 export {
   fetchTrips,
+  fetchCollaboratorTrips,
   fetchSavedItems,
   fetchProfile,
   fetchMosaicTiles,

--- a/supabase/migrations/20260327000000_fix_trips_rls.sql
+++ b/supabase/migrations/20260327000000_fix_trips_rls.sql
@@ -1,0 +1,34 @@
+-- Fix trips RLS: remove overly-broad public policies that leak all shared/public trips
+-- to every authenticated user, and tighten anonymous insert access.
+
+-- 1. Drop trips_select_shared — any auth user sees ALL link/public trips.
+--    trips_select_by_share_token already handles share-link access correctly
+--    (requires matching share_link_token via current_share_token()).
+--    Collaborators access trips via "Collaborators can select trips" policy.
+DROP POLICY IF EXISTS "trips_select_shared" ON trips;
+
+-- 2. Drop trips_insert_public — WITH CHECK true lets anyone insert any trip.
+--    Replace with policy that only allows inserts where user_id IS NULL
+--    (anonymous creates from savePlanToSupabase via the web planner).
+DROP POLICY IF EXISTS "trips_insert_public" ON trips;
+
+CREATE POLICY "trips_insert_anonymous"
+  ON trips FOR INSERT
+  TO authenticated, anon
+  WITH CHECK (user_id IS NULL);
+
+-- 3. Drop trips_delete_public — anyone could delete public trips.
+--    "Users can delete their own trips" already covers owner deletes.
+DROP POLICY IF EXISTS "trips_delete_public" ON trips;
+
+-- 4. Drop trips_update_context_public — anyone could update public trips.
+--    "Users can update their own trips" already covers owner updates.
+--    Collaborator editors are covered by "editors_update_*" policies on child tables.
+DROP POLICY IF EXISTS "trips_update_context_public" ON trips;
+
+-- 5. Fix existing anonymous-created trips: set visibility from 'public' to 'private'.
+--    These are accessed via /api/trips?ids=... with service key, not RLS.
+UPDATE trips
+SET visibility = 'private'
+WHERE visibility = 'public'
+  AND user_id IS NULL;


### PR DESCRIPTION
## Summary
- Drop `trips_select_shared`, `trips_insert_public`, `trips_delete_public`, and `trips_update_context_public` RLS policies that leaked all shared/public trips to every authenticated user
- Add `fetchTrips(userId)` with `.eq('user_id', userId)` filter and new `fetchCollaboratorTrips(userId)` for collaborator join
- Update `useTrips` hook to fetch owned + collaborated trips, merge/deduplicate, and keep anonymous path unchanged
- Fix `savePlanToSupabase` to always use `visibility: 'private'` (anonymous trips accessed via service key API route, not RLS)
- Update 20 existing anonymous trips from `visibility = 'public'` to `'private'`
- Fix `/api/trips` route to filter by `user_id` for logged-in users

## Test plan
- [ ] Log in as User A — `/trips` should only show own + collaborated trips
- [ ] Log in as User B — should NOT see User A's trips
- [ ] Create a trip as anonymous user — verify it appears via the anon flow
- [ ] Share a trip via link — verify direct URL access still works (`trips_select_by_share_token`)
- [ ] Verify collaborators still see shared trips on their `/trips` tab