### PR TITLE
chore: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,12 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: 'npm'

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -7,7 +7,7 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v5
        with:
          fetch-depth: 0
      - run: |


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` from v4 to v5 (Node 24 native) across all 3 workflow files
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to deploy job for `aws-actions/configure-aws-credentials@v4` which has no Node 24-compatible release yet

Fixes the Node.js 20 deprecation warnings: actions will be forced to Node 24 on June 2, 2026.

## Test plan
- [ ] Next push to `develop` triggers the deploy workflow without Node 20 deprecation warnings
- [ ] Mirror workflow runs without warnings on next `main` push