### PR TITLE
feat: spotlight search two-phase pipeline overhaul

### DIFF
--- a/apps/web/app/api/search/deep/route.ts
+++ b/apps/web/app/api/search/deep/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl
+  const q = searchParams.get('q')
+  const intent = searchParams.get('intent')
+  const location = searchParams.get('location')
+  const entityType = searchParams.get('entityType')
+  const auth = req.headers.get('authorization')
+
+  if (!q || !auth || !API_URL) {
+    return NextResponse.json({ results: {} })
+  }
+
+  const params = new URLSearchParams({ q, intent: intent ?? 'unknown' })
+  if (location) params.set('location', location)
+  if (entityType) params.set('entityType', entityType)
+
+  const res = await fetch(`${API_URL}/search/deep?${params}`, {
+    headers: { Authorization: auth },
+  })
+
+  if (!res.ok) {
+    console.error('[search/deep proxy] Lambda error:', res.status, await res.text().catch(() => ''))
+    return NextResponse.json({ results: {} })
+  }
+
+  return NextResponse.json(await res.json())
+}

--- a/apps/web/app/api/search/quick/route.ts
+++ b/apps/web/app/api/search/quick/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get('q')
+  const auth = req.headers.get('authorization')
+
+  if (!q || !auth || !API_URL) {
+    return NextResponse.json({ intent: { intent: 'unknown', rawQuery: q ?? '' }, results: {} })
+  }
+
+  const res = await fetch(`${API_URL}/search/quick?q=${encodeURIComponent(q)}`, {
+    headers: { Authorization: auth },
+  })
+
+  if (!res.ok) {
+    console.error('[search/quick proxy] Lambda error:', res.status, await res.text().catch(() => ''))
+    return NextResponse.json({ intent: { intent: 'unknown', rawQuery: q }, results: {} })
+  }
+
+  return NextResponse.json(await res.json())
+}

--- a/apps/web/components/spotlight/SpotlightResultGroup.tsx
+++ b/apps/web/components/spotlight/SpotlightResultGroup.tsx
@@ -18,6 +18,14 @@ const TYPE_LABELS: Record<string, string> = {
   action: 'Quick Actions',
 }
 
+const SOURCE_LABELS: Record<string, string> = {
+  'my-trips': 'Your trips',
+  'foursquare': 'Foursquare',
+  'discover': 'Discover',
+  'serpapi': 'Web',
+  'collaborators': 'People',
+}
+
 interface Props {
   type: string
   results: SpotlightResult[]
@@ -57,6 +65,11 @@ export function SpotlightResultGroup({
         <span className="text-[10px] text-gray-300 dark:text-gray-600">
           ({results.length})
         </span>
+        {results[0]?.metadata?.source && (
+          <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 leading-none">
+            {SOURCE_LABELS[results[0].metadata.source as string] ?? results[0].metadata.source as string}
+          </span>
+        )}
       </div>
       {results.map((result, i) => (
         <SpotlightResultItem

--- a/apps/web/components/spotlight/SpotlightResults.tsx
+++ b/apps/web/components/spotlight/SpotlightResults.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, forwardRef } from 'react'
 import type { RefObject } from 'react'
-import { AnimatePresence } from 'motion/react'
+import { AnimatePresence, motion } from 'motion/react'
 import type { SpotlightResult } from '@travyl/shared'
 import { SpotlightResultGroup } from './SpotlightResultGroup'
 
@@ -10,22 +10,39 @@ const CATEGORY_ORDER = ['trip', 'restaurant', 'activity', 'destination', 'naviga
 
 interface Props {
   results: Record<string, SpotlightResult[]>
+  quickResults?: Record<string, SpotlightResult[]>
+  deepResults?: Record<string, SpotlightResult[]>
   activeIndex: number
   onSelect: (result: SpotlightResult) => void
   query: string
   itemRefs: RefObject<(HTMLButtonElement | null)[]>
   isPinned?: (id: string) => boolean
+  deepLoading?: boolean
 }
 
 export const SpotlightResults = forwardRef<HTMLDivElement, Props>(
-  function SpotlightResults({ results, activeIndex, onSelect, query, itemRefs, isPinned }, ref) {
+  function SpotlightResults({ results, quickResults, deepResults, activeIndex, onSelect, query, itemRefs, isPinned, deepLoading }, ref) {
     const orderedCategories = useMemo(() => {
       return CATEGORY_ORDER.filter((type) => results[type]?.length)
     }, [results])
 
+    // Phase 1 categories: those present in quickResults, or all categories if no quickResults provided
+    const quickCategories = useMemo(() => {
+      if (!quickResults) return orderedCategories
+      return CATEGORY_ORDER.filter((type) => quickResults[type]?.length)
+    }, [quickResults, orderedCategories])
+
+    // Phase 2 categories: those in deepResults but NOT already in Phase 1
+    const deepCategories = useMemo(() => {
+      if (!deepResults) return []
+      return CATEGORY_ORDER.filter(
+        (type) => deepResults[type]?.length && !quickResults?.[type]?.length
+      )
+    }, [deepResults, quickResults])
+
     let runningIndex = 0
 
-    if (orderedCategories.length === 0) {
+    if (orderedCategories.length === 0 && !deepLoading) {
       return (
         <div className="px-4 py-8 text-center">
           <p className="text-sm text-gray-400">No results found</p>
@@ -38,25 +55,66 @@ export const SpotlightResults = forwardRef<HTMLDivElement, Props>(
 
     return (
       <div ref={ref} className="max-h-[400px] overflow-y-auto py-2 scroll-smooth">
-        <AnimatePresence mode="wait">
-          {orderedCategories.map((type, groupIndex) => {
+        {/* Phase 1: renders immediately */}
+        {quickCategories.map((type, groupIndex) => {
+          const baseIndex = runningIndex
+          runningIndex += results[type]?.length ?? 0
+          return (
+            <SpotlightResultGroup
+              key={type}
+              type={type}
+              results={results[type] ?? []}
+              activeIndex={activeIndex}
+              baseIndex={baseIndex}
+              onSelect={onSelect}
+              query={query}
+              animationDelay={groupIndex * 0.05}
+              itemRefs={itemRefs}
+              isPinned={isPinned}
+            />
+          )
+        })}
+
+        {/* Phase 2: animates in when deep results arrive */}
+        <AnimatePresence>
+          {deepCategories.map((type, groupIndex) => {
             const baseIndex = runningIndex
-            runningIndex += results[type].length
+            runningIndex += results[type]?.length ?? 0
             return (
-              <SpotlightResultGroup
-                key={type}
-                type={type}
-                results={results[type]}
-                activeIndex={activeIndex}
-                baseIndex={baseIndex}
-                onSelect={onSelect}
-                query={query}
-                animationDelay={groupIndex * 0.05}
-                itemRefs={itemRefs}
-                isPinned={isPinned}
-              />
+              <motion.div
+                key={`deep-${type}`}
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2, delay: groupIndex * 0.05 }}
+              >
+                <SpotlightResultGroup
+                  type={type}
+                  results={results[type] ?? []}
+                  activeIndex={activeIndex}
+                  baseIndex={baseIndex}
+                  onSelect={onSelect}
+                  query={query}
+                  itemRefs={itemRefs}
+                  isPinned={isPinned}
+                />
+              </motion.div>
             )
           })}
+        </AnimatePresence>
+
+        {/* Phase 2 loading indicator */}
+        <AnimatePresence>
+          {deepLoading && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="px-4 py-2 text-center"
+            >
+              <p className="text-[11px] text-gray-400/60">Searching external sources...</p>
+            </motion.div>
+          )}
         </AnimatePresence>
       </div>
     )

--- a/apps/web/components/spotlight/SpotlightSearch.tsx
+++ b/apps/web/components/spotlight/SpotlightSearch.tsx
@@ -35,6 +35,8 @@ export function SpotlightSearch() {
     setQuery,
     results,
     isLoading,
+    quickLoading,
+    deepLoading,
     recentSearches,
     addRecentSearch,
     clearRecent,
@@ -364,6 +366,7 @@ export function SpotlightSearch() {
                             query={query}
                             itemRefs={itemRefs}
                             isPinned={isPinned}
+                            deepLoading={deepLoading}
                           />
                         ) : query.length >= 1 && !isLoading ? (
                           <div className="px-4 py-8 text-center">

--- a/apps/web/components/spotlight/SpotlightSearch.tsx
+++ b/apps/web/components/spotlight/SpotlightSearch.tsx
@@ -368,16 +368,20 @@ export function SpotlightSearch() {
                             isPinned={isPinned}
                             deepLoading={deepLoading}
                           />
-                        ) : query.length >= 1 && !isLoading ? (
+                        ) : query.length >= 1 && !isLoading && !quickLoading ? (
                           <div className="px-4 py-8 text-center">
-                            <p className="text-sm text-gray-400">No results found</p>
+                            <p className="text-sm text-gray-400">No results in your trips</p>
                             <p className="text-xs text-gray-400/70 mt-1">
-                              Try a different search term
+                              {deepLoading
+                                ? 'Still searching external sources...'
+                                : 'Try a different search term or check spelling'}
                             </p>
                           </div>
                         ) : query.length >= 1 && isLoading ? (
                           <div className="px-4 py-8 text-center">
-                            <p className="text-sm text-gray-400">Searching...</p>
+                            <p className="text-sm text-gray-400">
+                              {quickLoading ? 'Searching...' : 'Searching external places...'}
+                            </p>
                           </div>
                         ) : null}
                       </div>

--- a/apps/web/hooks/useSpotlightSearch.ts
+++ b/apps/web/hooks/useSpotlightSearch.ts
@@ -4,10 +4,8 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams, usePathname } from 'next/navigation'
 import { useAuthStore, useTrip, mergeSearchResults, type SpotlightResult } from '@travyl/shared'
-import { useContextSearch } from './useContextSearch'
 import { useCalendarCommandsStore } from '@/stores/calendarCommandsStore'
 import { fuzzyMatch } from '@/components/spotlight/fuzzyMatch'
-import { parseQueryIntent, type ParsedIntent } from '@/lib/parseQueryIntent'
 
 const RECENT_SEARCHES_KEY = 'travyl:recentSearches'
 const PINNED_RESULTS_KEY = 'travyl:pinnedResults'
@@ -37,101 +35,89 @@ const NAV_ITEMS: SpotlightResult[] = [
   { id: 'nav-settings', type: 'navigation', title: 'Settings', subtitle: 'App settings', href: '/profile/settings', score: 1 },
 ]
 
-async function fetchEntitySearch(
+// --- New interfaces for the two-phase pipeline ---
+
+interface QuickSearchTripResult {
+  tripId: string
+  title: string
+  destination: string
+  startDate: string | null
+  endDate: string | null
+  status: string
+  activityCount: number
+  imageUrl: string | null
+  score: number
+}
+
+interface QuickSearchEntityResult {
+  entity_id: string
+  entity_type: string
+  entity_name: string
+  entity_subtitle: string | null
+  trip_id: string | null
+  trip_title: string | null
+  trip_destination: string | null
+  image_url: string | null
+  score: number
+  latitude: number | null
+  longitude: number | null
+  metadata?: Record<string, unknown>
+}
+
+interface QuickSearchResponse {
+  intent: { intent: string; location?: string; entityType?: string; rawQuery: string }
+  results: {
+    trip?: QuickSearchTripResult[]
+    [key: string]: QuickSearchEntityResult[] | QuickSearchTripResult[] | undefined
+  }
+}
+
+interface DeepSearchResponse {
+  results: {
+    restaurant?: Array<{ id: string; type: string; title: string; subtitle: string; href: string; score: number; metadata?: Record<string, unknown> }>
+    activity?: Array<{ id: string; type: string; title: string; subtitle: string; href: string; score: number; metadata?: Record<string, unknown> }>
+    hotel?: Array<{ id: string; type: string; title: string; subtitle: string; href: string; score: number; metadata?: Record<string, unknown> }>
+    destination?: Array<{ id: string; type: string; title: string; subtitle: string; imageUrl?: string; href: string; score: number; metadata?: Record<string, unknown> }>
+    user?: Array<{ id: string; type: string; title: string; subtitle: string; href: string; score: number; metadata?: Record<string, unknown> }>
+    [key: string]: Array<{ id: string; type: string; title: string; subtitle: string; href?: string; imageUrl?: string; score: number; metadata?: Record<string, unknown> }> | undefined
+  }
+}
+
+// --- Fetch functions ---
+
+async function fetchSearchQuick(
   query: string,
-  types: string[] | null,
-  tripId: string | null,
   token: string,
-): Promise<Record<string, SpotlightResult[]>> {
+  tripId: string | null,
+): Promise<QuickSearchResponse> {
   const params = new URLSearchParams({ q: query })
-  if (types) params.set('types', types.join(','))
   if (tripId) params.set('tripId', tripId)
-
-  const res = await fetch(`/api/entity-search?${params}`, {
+  const res = await fetch(`/api/search/quick?${params}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
-  if (!res.ok) return {}
-
-  const { results } = await res.json() as {
-    results: Record<string, Array<{
-      entity_id: string
-      entity_type: string
-      entity_name: string
-      entity_subtitle: string | null
-      trip_id: string | null
-      trip_title: string | null
-      trip_destination: string | null
-      image_url: string | null
-      score: number
-      latitude: number | null
-      longitude: number | null
-      metadata?: Record<string, unknown>
-    }>>
-  }
-
-  // Transform API results to SpotlightResult
-  const mapped: Record<string, SpotlightResult[]> = {}
-  for (const [type, items] of Object.entries(results)) {
-    mapped[type] = items.map((item) => ({
-      id: item.entity_id,
-      type: item.entity_type as SpotlightResult['type'],
-      title: item.entity_name,
-      subtitle: item.entity_subtitle ?? item.trip_title ?? '',
-      imageUrl: item.image_url ?? undefined,
-      tripId: item.trip_id ?? undefined,
-      tripTitle: item.trip_title ?? undefined,
-      href: buildHref(item.entity_type, item.entity_id, item.trip_id, item.entity_name),
-      score: item.score,
-      metadata: {
-        ...item.metadata,
-        latitude: item.latitude ?? undefined,
-        longitude: item.longitude ?? undefined,
-      },
-    }))
-  }
-  return mapped
-}
-
-interface DiscoverPlace {
-  id: string
-  name: string
-  category: string
-  imageUrl: string
-  rating: number | null
-  priceLevel: string | null
-  location: string
-  latitude: number
-  longitude: number
-  description: string
-}
-
-interface DiscoverResponse {
-  destination: { name: string; imageUrl: string } | null
-  places: DiscoverPlace[]
-  route?: { origin: string; destination: string }
-}
-
-async function fetchDiscover(query: string, token: string): Promise<DiscoverResponse> {
-  const res = await fetch(`/api/discover?q=${encodeURIComponent(query)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) return { destination: null, places: [] }
+  if (!res.ok) return { intent: { intent: 'unknown', rawQuery: query }, results: {} }
   return res.json()
 }
 
-async function fetchFsqSearch(query: string, near?: string): Promise<Record<string, SpotlightResult[]>> {
-  const params = new URLSearchParams({ q: query })
-  if (near) params.set('near', near)
-  const res = await fetch(`/api/fsq-search?${params}`)
-  if (!res.ok) return {}
-  const { results } = await res.json() as { results: SpotlightResult[] }
-  const grouped: Record<string, SpotlightResult[]> = {}
-  for (const r of results) {
-    if (!grouped[r.type]) grouped[r.type] = []
-    grouped[r.type].push(r)
-  }
-  return grouped
+async function fetchSearchDeep(
+  query: string,
+  intent: { intent: string; location?: string; entityType?: string; rawQuery: string },
+  token: string,
+): Promise<DeepSearchResponse> {
+  const params = new URLSearchParams({
+    q: query,
+    intent: intent.intent,
+  })
+  if (intent.location) params.set('location', intent.location)
+  if (intent.entityType) params.set('entityType', intent.entityType)
+  const res = await fetch(`/api/search/deep?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) return { results: {} }
+  return res.json()
 }
+
+// --- Helpers ---
 
 function buildHref(type: string, entityId: string, tripId: string | null, entityName?: string): string {
   if (type === 'destination') return `/destination/${encodeURIComponent(entityName ?? '')}`
@@ -142,6 +128,25 @@ function buildHref(type: string, entityId: string, tripId: string | null, entity
   switch (type) {
     case 'flight': return `/trip/${tripId}/flights/${entityId}`
     default: return '/'
+  }
+}
+
+function mapEntityToSpotlight(item: QuickSearchEntityResult): SpotlightResult {
+  return {
+    id: item.entity_id,
+    type: item.entity_type as SpotlightResult['type'],
+    title: item.entity_name,
+    subtitle: item.entity_subtitle ?? item.trip_title ?? '',
+    imageUrl: item.image_url ?? undefined,
+    tripId: item.trip_id ?? undefined,
+    tripTitle: item.trip_title ?? undefined,
+    href: buildHref(item.entity_type, item.entity_id, item.trip_id, item.entity_name),
+    score: item.score,
+    metadata: {
+      ...item.metadata,
+      latitude: item.latitude ?? undefined,
+      longitude: item.longitude ?? undefined,
+    },
   }
 }
 
@@ -184,59 +189,31 @@ export function useSpotlightSearch() {
   const { data: tripData } = useTrip(isInTripContext && !clearTripScope ? tripId ?? undefined : undefined)
   const tripName = tripData?.title ?? null
 
-  // Debounce query for entity search (context-search has its own debounce)
+  // 200ms debounce (single debounce for the two-phase pipeline)
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 300)
+    const timer = setTimeout(() => setDebouncedQuery(query), 200)
     return () => clearTimeout(timer)
   }, [query])
 
-  // Determine entity-search types based on scope
-  const entitySearchTypes = useMemo(() => {
-    if (!scope) return null
-    return SCOPE_TO_TYPES[scope] ?? null
-  }, [scope])
+  const shouldSearchQuick = debouncedQuery.length >= 2 && !!token
 
-  const shouldSearch = debouncedQuery.length >= 3 && !!token
-
-  // Intent parsing — Phase 1 (sync regex) or Phase 2 (Haiku LLM fallback) before any search fires
-  const { data: parsedIntent, isLoading: intentLoading } = useQuery<ParsedIntent>({
-    queryKey: ['parse-intent', debouncedQuery],
-    queryFn: () => parseQueryIntent(debouncedQuery, token!),
-    enabled: shouldSearch,
-    staleTime: Infinity, // intent for a given query string never changes
-  })
-
-  // Existing context-search for trips (vector-powered)
-  const { results: tripSearchResults, isLoading: tripSearchLoading } = useContextSearch(query)
-
-  // New entity-search for hotels, flights, restaurants, activities, destinations
-  const { data: entityResults, isLoading: entityLoading } = useQuery({
-    queryKey: ['entity-search', debouncedQuery, effectiveTripId, entitySearchTypes],
-    queryFn: () => fetchEntitySearch(debouncedQuery, entitySearchTypes, effectiveTripId, token!),
-    enabled: shouldSearch,
+  // Phase 1: Quick search — internal data only
+  const { data: quickData, isLoading: quickLoading } = useQuery({
+    queryKey: ['search-quick', debouncedQuery, effectiveTripId],
+    queryFn: () => fetchSearchQuick(debouncedQuery, token!, effectiveTripId),
+    enabled: shouldSearchQuick,
     staleTime: 30_000,
   })
 
-  // Use parsed location if available (e.g. "Bakersfield" from "bakersfield restaurants")
-  const discoverLocation = parsedIntent?.location ?? debouncedQuery
+  // Extract intent from Phase 1 response (parsed server-side)
+  const parsedIntent = quickData?.intent
 
-  // Live discover for destination queries — waits for intent to resolve before firing.
-  // Fires regardless of scope so entity-type scoped searches (e.g. "bakersfield restaurants")
-  // still get discover results; scope filtering happens in discoverResults memo below.
-  const { data: discoverData, isLoading: discoverLoading } = useQuery({
-    queryKey: ['discover', discoverLocation],
-    queryFn: () => fetchDiscover(discoverLocation, token!),
-    enabled: shouldSearch && parsedIntent !== undefined,
-    staleTime: 60_000,
-  })
-
-  // Foursquare text search — fires for entity-search intents to surface named places
-  // (e.g. "the botanist bakersfield") that aren't in the user's saved trip data.
-  const fsqEnabled = shouldSearch && parsedIntent !== undefined && parsedIntent.intent === 'entity-search'
-  const { data: fsqResults, isLoading: fsqLoading } = useQuery({
-    queryKey: ['fsq-search', debouncedQuery, parsedIntent?.location],
-    queryFn: () => fetchFsqSearch(debouncedQuery, parsedIntent?.location),
-    enabled: fsqEnabled,
+  // Phase 2: Deep search — external data, only fires when Phase 1 returns intent
+  const shouldSearchDeep = !!quickData?.intent && debouncedQuery.length >= 3
+  const { data: deepData, isLoading: deepLoading } = useQuery({
+    queryKey: ['search-deep', debouncedQuery, quickData?.intent],
+    queryFn: () => fetchSearchDeep(debouncedQuery, quickData!.intent, token!),
+    enabled: shouldSearchDeep,
     staleTime: 60_000,
   })
 
@@ -287,12 +264,13 @@ export function useSpotlightSearch() {
     return cleaned.length ? { command: cleaned } : {}
   }, [commands, debouncedQuery, scope])
 
-  // Transform trip search results into SpotlightResult format
+  // Transform Phase 1 trip results
   const tripResults = useMemo((): Record<string, SpotlightResult[]> => {
-    if (scope && scope !== 'trips') return {} // scope filters out trip results
-    if (!tripSearchResults?.length) return {}
+    if (scope && scope !== 'trips') return {}
+    const trips = quickData?.results?.trip
+    if (!trips?.length) return {}
     return {
-      trip: tripSearchResults.map((r) => ({
+      trip: trips.map((r) => ({
         id: r.tripId,
         type: 'trip' as const,
         title: r.title,
@@ -301,71 +279,46 @@ export function useSpotlightSearch() {
         tripId: r.tripId,
         href: `/trip/${r.tripId}`,
         score: r.score,
+        metadata: { source: 'my-trips' },
       })),
     }
-  }, [tripSearchResults, scope])
+  }, [quickData?.results?.trip, scope])
 
-  // Transform discover response into SpotlightResult format
-  const discoverResults = useMemo((): Record<string, SpotlightResult[]> => {
-    if (!discoverData?.places?.length) return {}
-
-    // Build destination card — only when no scope (scope-less exploration)
+  // Transform Phase 1 entity results (activities + restaurants from user's trips)
+  const quickEntityResults = useMemo((): Record<string, SpotlightResult[]> => {
     const results: Record<string, SpotlightResult[]> = {}
-
-    if (!scope && discoverData.destination?.name) {
-      results.destination = [{
-        id: `discover-dest-${discoverData.destination.name}`,
-        type: 'destination' as const,
-        title: discoverData.destination.name,
-        subtitle: `${discoverData.places.length} places to explore`,
-        imageUrl: discoverData.destination.imageUrl || undefined,
-        href: `/destination/${encodeURIComponent(discoverData.destination.name)}`,
-        score: 2, // higher than entity results
-        metadata: {},
-      }]
-    }
-
-    // Group places by category → map to SpotlightResult types
-    const categoryMap: Record<string, SpotlightResult['type']> = {
-      dining: 'restaurant',
-      sightseeing: 'activity',
-      outdoor: 'activity',
-      cultural: 'activity',
-      shopping: 'activity',
-      nightlife: 'activity',
-      tour: 'activity',
-    }
-
-    // When a scope is active, only include place types that match it
-    const allowedTypes = scope ? new Set(SCOPE_TO_TYPES[scope] ?? []) : null
-
-    for (const place of discoverData.places) {
-      const type = categoryMap[place.category] ?? 'activity'
+    for (const [type, items] of Object.entries(quickData?.results ?? {})) {
+      if (type === 'trip') continue
+      if (!items?.length) continue
+      const allowedTypes = scope ? new Set(SCOPE_TO_TYPES[scope] ?? []) : null
       if (allowedTypes && !allowedTypes.has(type)) continue
-      if (!results[type]) results[type] = []
-      results[type].push({
-        id: place.id,
-        type,
-        title: place.name,
-        subtitle: place.location,
-        imageUrl: place.imageUrl || undefined,
-        href: buildHref(type, place.id, null),
-        score: 1.5,
-        metadata: {
-          rating: place.rating ?? undefined,
-          priceLevel: place.priceLevel ?? undefined,
-          latitude: place.latitude,
-          longitude: place.longitude,
-          category: place.category,
-          source: 'discover',
-        },
-      })
+      results[type] = (items as QuickSearchEntityResult[]).map(mapEntityToSpotlight)
     }
-
     return results
-  }, [discoverData, debouncedQuery, scope])
+  }, [quickData?.results, scope])
 
-  // Action results derived from parsed intent (replaces createTripIntent + routeIntent memos)
+  // Transform Phase 2 results (Foursquare + SerpAPI + collaborators)
+  const deepEntityResults = useMemo((): Record<string, SpotlightResult[]> => {
+    const results: Record<string, SpotlightResult[]> = {}
+    for (const [type, items] of Object.entries(deepData?.results ?? {})) {
+      if (!items?.length) continue
+      const allowedTypes = scope ? new Set(SCOPE_TO_TYPES[scope] ?? []) : null
+      if (allowedTypes && !allowedTypes.has(type)) continue
+      results[type] = items.map((item) => ({
+        id: item.id,
+        type: item.type as SpotlightResult['type'],
+        title: item.title,
+        subtitle: item.subtitle,
+        imageUrl: item.imageUrl,
+        href: item.href ?? '/',
+        score: item.score,
+        metadata: item.metadata,
+      }))
+    }
+    return results
+  }, [deepData?.results, scope])
+
+  // Action results derived from parsed intent
   const actionResults = useMemo((): Record<string, SpotlightResult[]> => {
     if (!parsedIntent) return {}
     const actions: SpotlightResult[] = []
@@ -384,21 +337,20 @@ export function useSpotlightSearch() {
       })
     }
 
-    if (parsedIntent.intent === 'route' && discoverData?.route) {
-      const { origin, destination } = discoverData.route
+    if (parsedIntent.intent === 'route') {
       actions.push({
         id: 'create-trip-route',
         type: 'action' as const,
-        title: `Plan trip: ${origin} to ${destination}`,
+        title: parsedIntent.location ? `Plan route to ${parsedIntent.location}` : 'Plan a route',
         subtitle: 'Start planning with destinations pre-filled',
         href: '',
         score: 100,
-        metadata: { prefillDestination: destination, origin },
+        metadata: { prefillDestination: parsedIntent.location ?? '' },
       })
     }
 
     return actions.length ? { action: actions } : {}
-  }, [parsedIntent, discoverData?.route])
+  }, [parsedIntent])
 
   // Auto-set scope from parsed entity type (only when user hasn't set one manually)
   useEffect(() => {
@@ -408,10 +360,13 @@ export function useSpotlightSearch() {
     }
   }, [parsedIntent?.entityType, scope, setScope])
 
-  // Merge all sources (now including commands, actions, discover, and Foursquare text search)
+  // Merge all sources
   const results = useMemo(() => {
-    return mergeSearchResults([actionResults, tripResults, entityResults ?? {}, discoverResults, fsqResults ?? {}, navResults, commandResults], { maxPerCategory: 5 })
-  }, [actionResults, tripResults, entityResults, discoverResults, fsqResults, navResults, commandResults])
+    return mergeSearchResults(
+      [actionResults, tripResults, quickEntityResults, deepEntityResults, navResults, commandResults],
+      { maxPerCategory: 5 },
+    )
+  }, [actionResults, tripResults, quickEntityResults, deepEntityResults, navResults, commandResults])
 
   // Recent searches
   const [recentSearches, setRecentSearches] = useState<string[]>(() => {
@@ -464,7 +419,9 @@ export function useSpotlightSearch() {
     query,
     setQuery,
     results,
-    isLoading: tripSearchLoading || entityLoading || discoverLoading || intentLoading || fsqLoading,
+    isLoading: quickLoading || deepLoading,
+    quickLoading,
+    deepLoading,
     recentSearches,
     addRecentSearch,
     clearRecent,

--- a/docs/superpowers/specs/2026-03-27-spotlight-search-overhaul-design.md
+++ b/docs/superpowers/specs/2026-03-27-spotlight-search-overhaul-design.md
@@ -1,0 +1,273 @@
+# Spotlight Search Overhaul
+
+Date: 2026-03-27
+
+## Problem
+
+The spotlight search (Ctrl+K) has three critical issues:
+
+1. **Empty results**: Context-search Lambda returns empty — likely a Bedrock embedding invocation failure
+2. **Stale/same results**: Every query returns the same results regardless of input — intent parsing is too aggressive at matching "discover"
+3. **Slow and janky**: 5 independent API calls fire from the browser (parse-intent, context-search, entity-search, discover, fsq-search), racing against each other with inconsistent timing
+
+## Architecture: Two-Phase Streaming Pipeline
+
+Replace the current 5 independent browser API calls with a two-phase pipeline that returns results progressively.
+
+### Phase 1 — Quick Search (`GET /search/quick`)
+
+Fast internal-only search. Warm Lambda target: <500ms. Cold start: ~1-2s (first invocation).
+
+| Source | Type | Method |
+|--------|------|--------|
+| My trips | Trip results | Text ILIKE on `trip_embeddings.text_content` (primary) + vector search via `search_trips` RPC (secondary, runs in parallel) |
+| My activities | Activity/Restaurant results | `search_entities` RPC on Supabase |
+| Calendar commands | Commands | Client-side fuzzy match (no API) |
+| Nav items | Navigation | Client-side fuzzy match (no API) |
+
+No external API calls. All data from Supabase + client-side.
+
+The text ILIKE fallback is the primary path because it doesn't require the Bedrock embedding call, keeping latency low. The vector search runs in parallel and merges in when ready. If the embedding call fails or is slow, text results still return.
+
+**End-to-end latency budget**: Warm Lambda — Phase 1 ~300ms + Phase 2 ~1.2s = ~1.5s total for all results. Cold start — up to 3s. Phase 1 results appear first, Phase 2 merges in progressively.
+
+**Intent parsing ownership**: `search-quick` Lambda runs its own copy of the regex rules (same logic as current `parseQueryIntentSync`). This avoids client/server contract complexity — the Lambda owns intent parsing, and the frontend simply passes the Lambda's parsed intent to Phase 2.
+
+### Phase 2 — Deep Search (`GET /search/deep`)
+
+External data enrichment. Target: <1500ms. Takes pre-parsed intent from Phase 1 via query parameters.
+
+| Source | Type | Method |
+|--------|------|--------|
+| Intent parse | Metadata | Claude Haiku via Bedrock (only when Phase 1 regex didn't classify intent) |
+| Foursquare | Restaurant/Activity | Places API — same `inferType` logic as current `fsq-search/route.ts`, using `near` param from intent location |
+| SerpAPI Discover | Destination/Activity | Same 3-parallel-category pattern as current `discover.ts` (dining, sightseeing, outdoor), results cached in DynamoDB with 1hr TTL using existing `RecommendationCache` table |
+| Collaborators | User | Supabase `trip_collaborators` join with `profiles` (by display_name or email match) |
+
+Collaborator search is limited to users who share trips with the current user (via `trip_collaborators`), not a global user search.
+
+### Intent Passthrough Contract
+
+Phase 1 returns intent in the response body. Phase 2 accepts it as query parameters:
+
+```
+GET /search/deep?q=bakersfield+restaurants&intent=entity-search&location=Bakersfield&entityType=restaurant
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `q` | string | yes | Raw search query |
+| `intent` | `discover` \| `entity-search` \| `create-trip` \| `route` \| `unknown` | yes | Parsed intent from Phase 1 |
+| `location` | string | no | Extracted location (Title Case) |
+| `entityType` | `restaurant` \| `hotel` \| `activity` \| `flight` | no | Extracted entity type |
+
+When `intent=unknown`, Phase 2 runs Claude Haiku to re-parse. Otherwise it uses the pre-parsed intent directly.
+
+### Frontend Flow
+
+```
+User types query
+  ↓ debounce 200ms
+  ├─ Phase 1 fires → results appear (warm <500ms)
+  └─ Phase 2 fires (query ≥ 3 chars) → results merge in (<1500ms)
+```
+
+- Phase 1 fires at `query.length >= 2` — even short queries get trip/command results
+- Phase 2 fires at `query.length >= 3` — external API calls are expensive, so only fire for longer queries
+- Phase 2 cancelled if user types again before it returns
+- Phase 1 cached 30s, Phase 2 cached 60s (React Query staleTime)
+- Loading states show what's pending
+- **Eliminates current double-debounce bug**: Current hook has 300ms debounce + `useContextSearch` adds another 300ms internally. New hook has single 200ms debounce.
+
+### Partial Failure
+
+Both Lambdas use the same partial failure pattern:
+- Each fan-out branch wraps in try/catch, logs the error, and returns `[]` on failure
+- The Lambda always returns 200 with whatever results succeeded
+- Failed branches are logged with structured error details for debugging
+- The response includes a `debug` field (only in non-production) listing which sources failed
+
+## Lambda Implementation
+
+### `services/search-quick.ts` (new)
+
+```
+1. Validate JWT
+2. Regex intent parse (synchronous, no LLM) → produces ParsedIntent
+3. Parallel fan-out (all wrapped in individual try/catch):
+   a. Text search: trip_embeddings ILIKE on text_content + title match on trips table
+   b. Vector search: generateEmbedding(query) → search_trips RPC (secondary)
+   c. Entity search: search_entities RPC
+4. Merge results (text + vector deduplicated by trip_id, entities separate)
+5. Return { intent: ParsedIntent, results: { trip: [...], activity: [...], restaurant: [...] } }
+```
+
+Links: `[supabaseSecretKey, supabaseUrl]`
+Permissions: Bedrock `InvokeModel` for `amazon.titan-embed-text-v2:0`
+
+### `services/search-deep.ts` (new)
+
+```
+1. Validate JWT
+2. Read intent from query params (q, intent, location, entityType)
+3. If intent=unknown, run Claude Haiku to re-parse
+4. Parallel fan-out (all wrapped in individual try/catch):
+   a. Foursquare search (if entity-search or discover intent)
+     - Uses foursquareApiKey SST secret
+     - Same inferType logic from current fsq-search route
+     - `near` param = intent.location
+   b. SerpAPI discover (if discover or route intent)
+     - Same 3-category parallel call pattern as current discover.ts
+     - DynamoDB cache with 1hr TTL using existing cache table
+   c. Collaborator search (Supabase trip_collaborators join)
+5. Merge, deduplicate, rank
+6. Return { results: { restaurant: [...], activity: [...], destination: [...], user: [...] } }
+```
+
+Links: `[supabaseSecretKey, supabaseUrl, serpApiKey, foursquareApiKey, cacheTable]`
+Permissions: Bedrock `InvokeModel` for `anthropic.claude-3-haiku-20240307-v1:0`
+
+### `infra/api.ts` changes
+
+Add two new routes:
+```typescript
+api.route('GET /search/quick', {
+  handler: 'services/search-quick.handler',
+  link: [supabaseSecretKey, supabaseUrl],
+  permissions: [{
+    actions: ['bedrock:InvokeModel'],
+    resources: ['arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v2:0'],
+  }],
+})
+
+api.route('GET /search/deep', {
+  handler: 'services/search-deep.handler',
+  link: [supabaseSecretKey, supabaseUrl, serpApiKey, foursquareApiKey, cacheTable],
+  permissions: [{
+    actions: ['bedrock:InvokeModel'],
+    resources: ['arn:aws:bedrock:*::foundation-model/anthropic.claude-3-haiku-20240307-v1:0'],
+  }],
+})
+```
+
+Keep existing Lambdas for backward compat — they become internal-only or can be removed later.
+
+### Cold Start Expectations
+
+- `search-quick`: Imports Bedrock SDK + Supabase client. Cold start ~500ms-1s. Warm invocations <200ms for text search, <400ms with embedding.
+- `search-deep`: Imports Bedrock SDK + Supabase + Foursquare + SerpAPI. Cold start ~800ms-1.5s. Warm invocations <300ms for internal + <1s for external APIs.
+- No provisioned concurrency for now. Monitor cold start frequency after deploy; add if >10% of requests are cold starts.
+
+## Search Quality Fixes
+
+### Fix: Empty context-search results
+- Add structured error logging to `generateEmbedding()` — catch and log specific Bedrock errors (not just `console.error`)
+- Verify Bedrock permissions are attached to the new Lambda
+- Lower vector similarity threshold from 0.15 to 0.10 for better recall
+- Text ILIKE fallback ensures results even when Bedrock is down
+
+### Fix: "Same results every time"
+- Make regex intent parsing less aggressive for single words:
+  - Current: bare word → `discover` intent
+  - New: bare word → `entity-search` with `location=<word>` (searches user's saved activities for that location)
+  - Only falls through to `discover` if entity-search returns no results
+- React Query `staleTime` and `sessionStorage` cache handle repeated identical queries — no new session tracking infrastructure needed
+
+### Improved ranking
+- Source priority: My data (3x) > External places (2x) > App controls (1x)
+- Recency boost: recently-accessed trips get 1.5x
+- Context boost: when inside a trip, results from that trip get 2x
+- Exact match: title exact match gets 3x over fuzzy
+- Deduplication: same place from multiple sources → keep highest score, merge metadata
+
+## Frontend Changes
+
+### `useSpotlightSearch` hook (rewritten)
+
+Replace 5 `useQuery` calls with 2 server queries + 2 client-side memos:
+
+```typescript
+// Client-side: commands + nav (no API)
+const commandResults = useMemo(...)
+const navResults = useMemo(...)
+
+// Phase 1: Quick search — internal data only
+const { data: quickResults, isLoading: quickLoading } = useQuery({
+  queryKey: ['search-quick', debouncedQuery],
+  queryFn: () => fetchSearchQuick(debouncedQuery, token!),
+  enabled: debouncedQuery.length >= 2 && !!token,
+  staleTime: 30_000,
+})
+
+// Phase 2: Deep search — external data + intent-driven
+const { data: deepResults } = useQuery({
+  queryKey: ['search-deep', debouncedQuery, quickResults?.intent],
+  queryFn: () => fetchSearchDeep(debouncedQuery, quickResults!.intent, token!),
+  enabled: !!quickResults?.intent && debouncedQuery.length >= 3,
+  staleTime: 60_000,
+})
+
+// Merge all sources
+const results = useMemo(() => mergeSearchResults([
+  quickResults?.results ?? {},
+  deepResults?.results ?? {},
+  commandResults,
+  navResults,
+]), [quickResults, deepResults, commandResults, navResults])
+```
+
+Features preserved: scope management, pinned results, recent searches, auto-scope from intent, trip context pill, action results.
+
+### New proxy routes
+
+Replace 5 existing routes with 2:
+- `apps/web/app/api/search/quick/route.ts`
+- `apps/web/app/api/search/deep/route.ts`
+
+Remove:
+- `apps/web/app/api/context-search/route.ts`
+- `apps/web/app/api/entity-search/route.ts`
+- `apps/web/app/api/discover/route.ts`
+- `apps/web/app/api/parse-intent/route.ts`
+- `apps/web/app/api/fsq-search/route.ts` (Foursquare moves to Lambda)
+
+### UI improvements
+
+- **Progressive reveal**: Phase 1 results render first, Phase 2 results animate in below
+- **Source tags**: Subtle label on each result group ("From your trips", "Foursquare", etc.)
+- **Smart loading**: Shows "Searching external places..." during Phase 2
+- **Better empty state**: Differentiates between "nothing in your trips" and "nothing anywhere"
+
+## Data Quality
+
+### `trip_embeddings.text_content` enrichment
+Activity names are already included by `index-trip.ts`. The remaining enrichment is:
+- Collaborator display names (from `trip_collaborators` join with `profiles`)
+- Destination description (from trip metadata or SerpAPI)
+
+- These additions improve both vector similarity and text ILIKE fallback match
+
+### `index-trip` Lambda update
+When a trip is indexed (via `POST /index`), append collaborator names and destination description to the existing `text_content` builder in `index-trip.ts`. The activity names are already included.
+
+### Supabase changes needed
+- **Collaborator search**: Add a `search_collaborators` RPC or extend `search_entities` to cover collaborator profiles. Query: join `trip_collaborators` with `profiles` where user shares a trip, match on `display_name` or `email` ILIKE.
+Run a one-time script (or manual `POST /index` for each trip) to re-index the 8 existing trips with enriched text_content. This can be done by calling `POST /index` for each trip ID, since the index endpoint regenerates the full embedding from current trip data.
+
+## Scope
+
+### In scope
+- Fix broken context-search (empty results)
+- Two new Lambdas: search-quick, search-deep
+- Frontend hook rewrite (2-phase fetch)
+- Proxy route consolidation (5 → 2)
+- Search quality fixes (ranking, dedup, intent)
+- UI polish (progressive results, loading states, source tags)
+
+### Out of scope
+- New entity detail pages (already designed in separate spec)
+- OpenSearch migration (future)
+- Amazon Personalize integration (future)
+- Mobile-specific search UX
+- Autocomplete/type-ahead (future feature)
+- Collaborator search beyond shared-trip context

--- a/infra/api.ts
+++ b/infra/api.ts
@@ -1,6 +1,6 @@
 import { activityCdn, cacheTable, placeIndex, userInteractions } from './storage'
 import { bus } from './events'
-import { supabaseSecretKey, supabaseUrl, serpApiKey, pexels } from './secrets'
+import { supabaseSecretKey, supabaseUrl, serpApiKey, pexels, foursquareApiKey } from './secrets'
 
 export const email = new sst.aws.Email('TravylEmail', {
   sender: 'gotravyl.com',
@@ -130,6 +130,28 @@ api.route('GET /discover', {
 api.route('GET /parse-intent', {
   handler: 'services/parse-intent.handler',
   link: [supabaseSecretKey, supabaseUrl],
+  permissions: [
+    {
+      actions: ['bedrock:InvokeModel'],
+      resources: ['arn:aws:bedrock:*::foundation-model/anthropic.claude-3-haiku-20240307-v1:0'],
+    },
+  ],
+})
+
+api.route('GET /search/quick', {
+  handler: 'services/search-quick.handler',
+  link: [supabaseSecretKey, supabaseUrl],
+  permissions: [
+    {
+      actions: ['bedrock:InvokeModel'],
+      resources: ['arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v2:0'],
+    },
+  ],
+})
+
+api.route('GET /search/deep', {
+  handler: 'services/search-deep.handler',
+  link: [supabaseSecretKey, supabaseUrl, serpApiKey, foursquareApiKey, cacheTable],
   permissions: [
     {
       actions: ['bedrock:InvokeModel'],

--- a/services/index-trip.ts
+++ b/services/index-trip.ts
@@ -46,6 +46,25 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       .select('activity_name, activity_type, notes, starting_date, ending_date, activity_data')
       .eq('trip_id', tripId)
 
+    // Fetch collaborator display names
+    const { data: collaborators } = await supabase
+      .from('trip_collaborators')
+      .select('user_id')
+      .eq('trip_id', tripId)
+
+    const collaboratorIds = (collaborators ?? []).map((c: any) => c.user_id)
+
+    const { data: profiles } = collaboratorIds.length
+      ? await supabase
+          .from('profiles')
+          .select('display_name')
+          .in('id', collaboratorIds)
+      : { data: [] }
+
+    const collaboratorNames = (profiles ?? [])
+      .map((p: any) => p.display_name)
+      .filter(Boolean)
+
     // Build text blob
     interface ActivityData { category?: string; location_name?: string }
 
@@ -76,6 +95,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       trip.status,
       dateRange,
       activityText,
+      collaboratorNames.length ? `With: ${collaboratorNames.join(', ')}` : null,
     ].filter(Boolean).join(' | ')
 
     // Generate embedding

--- a/services/lib/embeddings.ts
+++ b/services/lib/embeddings.ts
@@ -6,18 +6,28 @@ const client = new BedrockRuntimeClient({})
 const MODEL_ID = 'amazon.titan-embed-text-v2:0'
 
 export async function generateEmbedding(text: string): Promise<number[]> {
-  const response = await client.send(
-    new InvokeModelCommand({
-      modelId: MODEL_ID,
-      contentType: 'application/json',
-      accept: 'application/json',
-      body: JSON.stringify({
-        inputText: text,
-        dimensions: 1024,
+  try {
+    const response = await client.send(
+      new InvokeModelCommand({
+        modelId: MODEL_ID,
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify({
+          inputText: text,
+          dimensions: 1024,
+        }),
       }),
-    }),
-  )
+    )
 
-  const result = JSON.parse(new TextDecoder().decode(response.body))
-  return result.embedding as number[]
+    const result = JSON.parse(new TextDecoder().decode(response.body))
+    return result.embedding as number[]
+  } catch (err: any) {
+    console.error('[embeddings] Bedrock invocation failed:', {
+      model: MODEL_ID,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorStack: err.stack?.split('\n')?.[0],
+    })
+    throw err  // re-throw so caller can fall back
+  }
 }

--- a/services/lib/intent-parser.ts
+++ b/services/lib/intent-parser.ts
@@ -1,0 +1,103 @@
+export type SearchIntent =
+  | 'discover'
+  | 'entity-search'
+  | 'create-trip'
+  | 'route'
+  | 'unknown'
+
+export interface ParsedIntent {
+  intent: SearchIntent
+  location?: string
+  entityType?: 'restaurant' | 'hotel' | 'activity' | 'flight'
+  rawQuery: string
+}
+
+const ENTITY_SYNONYMS: Record<string, ParsedIntent['entityType']> = {
+  restaurant: 'restaurant', restaurants: 'restaurant',
+  food: 'restaurant', dining: 'restaurant', eat: 'restaurant',
+  eats: 'restaurant', cafe: 'restaurant', cafes: 'restaurant',
+  bar: 'restaurant', bars: 'restaurant', brunch: 'restaurant',
+  lunch: 'restaurant', dinner: 'restaurant',
+  hotel: 'hotel', hotels: 'hotel', stay: 'hotel',
+  lodging: 'hotel', accommodation: 'hotel', accommodations: 'hotel',
+  hostel: 'hotel', hostels: 'hotel', motel: 'hotel', motels: 'hotel',
+  airbnb: 'hotel', resort: 'hotel', resorts: 'hotel',
+  activity: 'activity', activities: 'activity',
+  attraction: 'activity', attractions: 'activity',
+  sights: 'activity', sightseeing: 'activity',
+  tour: 'activity', tours: 'activity',
+  museum: 'activity', museums: 'activity', park: 'activity', parks: 'activity',
+  flight: 'flight', flights: 'flight', fly: 'flight',
+  airline: 'flight', airlines: 'flight',
+}
+
+function toTitleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchEntityInCity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^${escapeRegex(synonym)}\\s+in\\s+(.+)$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+function matchCityEntity(q: string): { entityType: ParsedIntent['entityType']; location: string } | null {
+  for (const [synonym, entityType] of Object.entries(ENTITY_SYNONYMS)) {
+    const re = new RegExp(`^(.+?)\\s+${escapeRegex(synonym)}$`)
+    const m = q.match(re)
+    if (m) return { entityType, location: toTitleCase(m[1].trim()) }
+  }
+  return null
+}
+
+export function parseQueryIntentSync(rawQuery: string): ParsedIntent | null {
+  const q = rawQuery.trim().toLowerCase()
+
+  // Pattern 1: "trip to [destination]"
+  const tripTo = q.match(/^trip\s+to\s+(.+)$/)
+  if (tripTo) return { intent: 'create-trip', location: toTitleCase(tripTo[1].trim()), rawQuery }
+
+  // Pattern 2: "new trip" / "create trip"
+  if (/^(?:new|create)\s+trip$/.test(q)) return { intent: 'create-trip', rawQuery }
+
+  // Pattern 3: "[entity] in [city]"
+  const entityInCity = matchEntityInCity(q)
+  if (entityInCity) return { intent: 'entity-search', ...entityInCity, rawQuery }
+
+  // Pattern 3.5: "[places/where] to [synonym] in [city]"
+  const placesToIn = q.match(/^(?:places?\s+to|where\s+to)\s+(\w+)\s+in\s+(.+)$/)
+  if (placesToIn) {
+    const entityType = ENTITY_SYNONYMS[placesToIn[1]]
+    if (entityType) return { intent: 'entity-search', entityType, location: toTitleCase(placesToIn[2].trim()), rawQuery }
+  }
+
+  // Pattern 4: "things to do in [city]"
+  const thingsToDo = q.match(/^things?\s+to\s+do\s+in\s+(.+)$/)
+  if (thingsToDo) return { intent: 'entity-search', entityType: 'activity', location: toTitleCase(thingsToDo[1].trim()), rawQuery }
+
+  // Pattern 5: "[city] [entity]"
+  const cityEntity = matchCityEntity(q)
+  if (cityEntity) return { intent: 'entity-search', ...cityEntity, rawQuery }
+
+  // Pattern 6: "X to Y" (generic route)
+  const route = q.match(/^(.+?)\s+to\s+(.+)$/)
+  if (route) {
+    const dest = route[2].trim()
+    if (!/\s+(?:in|to)\s+/.test(dest)) {
+      return { intent: 'route', location: toTitleCase(dest), rawQuery }
+    }
+  }
+
+  // Pattern 7 (Lambda variant): bare single word → entity-search (searches user data first)
+  if (!q.includes(' ')) return { intent: 'entity-search', location: toTitleCase(q), entityType: undefined, rawQuery }
+
+  // No match
+  return null
+}

--- a/services/search-deep.ts
+++ b/services/search-deep.ts
@@ -1,0 +1,469 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { Resource } from 'sst'
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
+import { createClient } from '@supabase/supabase-js'
+import { validateAuth } from './lib/auth'
+import { searchPlaces } from './lib/serpapi'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type EntityType = 'restaurant' | 'hotel' | 'activity' | 'flight' | null
+type Intent = 'discover' | 'entity-search' | 'create-trip' | 'route' | 'unknown'
+
+interface ParsedIntent {
+  intent: Intent
+  location: string | null
+  entityType: EntityType
+}
+
+interface FsqCategory {
+  id: number
+  name: string
+}
+
+interface FsqSearchResult {
+  fsq_id: string
+  name: string
+  location: {
+    address?: string
+    locality?: string
+    region?: string
+    country?: string
+    formatted_address?: string
+  }
+  categories?: FsqCategory[]
+  rating?: number
+  stats?: { total_ratings?: number }
+  price?: number
+}
+
+interface FsqApiResponse {
+  results?: FsqSearchResult[]
+}
+
+export interface FsqResult {
+  id: string
+  type: 'restaurant' | 'hotel' | 'activity'
+  title: string
+  subtitle: string
+  href: string
+  score: number
+  metadata: {
+    rating?: number
+    priceLevel?: number
+    source: 'foursquare'
+  }
+}
+
+export interface DiscoverResult {
+  id: string
+  type: 'destination'
+  title: string
+  subtitle: string
+  imageUrl?: string
+  href: string
+  score: number
+  metadata: { source: 'serpapi' }
+}
+
+export interface CollaboratorResult {
+  id: string
+  type: 'user'
+  title: string
+  subtitle: string
+  href: string
+  score: number
+  metadata: { source: 'collaborators' }
+}
+
+interface DeepSearchResponse {
+  results: {
+    restaurant: FsqResult[]
+    activity: FsqResult[]
+    hotel: FsqResult[]
+    destination: DiscoverResult[]
+    user: CollaboratorResult[]
+  }
+  debug?: { failedSources: string[] }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FSQ_FIELDS = 'fsq_id,name,location,categories,rating,stats,price'
+const MODEL_ID = 'anthropic.claude-3-haiku-20240307-v1:0'
+
+const HAIKU_PROMPT = `You are a travel search intent parser. Extract structured intent from a search query.
+Return ONLY valid JSON — no explanation, no markdown, no code fences.
+Schema:
+{
+  "intent": "discover" | "entity-search" | "create-trip" | "route" | "unknown",
+  "location": string | null,
+  "entityType": "restaurant" | "hotel" | "activity" | "flight" | null
+}
+Rules:
+- "discover": user wants to explore a destination with no specific entity type
+- "entity-search": user wants a specific category of place in a location
+- "create-trip": user wants to plan or start a trip
+- "route": user mentions two places (origin to destination)
+- "unknown": none of the above apply
+- location should be in Title Case (e.g. "Bakersfield", "New York")
+Query: `
+
+// ---------------------------------------------------------------------------
+// Bedrock / Claude Haiku re-parse
+// ---------------------------------------------------------------------------
+
+const bedrockClient = new BedrockRuntimeClient({})
+
+async function reParseIntent(q: string): Promise<ParsedIntent | null> {
+  try {
+    const response = await bedrockClient.send(
+      new InvokeModelCommand({
+        modelId: MODEL_ID,
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify({
+          anthropic_version: 'bedrock-2023-05-31',
+          messages: [{ role: 'user', content: `${HAIKU_PROMPT}"${q}"` }],
+          max_tokens: 100,
+          temperature: 0,
+        }),
+      }),
+    )
+    const responseBody = new TextDecoder().decode(response.body)
+    const bedrockResult = JSON.parse(responseBody)
+    const text: string = bedrockResult.content?.[0]?.text?.trim() ?? ''
+    return JSON.parse(text) as ParsedIntent
+  } catch (err) {
+    console.error('[search-deep] haiku re-parse error:', err)
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DynamoDB cache (reuse discover cache pattern)
+// ---------------------------------------------------------------------------
+
+const dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+
+interface DiscoverCacheEntry {
+  pk: string
+  sk: string
+  data: DiscoverResult[]
+  expiresAt: number
+}
+
+async function getCachedDiscover(location: string): Promise<DiscoverResult[] | null> {
+  try {
+    const result = await dynamoClient.send(
+      new GetCommand({
+        TableName: Resource.RecommendationCache.name,
+        Key: { pk: `discover:${location.toLowerCase()}`, sk: 'results-deep' },
+      }),
+    )
+    if (!result.Item) return null
+    const entry = result.Item as DiscoverCacheEntry
+    if (entry.expiresAt < Math.floor(Date.now() / 1000)) return null
+    return entry.data
+  } catch (err) {
+    console.error('[search-deep] dynamo get error:', err)
+    return null
+  }
+}
+
+async function setCachedDiscover(location: string, data: DiscoverResult[]): Promise<void> {
+  try {
+    await dynamoClient.send(
+      new PutCommand({
+        TableName: Resource.RecommendationCache.name,
+        Item: {
+          pk: `discover:${location.toLowerCase()}`,
+          sk: 'results-deep',
+          data,
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        },
+      }),
+    )
+  } catch (err) {
+    console.error('[search-deep] dynamo put error:', err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Foursquare helpers
+// ---------------------------------------------------------------------------
+
+function inferType(categories: FsqCategory[] = []): 'restaurant' | 'hotel' | 'activity' {
+  for (const cat of categories) {
+    const name = cat.name.toLowerCase()
+    if (/hotel|motel|hostel|inn|lodge|resort/.test(name)) return 'hotel'
+    if (/restaurant|cafe|bar|pub|diner|bistro|bakery|food|dining|eatery|drink/.test(name))
+      return 'restaurant'
+  }
+  return 'activity'
+}
+
+function buildSubtitle(loc: FsqSearchResult['location']): string {
+  return (
+    loc.formatted_address ??
+    [loc.address, loc.locality, loc.region, loc.country].filter(Boolean).join(', ')
+  )
+}
+
+async function fetchFoursquare(
+  q: string,
+  near: string | null,
+): Promise<{ restaurant: FsqResult[]; hotel: FsqResult[]; activity: FsqResult[] }> {
+  const params = new URLSearchParams({ query: q, fields: FSQ_FIELDS, limit: '10' })
+  if (near) params.set('near', near)
+
+  const res = await fetch(`https://api.foursquare.com/v3/places/search?${params}`, {
+    headers: {
+      Authorization: Resource.FoursquareApiKey.value,
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(5000),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error(`[search-deep] foursquare ${res.status}: ${body}`)
+    throw new Error(`Foursquare error ${res.status}`)
+  }
+
+  const data = (await res.json()) as FsqApiResponse
+  const places = data.results ?? []
+
+  const grouped: { restaurant: FsqResult[]; hotel: FsqResult[]; activity: FsqResult[] } = {
+    restaurant: [],
+    hotel: [],
+    activity: [],
+  }
+
+  places.forEach((place, i) => {
+    const type = inferType(place.categories)
+    grouped[type].push({
+      id: place.fsq_id,
+      type,
+      title: place.name,
+      subtitle: buildSubtitle(place.location),
+      href: `https://foursquare.com/v/${place.fsq_id}`,
+      score: Math.max(0, 1 - i * 0.05),
+      metadata: {
+        rating: place.rating,
+        priceLevel: place.price,
+        source: 'foursquare',
+      },
+    })
+  })
+
+  return grouped
+}
+
+// ---------------------------------------------------------------------------
+// SerpAPI discover helpers
+// ---------------------------------------------------------------------------
+
+async function fetchDiscover(location: string): Promise<DiscoverResult[]> {
+  // Cache check
+  const cached = await getCachedDiscover(location)
+  if (cached) {
+    console.log('[search-deep] discover cache hit for', location)
+    return cached
+  }
+
+  console.log('[search-deep] discover cache miss, firing 3 SerpAPI calls for', location)
+
+  const [diningResults, sightseeingResults, outdoorResults] = await Promise.all([
+    searchPlaces(location, 'dining', { limit: 10 }),
+    searchPlaces(location, 'sightseeing', { limit: 10 }),
+    searchPlaces(location, 'outdoor', { limit: 10 }),
+  ])
+
+  const seen = new Set<string>()
+  const discoverResults: DiscoverResult[] = []
+
+  for (const card of [...sightseeingResults, ...diningResults, ...outdoorResults]) {
+    const key = card.name.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    discoverResults.push({
+      id: card.id,
+      type: 'destination',
+      title: card.name,
+      subtitle: card.location,
+      imageUrl: card.imageUrl || undefined,
+      href: `/search?q=${encodeURIComponent(card.name)}`,
+      score: card.relevanceScore,
+      metadata: { source: 'serpapi' },
+    })
+    if (discoverResults.length >= 15) break
+  }
+
+  if (discoverResults.length > 0) {
+    await setCachedDiscover(location, discoverResults)
+  }
+
+  return discoverResults
+}
+
+// ---------------------------------------------------------------------------
+// Collaborator search
+// ---------------------------------------------------------------------------
+
+async function fetchCollaborators(
+  q: string,
+  userId: string,
+): Promise<CollaboratorResult[]> {
+  const supabase = createClient(Resource.SupabaseUrl.value, Resource.SupabaseSecretKey.value)
+
+  // Step 1: get trip_ids for the current user
+  const { data: myTrips, error: tripsError } = await supabase
+    .from('trip_collaborators')
+    .select('trip_id')
+    .eq('user_id', userId)
+
+  if (tripsError || !myTrips || myTrips.length === 0) return []
+
+  const tripIds = myTrips.map((t: { trip_id: string }) => t.trip_id)
+
+  // Step 2: get all collaborator user_ids on those trips (excluding self)
+  const { data: collaboratorRows, error: collabError } = await supabase
+    .from('trip_collaborators')
+    .select('user_id')
+    .in('trip_id', tripIds)
+    .neq('user_id', userId)
+
+  if (collabError || !collaboratorRows || collaboratorRows.length === 0) return []
+
+  const collaboratorIds = [...new Set(collaboratorRows.map((r: { user_id: string }) => r.user_id))]
+
+  // Step 3: query profiles matching the search query
+  const pattern = `%${q}%`
+  const { data: profiles, error: profilesError } = await supabase
+    .from('profiles')
+    .select('id, display_name, email')
+    .in('id', collaboratorIds)
+    .or(`display_name.ilike.${pattern},email.ilike.${pattern}`)
+    .limit(5)
+
+  if (profilesError || !profiles) return []
+
+  return profiles.map(
+    (p: { id: string; display_name: string | null; email: string | null }, i: number) => ({
+      id: p.id,
+      type: 'user' as const,
+      title: p.display_name ?? p.email ?? 'Unknown',
+      subtitle: p.email ?? '',
+      href: `/profile/${p.id}`,
+      score: Math.max(0, 1 - i * 0.1),
+      metadata: { source: 'collaborators' as const },
+    }),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    const userId = await validateAuth(event.headers.authorization)
+
+    const params = event.queryStringParameters ?? {}
+    const q = params.q?.trim() ?? ''
+    let intent = (params.intent as Intent) ?? 'unknown'
+    let location = params.location ?? null
+    let entityType = (params.entityType as EntityType) ?? null
+
+    if (!q || q.length < 2) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'q parameter required (min 2 chars)' }),
+      }
+    }
+
+    console.log('[search-deep] q:', q, 'intent:', intent, 'location:', location, 'userId:', userId)
+
+    // Step 3: re-parse unknown intent via Claude Haiku
+    if (intent === 'unknown') {
+      const reparsed = await reParseIntent(q)
+      if (reparsed) {
+        intent = reparsed.intent
+        location = reparsed.location ?? location
+        entityType = reparsed.entityType ?? entityType
+        console.log('[search-deep] haiku re-parsed intent:', intent, 'location:', location)
+      }
+    }
+
+    // Step 4: parallel fan-out
+    const failedSources: string[] = []
+
+    const fsqPromise: Promise<{ restaurant: FsqResult[]; hotel: FsqResult[]; activity: FsqResult[] }> =
+      intent === 'entity-search' || intent === 'discover'
+        ? fetchFoursquare(q, location).catch((err) => {
+            console.error('[search-deep] foursquare failed:', err)
+            failedSources.push('foursquare')
+            return { restaurant: [], hotel: [], activity: [] }
+          })
+        : Promise.resolve({ restaurant: [], hotel: [], activity: [] })
+
+    const discoverPromise: Promise<DiscoverResult[]> =
+      (intent === 'discover' || intent === 'route') && location
+        ? fetchDiscover(location).catch((err) => {
+            console.error('[search-deep] discover failed:', err)
+            failedSources.push('serpapi')
+            return []
+          })
+        : Promise.resolve([])
+
+    const collaboratorsPromise: Promise<CollaboratorResult[]> =
+      q.length >= 2
+        ? fetchCollaborators(q, userId).catch((err) => {
+            console.error('[search-deep] collaborators failed:', err)
+            failedSources.push('collaborators')
+            return []
+          })
+        : Promise.resolve([])
+
+    const [fsqResults, discoverResults, collaboratorResults] = await Promise.all([
+      fsqPromise,
+      discoverPromise,
+      collaboratorsPromise,
+    ])
+
+    // Step 5+6: merge and return
+    const response: DeepSearchResponse = {
+      results: {
+        restaurant: fsqResults.restaurant,
+        activity: fsqResults.activity,
+        hotel: fsqResults.hotel,
+        destination: discoverResults,
+        user: collaboratorResults,
+      },
+    }
+
+    if (process.env.SST_STAGE !== 'production' && failedSources.length > 0) {
+      response.debug = { failedSources }
+    }
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response),
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message === 'Invalid token' || message.includes('Authorization')) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('[search-deep] unhandled error:', err)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+}

--- a/services/search-quick.ts
+++ b/services/search-quick.ts
@@ -1,0 +1,175 @@
+import { Resource } from 'sst'
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { createClient } from '@supabase/supabase-js'
+import { validateAuth } from './lib/auth'
+import { generateEmbedding } from './lib/embeddings'
+import { parseQueryIntentSync, type ParsedIntent } from './lib/intent-parser'
+
+interface TripResult {
+  tripId: string
+  title: string
+  destination: string
+  startDate: string | null
+  endDate: string | null
+  status: string
+  activityCount: number
+  imageUrl: string | null
+  score: number
+}
+
+interface EntityResult {
+  entity_id: string
+  entity_type: string
+  entity_name: string
+  entity_subtitle: string | null
+  trip_id: string | null
+  trip_title: string | null
+  trip_destination: string | null
+  image_url: string | null
+  score: number
+  latitude: number | null
+  longitude: number | null
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    const userId = await validateAuth(event.headers.authorization)
+    const q = event.queryStringParameters?.q ?? ''
+
+    if (q.length < 2) {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          intent: { intent: 'unknown', rawQuery: q } satisfies ParsedIntent,
+          results: { trip: [] },
+        }),
+      }
+    }
+
+    const parsedIntent: ParsedIntent = parseQueryIntentSync(q) ?? { intent: 'unknown', rawQuery: q }
+
+    const supabase = createClient(Resource.SupabaseUrl.value, Resource.SupabaseSecretKey.value)
+    const failedSources: string[] = []
+
+    const [textTripRows, vectorTripRows, entityGrouped] = await Promise.all([
+      // Branch a: text search on trip_embeddings
+      (async (): Promise<Array<{ trip_id: string; metadata: Record<string, any>; score: number }>> => {
+        try {
+          const { data, error } = await supabase
+            .from('trip_embeddings')
+            .select('trip_id, metadata')
+            .eq('user_id', userId)
+            .or(`text_content.ilike.%${q}%`)
+            .limit(5)
+          if (error) {
+            console.error('search-quick text search error:', error)
+            failedSources.push('text')
+            return []
+          }
+          return (data ?? []).map((row: any) => ({
+            trip_id: row.trip_id,
+            metadata: row.metadata,
+            score: 0.5,
+          }))
+        } catch (err) {
+          console.error('search-quick text search exception:', err)
+          failedSources.push('text')
+          return []
+        }
+      })(),
+
+      // Branch b: vector search
+      (async (): Promise<Array<{ trip_id: string; metadata: Record<string, any>; score: number }>> => {
+        try {
+          const queryEmbedding = await generateEmbedding(q)
+          const { data, error } = await supabase.rpc('search_trips', {
+            query_embedding: JSON.stringify(queryEmbedding),
+            match_user_id: userId,
+            match_count: 5,
+          })
+          if (error) {
+            console.error('search-quick vector search error:', error)
+            failedSources.push('vector')
+            return []
+          }
+          return data ?? []
+        } catch (err) {
+          console.error('search-quick vector search exception:', err)
+          failedSources.push('vector')
+          return []
+        }
+      })(),
+
+      // Branch c: entity search
+      (async (): Promise<Record<string, EntityResult[]>> => {
+        try {
+          const { data, error } = await supabase.rpc('search_entities', {
+            query: q,
+            match_user_id: userId,
+            entity_types: ['restaurant', 'activity'],
+            match_trip_id: null,
+            match_count: 20,
+          })
+          if (error) {
+            console.error('search-quick entity search error:', error)
+            failedSources.push('entity')
+            return {}
+          }
+          const grouped: Record<string, EntityResult[]> = {}
+          for (const row of (data as EntityResult[]) ?? []) {
+            if (!grouped[row.entity_type]) grouped[row.entity_type] = []
+            grouped[row.entity_type].push(row)
+          }
+          return grouped
+        } catch (err) {
+          console.error('search-quick entity search exception:', err)
+          failedSources.push('entity')
+          return {}
+        }
+      })(),
+    ])
+
+    // Merge trip results: vector takes priority, text fills gaps
+    const seen = new Set<string>()
+    const mergedTrips: TripResult[] = []
+
+    for (const row of [...vectorTripRows, ...textTripRows]) {
+      if (!seen.has(row.trip_id)) {
+        seen.add(row.trip_id)
+        mergedTrips.push({
+          tripId: row.trip_id,
+          title: row.metadata.title,
+          destination: row.metadata.destination,
+          startDate: row.metadata.startDate ?? null,
+          endDate: row.metadata.endDate ?? null,
+          status: row.metadata.status,
+          activityCount: row.metadata.activityCount,
+          imageUrl: row.metadata.imageUrl ?? null,
+          score: row.score,
+        })
+      }
+    }
+
+    const tripResults = mergedTrips.slice(0, 5)
+
+    const responseBody: Record<string, unknown> = {
+      intent: parsedIntent,
+      results: {
+        trip: tripResults,
+        ...entityGrouped,
+      },
+    }
+
+    if (process.env.SST_STAGE !== 'production') {
+      responseBody.debug = { failedSources }
+    }
+
+    return { statusCode: 200, body: JSON.stringify(responseBody) }
+  } catch (err: any) {
+    if (err.message === 'Invalid token' || err.message?.includes('Authorization')) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('search-quick error:', err)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+}


### PR DESCRIPTION
## Summary

- Replace 4 existing search Lambdas (`context-search`, `entity-search`, `discover`, `parse-intent`) with two new ones: `search-quick` (Phase 1, internal data) and `search-deep` (Phase 2, external APIs)
- Rewrite `useSpotlightSearch` hook from 5 independent queries to a two-phase pipeline with a single 200ms debounce (down from 600ms total)
- Progressive reveal: Phase 1 results (trips, saved entities) appear in <500ms; Phase 2 results (Foursquare, SerpAPI, collaborators) animate in when ready
- Fix bare-word queries always returning the same discover results (now searches user data first)
- Add source tag badges to result groups, phase-aware loading/empty states, structured embedding error logging, and collaborator name enrichment in trip indexing

## Test Plan

- [ ] Open spotlight (Ctrl+K), type 2+ chars — Phase 1 results appear quickly
- [ ] Type a bare word (e.g. `bakersfield`) — searches your trips first, then external places
- [ ] Type `bakersfield restaurants` — auto-scopes to restaurants, Foursquare results animate in
- [ ] Type `trip to paris` — create-trip action card appears
- [ ] Type `la to sf` — route action card appears
- [ ] Type 1 char — no search fires (min 2)
- [ ] Source tags visible on result groups (e.g. "Your trips", "Foursquare")
- [ ] Loading text: "Searching..." during Phase 1, "Searching external places..." during Phase 2 only
- [ ] Empty state: "No results in your trips" with dynamic sub-text based on deepLoading