### PR TITLE
feat: fix public trips discovery and fork flow

### DIFF
--- a/apps/web/components/spotlight/SpotlightResultGroup.tsx
+++ b/apps/web/components/spotlight/SpotlightResultGroup.tsx
@@ -65,11 +65,14 @@ export function SpotlightResultGroup({
         <span className="text-[10px] text-gray-300 dark:text-gray-600">
           ({results.length})
         </span>
-        {results[0]?.metadata?.source && (
-          <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 leading-none">
-            {SOURCE_LABELS[results[0].metadata.source as string] ?? results[0].metadata.source as string}
-          </span>
-        )}
+        {(() => {
+          const src = results[0]?.metadata?.source as string | undefined
+          return src ? (
+            <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 leading-none">
+              {SOURCE_LABELS[src] ?? src}
+            </span>
+          ) : null
+        })()}
       </div>
       {results.map((result, i) => (
         <SpotlightResultItem

--- a/apps/web/hooks/useSpotlightSearch.ts
+++ b/apps/web/hooks/useSpotlightSearch.ts
@@ -309,7 +309,7 @@ export function useSpotlightSearch() {
         type: item.type as SpotlightResult['type'],
         title: item.title,
         subtitle: item.subtitle,
-        imageUrl: item.imageUrl,
+        imageUrl: (item as { imageUrl?: string }).imageUrl,
         href: item.href ?? '/',
         score: item.score,
         metadata: item.metadata,

--- a/docs/superpowers/plans/2026-03-27-ai-day-planner.md
+++ b/docs/superpowers/plans/2026-03-27-ai-day-planner.md
@@ -1,0 +1,1116 @@
+# AI Day Planner (Magic Wand) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a wand button to the calendar toolbar that auto-fills a day's open time gaps with AI-suggested activities, shown as dismissible ghost blocks directly on the calendar grid.
+
+**Architecture:** Four layers built bottom-up — (1) shared `computeGaps` utility, (2) `POST /fill-gaps` Lambda using SerpAPI, (3) `useGapFiller` hook + `GhostEventBlock` component, (4) wiring into `CalendarDashboard` / `CalendarToolbar` / `DayColumn` / `DayView` / `WeekView`.
+
+**Tech Stack:** TypeScript, React 19, Next.js 16, Tailwind CSS v4, React Query, SST v4 Lambdas, SerpAPI, DynamoDB, Vitest, iconoir-react
+
+**Spec:** `docs/superpowers/specs/2026-03-27-ai-day-planner-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `packages/shared/src/utils/gapCompute.ts` | Pure `computeGaps` function |
+| `packages/shared/src/utils/gapCompute.test.ts` | Vitest tests for `computeGaps` |
+| `services/fill-gaps.ts` | Lambda handler for `POST /fill-gaps` |
+| `apps/web/components/calendar/GhostEventBlock.tsx` | Ghost activity block with confirm/dismiss |
+| `apps/web/components/calendar/hooks/useGapFiller.ts` | React Query mutation for `/fill-gaps` |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `packages/shared/src/utils/index.ts` | Export `computeGaps`, `Gap` |
+| `services/lib/cache.ts` | Add `getCachedGaps` / `setCachedGaps` |
+| `infra/api.ts` | Add `POST /fill-gaps` route |
+| `apps/web/components/calendar/CalendarToolbar.tsx` | Add wand button + 4 new props |
+| `apps/web/components/calendar/CalendarDashboard.tsx` | Ghost state, `useGapFiller`, prop threading |
+| `apps/web/components/calendar/DayColumn.tsx` | Ghost layer rendering |
+| `apps/web/components/calendar/DayView.tsx` | Thread ghost props |
+| `apps/web/components/calendar/WeekView.tsx` | Thread ghost props |
+
+---
+
+## Chunk 1: Shared — `computeGaps`
+
+### Task 1: `computeGaps` — Tests
+
+**Files:**
+- Create: `packages/shared/src/utils/gapCompute.test.ts`
+- Create: `packages/shared/src/utils/gapCompute.ts` (stub to make file exist)
+
+- [ ] **Step 1: Create stub**
+
+```typescript
+// packages/shared/src/utils/gapCompute.ts
+export interface Gap {
+  startHour: number
+  endHour: number
+  durationHours: number
+}
+
+export function computeGaps(
+  _activities: Array<{ startHour: number; duration: number }>,
+  _dayStart = 8,
+  _dayEnd = 22,
+): Gap[] {
+  return []
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```typescript
+// packages/shared/src/utils/gapCompute.test.ts
+import { describe, it, expect } from 'vitest'
+import { computeGaps } from './gapCompute'
+
+describe('computeGaps', () => {
+  it('returns full day as one gap when no activities', () => {
+    const result = computeGaps([])
+    expect(result).toEqual([{ startHour: 8, endHour: 22, durationHours: 14 }])
+  })
+
+  it('returns gap before first activity', () => {
+    const result = computeGaps([{ startHour: 11, duration: 1 }])
+    expect(result).toContainEqual({ startHour: 8, endHour: 11, durationHours: 3 })
+  })
+
+  it('returns gap after last activity', () => {
+    const result = computeGaps([{ startHour: 9, duration: 2 }])
+    expect(result).toContainEqual({ startHour: 11, endHour: 22, durationHours: 11 })
+  })
+
+  it('returns gap between two activities', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 1 },
+      { startHour: 14, duration: 2 },
+    ])
+    expect(result).toContainEqual({ startHour: 10, endHour: 14, durationHours: 4 })
+  })
+
+  it('filters out gaps shorter than 1 hour', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 1 },
+      { startHour: 9.5, duration: 2 },  // overlapping; leaves 0.5h before
+    ])
+    // The gap before (8–9) is 1h, included
+    // The gap after (11.5–22) is included
+    // No sub-1h gaps
+    result.forEach((g) => expect(g.durationHours).toBeGreaterThanOrEqual(1))
+  })
+
+  it('handles activities that overlap (cursor advances past overlapping end)', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 3 },  // 9–12
+      { startHour: 10, duration: 1 }, // 10–11 (inside first)
+    ])
+    // Cursor ends at 12, not 11
+    const afterGap = result.find((g) => g.startHour === 12)
+    expect(afterGap).toBeDefined()
+    expect(afterGap?.endHour).toBe(22)
+  })
+
+  it('respects custom dayStart and dayEnd', () => {
+    const result = computeGaps([], 6, 24)
+    expect(result).toEqual([{ startHour: 6, endHour: 24, durationHours: 18 }])
+  })
+
+  it('returns empty when day is fully scheduled', () => {
+    const result = computeGaps([{ startHour: 8, duration: 14 }]) // 8–22
+    expect(result).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 3: Run tests — expect failures**
+
+```bash
+cd packages/shared && npm test -- --reporter=verbose 2>&1 | grep -A3 "gapCompute"
+```
+Expected: multiple FAIL
+
+---
+
+### Task 2: `computeGaps` — Implementation
+
+**Files:**
+- Modify: `packages/shared/src/utils/gapCompute.ts`
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// packages/shared/src/utils/gapCompute.ts
+export interface Gap {
+  startHour: number
+  endHour: number
+  durationHours: number
+}
+
+export function computeGaps(
+  activities: Array<{ startHour: number; duration: number }>,
+  dayStart = 8,
+  dayEnd = 22,
+): Gap[] {
+  const sorted = [...activities].sort((a, b) => a.startHour - b.startHour)
+  const gaps: Gap[] = []
+  let cursor = dayStart
+
+  for (const act of sorted) {
+    if (act.startHour > cursor) {
+      const duration = act.startHour - cursor
+      gaps.push({ startHour: cursor, endHour: act.startHour, durationHours: duration })
+    }
+    cursor = Math.max(cursor, act.startHour + act.duration)
+  }
+
+  if (cursor < dayEnd) {
+    gaps.push({ startHour: cursor, endHour: dayEnd, durationHours: dayEnd - cursor })
+  }
+
+  return gaps.filter((g) => g.durationHours >= 1)
+}
+```
+
+- [ ] **Step 2: Run tests — expect all pass**
+
+```bash
+cd packages/shared && npm test -- --reporter=verbose 2>&1 | grep -A3 "gapCompute"
+```
+Expected: all PASS
+
+---
+
+### Task 3: Export from shared barrel
+
+**Files:**
+- Modify: `packages/shared/src/utils/index.ts` (append at end of file)
+
+- [ ] **Step 1: Add exports to `packages/shared/src/utils/index.ts`**
+
+Append to the end of the file:
+
+```typescript
+// Gap computation utility
+export { computeGaps } from './gapCompute'
+export type { Gap } from './gapCompute'
+```
+
+- [ ] **Step 2: Verify the export is accessible**
+
+```bash
+cd packages/shared && npm run build 2>&1 | tail -5
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/shared/src/utils/gapCompute.ts packages/shared/src/utils/gapCompute.test.ts packages/shared/src/utils/index.ts
+git commit -m "feat: add computeGaps shared utility"
+```
+
+---
+
+## Chunk 2: Backend — Cache, Lambda, Route
+
+### Task 4: Cache helpers
+
+**Files:**
+- Modify: `services/lib/cache.ts`
+
+- [ ] **Step 1: Add gap cache helpers**
+
+Append to `services/lib/cache.ts` after the existing `setCachedSuggestions` function:
+
+```typescript
+// ─── Gap-fill cache ────────────────────────────────────────────
+
+export interface GapSuggestion {
+  title: string
+  type: string
+  startHour: number
+  duration: number
+  latitude?: number
+  longitude?: number
+  address?: string
+  rating?: number
+  price?: number | null
+  image?: string
+  description?: string
+}
+
+interface GapCacheEntry {
+  pk: string
+  sk: string
+  suggestions: GapSuggestion[]
+  expiresAt: number
+}
+
+export async function getCachedGaps(
+  tripId: string,
+  date: string,
+): Promise<GapSuggestion[] | null> {
+  const result = await client.send(
+    new GetCommand({
+      TableName: Resource.RecommendationCache.name,
+      Key: { pk: `fill-gaps:${tripId}:${date}`, sk: 'gaps' },
+    }),
+  )
+  if (!result.Item) return null
+  const entry = result.Item as GapCacheEntry
+  if (entry.expiresAt < Math.floor(Date.now() / 1000)) return null
+  return entry.suggestions
+}
+
+export async function setCachedGaps(
+  tripId: string,
+  date: string,
+  suggestions: GapSuggestion[],
+  ttlSeconds = 1800,
+): Promise<void> {
+  await client.send(
+    new PutCommand({
+      TableName: Resource.RecommendationCache.name,
+      Item: {
+        pk: `fill-gaps:${tripId}:${date}`,
+        sk: 'gaps',
+        suggestions,
+        expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+      },
+    }),
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "cache.ts"
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/lib/cache.ts
+git commit -m "feat: add getCachedGaps/setCachedGaps cache helpers"
+```
+
+---
+
+### Task 5: `fill-gaps` Lambda handler
+
+**Files:**
+- Create: `services/fill-gaps.ts`
+
+- [ ] **Step 1: Create the Lambda**
+
+```typescript
+// services/fill-gaps.ts
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { validateAuth } from './lib/auth'
+import { getCachedGaps, setCachedGaps, type GapSuggestion } from './lib/cache'
+import { searchPlaces } from './lib/serpapi'
+import { computeGaps } from '@travyl/shared'
+
+interface FillGapsRequestBody {
+  tripId: string
+  date: string
+  destination: string
+  activities: Array<{
+    id: string
+    title: string
+    type: string
+    startHour: number
+    duration: number
+    latitude?: number
+    longitude?: number
+  }>
+}
+
+// Activity types to cycle through for variety
+const CATEGORY_ROTATION = [
+  'sightseeing', 'dining', 'cultural', 'outdoor', 'shopping', 'tour',
+] as const
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    const userId = await validateAuth(event.headers.authorization)
+    console.log('[fill-gaps] userId:', userId)
+
+    const body = JSON.parse(event.body ?? '{}') as FillGapsRequestBody
+    const { tripId, date, destination, activities = [] } = body
+
+    if (!tripId || !date || !destination) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'tripId, date, and destination required' }) }
+    }
+
+    // Check cache
+    const cached = await getCachedGaps(tripId, date)
+    if (cached) {
+      console.log('[fill-gaps] cache hit, returning', cached.length, 'suggestions')
+      return { statusCode: 200, body: JSON.stringify({ suggestions: cached }) }
+    }
+
+    // Compute free time slots
+    const gaps = computeGaps(
+      activities.map((a) => ({ startHour: a.startHour, duration: a.duration })),
+    )
+    console.log('[fill-gaps] computed', gaps.length, 'gaps for', destination)
+
+    if (gaps.length === 0) {
+      return { statusCode: 200, body: JSON.stringify({ suggestions: [] }) }
+    }
+
+    // Collect already-scheduled types to avoid repeating
+    const scheduledTypes = new Set(activities.map((a) => a.type.toLowerCase()))
+
+    // Pick a category for each gap, prioritising types not yet scheduled
+    const suggestions: GapSuggestion[] = []
+
+    for (const gap of gaps.slice(0, 3)) {
+      const unusedCategory = CATEGORY_ROTATION.find((c) => !scheduledTypes.has(c))
+      const category = unusedCategory ?? 'sightseeing'
+
+      const places = await searchPlaces(destination, category, { limit: 5 })
+      if (places.length === 0) continue
+
+      // Deduplicate against already-scheduled activity titles (case-insensitive)
+      const scheduledTitles = activities.map((a) => a.title.toLowerCase())
+      const place = places.find(
+        (p) => !scheduledTitles.some((t) => t.includes(p.name.toLowerCase()) || p.name.toLowerCase().includes(t)),
+      ) ?? places[0]
+
+      // Clamp duration to fit the gap, max 2.5h
+      const duration = Math.min(gap.durationHours, 2.5)
+
+      suggestions.push({
+        title: place.name,
+        type: category,
+        startHour: gap.startHour,
+        duration,
+        latitude: place.latitude ?? undefined,
+        longitude: place.longitude ?? undefined,
+        address: place.address ?? undefined,
+        rating: place.rating ?? undefined,
+        price: place.price ?? null,
+        image: place.image ?? undefined,
+        description: place.description ?? undefined,
+      })
+
+      scheduledTypes.add(category)
+    }
+
+    console.log('[fill-gaps] returning', suggestions.length, 'suggestions')
+
+    if (suggestions.length > 0) {
+      await setCachedGaps(tripId, date, suggestions)
+    }
+
+    return { statusCode: 200, body: JSON.stringify({ suggestions }) }
+  } catch (err: any) {
+    if (err.message === 'Invalid token' || err.message?.includes('Authorization')) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('[fill-gaps] error:', err)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "fill-gaps"
+```
+Expected: no errors
+
+---
+
+### Task 6: Register route in `infra/api.ts`
+
+**Files:**
+- Modify: `infra/api.ts`
+
+- [ ] **Step 1: Add the route**
+
+**Depends on:** Task 3 Step 2 (shared build verify) must pass before this Lambda will compile.
+
+Add immediately after the closing `})` of the `GET /suggest` block (line 48 in `infra/api.ts`):
+
+```typescript
+api.route('POST /fill-gaps', {
+  handler: 'services/fill-gaps.handler',
+  link: [cacheTable, supabaseSecretKey, supabaseUrl, serpApiKey],
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/fill-gaps.ts infra/api.ts
+git commit -m "feat: add POST /fill-gaps Lambda endpoint"
+```
+
+---
+
+## Chunk 3: Frontend Components
+
+### Task 7: `GhostEventBlock` component
+
+**Files:**
+- Create: `apps/web/components/calendar/GhostEventBlock.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// apps/web/components/calendar/GhostEventBlock.tsx
+'use client'
+import { HOUR_HEIGHT } from './constants'
+import type { CalendarActivity } from './types'
+
+interface GhostEventBlockProps {
+  activity: CalendarActivity
+  timeRangeStartHour: number
+  onConfirm: (activity: CalendarActivity) => void
+  onDismiss: (id: string) => void
+}
+
+export function GhostEventBlock({
+  activity,
+  timeRangeStartHour,
+  onConfirm,
+  onDismiss,
+}: GhostEventBlockProps) {
+  const top = (activity.startHour - timeRangeStartHour) * HOUR_HEIGHT
+  const height = activity.duration * HOUR_HEIGHT
+
+  return (
+    <div
+      className="absolute left-0 right-0 px-1"
+      style={{ top, height, pointerEvents: 'auto' }}
+    >
+      <div
+        className="relative h-full rounded-md border-2 border-dashed flex flex-col justify-between p-2 overflow-hidden"
+        style={{
+          opacity: 0.55,
+          borderColor: 'var(--cal-accent)',
+          background: 'color-mix(in srgb, var(--cal-accent) 10%, transparent)',
+        }}
+      >
+        <span className="text-[11px] font-medium text-[var(--cal-text)] truncate leading-tight">
+          {activity.title}
+        </span>
+        <div className="flex gap-1 justify-end mt-1">
+          <button
+            onClick={() => onConfirm(activity)}
+            className="text-[10px] font-semibold rounded px-2 py-0.5 transition-opacity"
+            style={{ background: 'var(--cal-accent)', color: 'white' }}
+          >
+            + Add
+          </button>
+          <button
+            onClick={() => onDismiss(activity.id)}
+            className="text-[10px] rounded px-2 py-0.5 transition-colors"
+            style={{ color: 'var(--cal-text-secondary)', background: 'transparent' }}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "GhostEventBlock"
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/GhostEventBlock.tsx
+git commit -m "feat: add GhostEventBlock component"
+```
+
+---
+
+### Task 8: `useGapFiller` hook
+
+**Files:**
+- Create: `apps/web/components/calendar/hooks/useGapFiller.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// apps/web/components/calendar/hooks/useGapFiller.ts
+import { useMutation } from '@tanstack/react-query'
+import { supabase } from '@travyl/shared'
+import type { CalendarActivity } from '../types'
+
+interface GapSuggestionDto {
+  title: string
+  type: string
+  startHour: number
+  duration: number
+  latitude?: number
+  longitude?: number
+  address?: string
+  rating?: number
+  price?: number | null
+  image?: string
+  description?: string
+}
+
+interface FillGapsParams {
+  date: string
+  dayIndex: number
+  activities: CalendarActivity[]
+}
+
+interface UseGapFillerOpts {
+  tripId: string
+  destination: string
+  onSuccess: (suggestions: CalendarActivity[]) => void
+  onError?: () => void
+}
+
+export function useGapFiller({
+  tripId,
+  destination,
+  onSuccess,
+  onError,
+}: UseGapFillerOpts): {
+  fill: (params: FillGapsParams) => void
+  isPending: boolean
+} {
+  const mutation = useMutation<CalendarActivity[], Error, FillGapsParams>({
+    mutationFn: async ({ date, dayIndex, activities }) => {
+      const { data: { session } } = await supabase.auth.getSession()
+      const token = session?.access_token
+      if (!token) throw new Error('Not authenticated')
+
+      const apiUrl = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL ?? ''
+      const res = await fetch(`${apiUrl}/fill-gaps`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          tripId,
+          destination,
+          date,
+          activities: activities.map((a) => ({
+            id: a.id,
+            title: a.title,
+            type: a.type,
+            startHour: a.startHour,
+            duration: a.duration,
+            latitude: a.latitude,
+            longitude: a.longitude,
+          })),
+        }),
+      })
+
+      if (!res.ok) throw new Error(`fill-gaps failed: ${res.status}`)
+
+      const data: { suggestions: GapSuggestionDto[] } = await res.json()
+
+      return data.suggestions.map((s) => ({
+        id: `ghost-${crypto.randomUUID()}`,
+        title: s.title,
+        type: s.type,
+        day: dayIndex,
+        startHour: s.startHour,
+        duration: s.duration,
+        latitude: s.latitude,
+        longitude: s.longitude,
+        rating: s.rating,
+        price: s.price != null ? `$${s.price}` : undefined,
+        image: s.image,
+        unscheduled: false,
+      } satisfies CalendarActivity))
+    },
+    onSuccess,
+    onError: () => {
+      onError?.()
+    },
+  })
+
+  return {
+    fill: (params) => mutation.mutate(params),
+    isPending: mutation.isPending,
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "useGapFiller"
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/hooks/useGapFiller.ts
+git commit -m "feat: add useGapFiller React Query hook"
+```
+
+---
+
+## Chunk 4: Wiring
+
+### Task 9: `DayColumn` — ghost layer
+
+**Files:**
+- Modify: `apps/web/components/calendar/DayColumn.tsx`
+
+- [ ] **Step 1: Add `GhostEventBlock` import and new props to `DayColumnProps`**
+
+Add the import after the existing imports (around line 9):
+```typescript
+import { GhostEventBlock } from './GhostEventBlock'
+```
+
+Add to `DayColumnProps` interface (after `onVotePoll?` on line 35):
+```typescript
+  ghostActivities?: CalendarActivity[]
+  onConfirmGhost?: (activity: CalendarActivity) => void
+  onDismissGhost?: (id: string) => void
+```
+
+- [ ] **Step 2: Destructure new props in `DayColumn` function signature**
+
+In the `DayColumn` function destructuring (starts around line 75), add after `onVotePoll`:
+```typescript
+  ghostActivities = [],
+  onConfirmGhost,
+  onDismissGhost,
+```
+
+- [ ] **Step 3: Add ghost layer inside the droppable grid `div`**
+
+Inside `DayColumn`, find the return statement's droppable grid `div` (the one with `ref={setNodeRef}` or `data-day-index`). Add the ghost layer as the last child inside that div:
+
+```tsx
+{/* Ghost activity layer — above events (z-10), pointer-events only on blocks */}
+{ghostActivities.length > 0 && (
+  <div className="absolute inset-0" style={{ pointerEvents: 'none', zIndex: 10 }}>
+    {ghostActivities
+      .filter((g) => g.day === dayIndex)
+      .map((ghost) => (
+        <GhostEventBlock
+          key={ghost.id}
+          activity={ghost}
+          timeRangeStartHour={timeRange.startHour}
+          onConfirm={(a) => onConfirmGhost?.(a)}
+          onDismiss={(id) => onDismissGhost?.(id)}
+        />
+      ))}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "DayColumn"
+```
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/calendar/DayColumn.tsx
+git commit -m "feat: add ghost activity layer to DayColumn"
+```
+
+---
+
+### Task 10: Thread ghost props through `DayView` and `WeekView`
+
+**Files:**
+- Modify: `apps/web/components/calendar/DayView.tsx`
+- Modify: `apps/web/components/calendar/WeekView.tsx`
+
+- [ ] **Step 1: Update `DayViewProps`**
+
+In `apps/web/components/calendar/DayView.tsx`, add to the `DayViewProps` interface (after `onVotePoll?`):
+```typescript
+  ghostActivities?: CalendarActivity[]
+  onConfirmGhost?: (activity: CalendarActivity) => void
+  onDismissGhost?: (id: string) => void
+```
+
+- [ ] **Step 2: Destructure and pass through in `DayView`**
+
+In the `DayView` function, add to destructuring (after `onVotePoll`):
+```typescript
+  ghostActivities,
+  onConfirmGhost,
+  onDismissGhost,
+```
+
+Pass to `DayColumn` (which `DayView` renders internally):
+```tsx
+ghostActivities={ghostActivities}
+onConfirmGhost={onConfirmGhost}
+onDismissGhost={onDismissGhost}
+```
+
+- [ ] **Step 3: Update `WeekViewProps`**
+
+In `apps/web/components/calendar/WeekView.tsx`, add to `WeekViewProps` interface (after `onVotePoll?` on line ~30):
+```typescript
+  ghostActivities?: CalendarActivity[]
+  onConfirmGhost?: (activity: CalendarActivity) => void
+  onDismissGhost?: (id: string) => void
+```
+
+- [ ] **Step 4: Destructure and pass through in `WeekView`**
+
+In the `WeekView` function, add to destructuring (after `onVotePoll`):
+```typescript
+  ghostActivities,
+  onConfirmGhost,
+  onDismissGhost,
+```
+
+Pass to each `DayColumn` render in `WeekView`:
+```tsx
+ghostActivities={ghostActivities}
+onConfirmGhost={onConfirmGhost}
+onDismissGhost={onDismissGhost}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep -E "DayView|WeekView"
+```
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/calendar/DayView.tsx apps/web/components/calendar/WeekView.tsx
+git commit -m "feat: thread ghost props through DayView and WeekView"
+```
+
+---
+
+### Task 11: `CalendarToolbar` — wand button
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarToolbar.tsx`
+
+- [ ] **Step 1: Add `MagicWand` to imports**
+
+Change line 4 from:
+```typescript
+import { Plus, ShareAndroid, Clock } from 'iconoir-react'
+```
+to:
+```typescript
+import { Plus, ShareAndroid, Clock, MagicWand } from 'iconoir-react'
+```
+
+- [ ] **Step 2: Add new props to `CalendarToolbarProps`**
+
+Add to `CalendarToolbarProps` interface (after `onOpenHistory?`):
+```typescript
+  onFillGaps?: () => void
+  isGapFilling?: boolean
+  hasGhosts?: boolean
+  hasGaps?: boolean
+```
+
+- [ ] **Step 3: Destructure new props in `CalendarToolbar`**
+
+Add to the function destructuring (after `onOpenHistory`):
+```typescript
+  onFillGaps,
+  isGapFilling = false,
+  hasGhosts = false,
+  hasGaps = false,
+```
+
+- [ ] **Step 4: Add wand button in the right controls section**
+
+In the "Right controls" `div` (around line 239), add the wand button after the history button (`Clock`) block and before the collaborator avatars block:
+
+```tsx
+{/* Magic wand — gap filler */}
+{!isSharedView && onFillGaps && (
+  <button
+    onClick={onFillGaps}
+    disabled={isGapFilling || (!hasGaps && !hasGhosts)}
+    title={
+      isGapFilling
+        ? 'Finding suggestions…'
+        : hasGhosts
+        ? 'Clear suggestions'
+        : hasGaps
+        ? 'Fill day with AI suggestions'
+        : 'Day is fully scheduled'
+    }
+    aria-label="Fill day with AI suggestions"
+    className={[
+      'p-1.5 rounded-lg transition-colors',
+      hasGhosts && !isGapFilling
+        ? 'text-[var(--cal-accent)] bg-[color-mix(in_srgb,var(--cal-accent)_12%,transparent)]'
+        : 'text-gray-500 dark:text-[#7a9cc0] hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30',
+      (isGapFilling || (!hasGaps && !hasGhosts)) ? 'opacity-40 cursor-not-allowed' : '',
+    ].join(' ')}
+  >
+    {isGapFilling ? (
+      <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+      </svg>
+    ) : (
+      <MagicWand className="w-4 h-4" />
+    )}
+  </button>
+)}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+npm run typecheck 2>&1 | grep "CalendarToolbar"
+```
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/components/calendar/CalendarToolbar.tsx
+git commit -m "feat: add magic wand button to CalendarToolbar"
+```
+
+---
+
+### Task 12: `CalendarDashboard` — state and wiring
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarDashboard.tsx`
+
+- [ ] **Step 1: Add imports**
+
+Add near the top of the file (after the existing hook imports):
+```typescript
+import { computeGaps } from '@travyl/shared'
+import { useGapFiller } from './hooks/useGapFiller'
+```
+
+- [ ] **Step 2: Add ghost state after the existing `useState` declarations (around line 98–105)**
+
+```typescript
+const [ghostActivities, setGhostActivities] = useState<CalendarActivity[]>([])
+```
+
+- [ ] **Step 3: Add `useEffect` to clear ghosts on day change (after existing `useEffect` hooks)**
+
+```typescript
+// Clear ghost suggestions when the user navigates to a different day
+useEffect(() => {
+  setGhostActivities([])
+}, [selectedDayIndex])
+```
+
+- [ ] **Step 4: Add memos for `selectedDayGhosts`, updated `timeRange`, and `hasGaps`**
+
+Replace the existing `timeRange` memo:
+```typescript
+// existing: const timeRange = useMemo(() => computeTimeRange(activities), [activities])
+```
+with:
+```typescript
+const selectedDayGhosts = useMemo(
+  () => ghostActivities.filter((g) => g.day === selectedDayIndex),
+  [ghostActivities, selectedDayIndex],
+)
+
+const timeRange = useMemo(
+  () => computeTimeRange([...activities, ...selectedDayGhosts]),
+  [activities, selectedDayGhosts],
+)
+
+const hasGaps = useMemo(
+  () =>
+    computeGaps(
+      scheduledActivities
+        .filter((a) => a.day === selectedDayIndex)
+        .map((a) => ({ startHour: a.startHour, duration: a.duration })),
+    ).length > 0,
+  [scheduledActivities, selectedDayIndex],
+)
+```
+
+- [ ] **Step 5: Wire `useGapFiller`**
+
+Add after the `usePollSync` call (around line 141):
+```typescript
+const { fill: fillGaps, isPending: isGapFilling } = useGapFiller({
+  tripId,
+  destination: trip?.destination ?? '',
+  onSuccess: (suggestions) => {
+    if (suggestions.length === 0) {
+      // No suggestions found — wand returns to idle silently (nothing to show)
+      return
+    }
+    setGhostActivities(suggestions)
+  },
+  onError: () => {
+    // Error fetching suggestions — wand returns to idle (ghostActivities stays empty)
+    // Note: add a toast here using whatever notification pattern the app uses
+    console.error('[fill-gaps] Failed to fetch gap suggestions')
+  },
+})
+```
+
+- [ ] **Step 6: Add ghost confirm/dismiss handlers and `handleFillGaps`**
+
+Add alongside the other `useCallback` handlers:
+```typescript
+const handleConfirmGhost = useCallback((ghost: CalendarActivity) => {
+  addActivity({ ...ghost, id: crypto.randomUUID() })
+  setGhostActivities((prev) => prev.filter((g) => g.id !== ghost.id))
+}, [addActivity])
+
+const handleDismissGhost = useCallback((id: string) => {
+  setGhostActivities((prev) => prev.filter((g) => g.id !== id))
+}, [])
+
+const handleFillGaps = useCallback(() => {
+  if (ghostActivities.length > 0) {
+    setGhostActivities([])
+    return
+  }
+  if (!trip) return
+  const date = new Date(parsedStartMs + selectedDayIndex * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0]
+  const dayActivities = scheduledActivities.filter((a) => a.day === selectedDayIndex)
+  fillGaps({ date, dayIndex: selectedDayIndex, activities: dayActivities })
+}, [ghostActivities, trip, parsedStartMs, selectedDayIndex, scheduledActivities, fillGaps])
+```
+
+- [ ] **Step 7: Pass wand props to `CalendarToolbar`**
+
+In the `<CalendarToolbar ...>` JSX (around line 540), add these props:
+```tsx
+onFillGaps={handleFillGaps}
+isGapFilling={isGapFilling}
+hasGhosts={ghostActivities.length > 0}
+hasGaps={hasGaps}
+```
+
+- [ ] **Step 8: Pass ghost props to `WeekView`**
+
+In the `<WeekView ...>` JSX (around line 593), add:
+```tsx
+ghostActivities={ghostActivities}
+onConfirmGhost={handleConfirmGhost}
+onDismissGhost={handleDismissGhost}
+```
+
+- [ ] **Step 9: Pass ghost props to `DayView`**
+
+In the `<DayView ...>` JSX (around line 625), add:
+```tsx
+ghostActivities={ghostActivities}
+onConfirmGhost={handleConfirmGhost}
+onDismissGhost={handleDismissGhost}
+```
+
+- [ ] **Step 10: Full typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: zero errors
+
+- [ ] **Step 11: Lint**
+
+```bash
+npm run lint
+```
+Expected: zero errors
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/web/components/calendar/CalendarDashboard.tsx
+git commit -m "feat: wire AI day planner into CalendarDashboard"
+```
+
+---
+
+## Chunk 5: Deploy and Smoke Test
+
+### Task 13: Deploy and verify
+
+- [ ] **Step 1: Full typecheck before deploying**
+
+```bash
+npm run typecheck
+```
+Expected: zero errors across all workspaces
+
+- [ ] **Step 2: Deploy to production**
+
+```bash
+AWS_PROFILE=525610233002_AdministratorAccess npx sst deploy --stage production
+```
+Expected: deploys without error; `POST /fill-gaps` appears in the API Gateway route list
+
+- [ ] **Step 3: Smoke test the endpoint**
+
+```bash
+# Get a valid token from your browser's DevTools (Application → Local Storage → supabase session)
+TOKEN="<paste-token-here>"
+curl -s -X POST \
+  "https://yqtl1xdcea.execute-api.us-east-1.amazonaws.com/fill-gaps" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tripId":"test","date":"2026-04-15","destination":"Paris, France","activities":[{"id":"1","title":"Eiffel Tower","type":"sightseeing","startHour":10,"duration":2}]}' \
+  | jq .
+```
+Expected: JSON with `suggestions` array (may be empty if SerpAPI quota is low)
+
+- [ ] **Step 4: Browser smoke test**
+
+1. Open a trip with activities on one day
+2. Verify the wand button appears in the toolbar (non-shared view)
+3. Click the wand — verify loading spinner appears
+4. Verify 0–3 ghost activity blocks appear on the calendar
+5. Click **+ Add** on a ghost — verify it becomes a real activity
+6. Click **×** on a ghost — verify it disappears
+7. Navigate to a different day — verify remaining ghosts clear
+8. Click wand again with ghosts showing — verify they clear immediately (toggle)
+9. Fully schedule a day — verify wand button becomes disabled with tooltip "Day is fully scheduled"
+
+- [ ] **Step 5: Final commit (if any cleanup needed)**
+
+```bash
+git add -A
+git commit -m "feat: AI day planner complete — magic wand gap-fill for trip calendar"
+```

--- a/docs/superpowers/plans/2026-03-27-book-my-trip.md
+++ b/docs/superpowers/plans/2026-03-27-book-my-trip.md
@@ -1,0 +1,1873 @@
+# Book My Trip — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Book My Trip" feature that sweeps all scheduled calendar activities, auto-matches each to Viator, OpenTable, Ticketmaster, or Amadeus via affiliate APIs, and surfaces booking links in a slide-in panel — with live Realtime progress updates and per-activity status badges.
+
+**Architecture:** A new `book.ts` Lambda handles `POST /book/match` (fans out to provider APIs in parallel, upserts results to `booking_matches` Supabase table) and `GET /book/status/:tripId` (returns stored matches). The frontend subscribes to Supabase Realtime on `booking_matches` before firing the POST, so progress updates stream live. Core routing + confidence scoring logic lives in `packages/shared` for testability; provider API clients are thin fetch wrappers in `services/lib/booking/`.
+
+**Tech Stack:** SST v4 Ion (Lambda + API Gateway), Supabase (PostgreSQL + Realtime), Vitest, Next.js 16, React 19, Tailwind CSS v4, iconoir-react, motion/react
+
+**Spec:** `docs/superpowers/specs/2026-03-27-book-my-trip-design.md`
+
+---
+
+## File Map
+
+### New files
+| File | Responsibility |
+|---|---|
+| `packages/shared/src/utils/bookingMatcher.ts` | Pure routing + confidence scoring logic (testable) |
+| `packages/shared/src/utils/bookingMatcher.test.ts` | Vitest unit tests |
+| `services/lib/booking/types.ts` | Shared types for the booking system |
+| `services/lib/booking/viator.ts` | Viator affiliate API client |
+| `services/lib/booking/opentable.ts` | OpenTable affiliate API client |
+| `services/lib/booking/ticketmaster.ts` | Ticketmaster Discovery API client |
+| `services/lib/booking/amadeus.ts` | Amadeus Activities API client |
+| `services/book.ts` | Lambda handler — POST /book/match, GET /book/status/:tripId |
+| `apps/web/components/calendar/hooks/useBookingMatches.ts` | Supabase Realtime subscription + status writes |
+| `apps/web/components/calendar/BookingPanel.tsx` | Slide-in drawer UI — Loading / Summary / Done states |
+
+### Modified files
+| File | Change |
+|---|---|
+| `infra/secrets.ts` | Add 4 new SST secrets |
+| `infra/api.ts` | Add POST /book/match + GET /book/status/:tripId routes |
+| `apps/web/components/calendar/CalendarToolbar.tsx` | Add "Book My Trip" + "View Bookings" buttons + new props |
+| `apps/web/components/calendar/EventBlock.tsx` | Add `bookingStatus` prop + status badge |
+| `apps/web/components/calendar/CalendarDashboard.tsx` | Wire up booking hooks, panel, toolbar props |
+
+---
+
+## Chunk 1: Infrastructure
+
+### Task 1: Supabase migration — booking_matches table
+
+**Files:**
+- Create: migration via Supabase MCP
+
+- [ ] **Step 1: Apply the migration**
+
+Run this via Supabase MCP `apply_migration` with name `add_booking_matches`:
+
+```sql
+create table booking_matches (
+  id uuid primary key default gen_random_uuid(),
+  trip_id uuid not null references trips(id) on delete cascade,
+  activity_id text not null,
+  provider text,
+  matched_name text,
+  booking_url text,
+  affiliate_url text,
+  confidence float,
+  status text not null default 'unmatched',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint booking_matches_trip_activity_key unique (trip_id, activity_id)
+);
+
+create or replace function set_booking_matches_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger booking_matches_updated_at
+  before update on booking_matches
+  for each row execute function set_booking_matches_updated_at();
+
+alter table booking_matches enable row level security;
+
+create policy "booking_matches_select"
+  on booking_matches for select
+  using (
+    trip_id in (
+      select id from trips where user_id = auth.uid()
+      union
+      select trip_id from trip_collaborators where user_id = auth.uid() and invite_status = 'accepted'
+    )
+  );
+
+create policy "booking_matches_update_opened"
+  on booking_matches for update
+  using (
+    trip_id in (
+      select id from trips where user_id = auth.uid()
+      union
+      select trip_id from trip_collaborators where user_id = auth.uid() and invite_status = 'accepted'
+    )
+  )
+  with check (status = 'opened');
+```
+
+- [ ] **Step 2: Enable Realtime on booking_matches**
+
+Run via Supabase MCP `execute_sql`:
+
+```sql
+alter publication supabase_realtime add table booking_matches;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add booking_matches Supabase migration"
+```
+
+---
+
+### Task 2: SST secrets + API routes
+
+**Files:**
+- Modify: `infra/secrets.ts`
+- Modify: `infra/api.ts`
+
+- [ ] **Step 1: Add secrets to `infra/secrets.ts`**
+
+Append to the end of `infra/secrets.ts`:
+
+```ts
+// ─── Booking / Affiliate ────────────────────────────────────
+export const viatorAffiliateKey = new sst.Secret('ViatorAffiliateKey')
+export const openTableAffiliateKey = new sst.Secret('OpenTableAffiliateKey')
+export const ticketmasterApiKey = new sst.Secret('TicketmasterApiKey')
+export const amadeusApiKey = new sst.Secret('AmadeusApiKey')
+export const amadeusApiSecret = new sst.Secret('AmadeusApiSecret')
+```
+
+- [ ] **Step 2: Add routes to `infra/api.ts`**
+
+First add the import at the top of `infra/api.ts` (alongside existing secret imports):
+
+```ts
+import { viatorAffiliateKey, openTableAffiliateKey, ticketmasterApiKey, amadeusApiKey, amadeusApiSecret } from './secrets'
+```
+
+Then append two routes at the end of `infra/api.ts`:
+
+```ts
+api.route('POST /book/match', {
+  handler: 'services/book.handler',
+  link: [supabaseSecretKey, supabaseUrl, viatorAffiliateKey, openTableAffiliateKey, ticketmasterApiKey, amadeusApiKey, amadeusApiSecret],
+  timeout: '30 seconds',
+})
+
+api.route('GET /book/status/{tripId}', {
+  handler: 'services/book.statusHandler',
+  link: [supabaseSecretKey, supabaseUrl],
+  timeout: '10 seconds',
+})
+```
+
+- [ ] **Step 3: Set placeholder secret values (dev only)**
+
+```bash
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set ViatorAffiliateKey placeholder --stage production
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set OpenTableAffiliateKey placeholder --stage production
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set TicketmasterApiKey placeholder --stage production
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set AmadeusApiKey placeholder --stage production
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set AmadeusApiSecret placeholder --stage production
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/secrets.ts infra/api.ts
+git commit -m "feat: add booking SST secrets and API routes"
+```
+
+---
+
+## Chunk 2: Business logic (matcher + providers)
+
+### Task 3: Booking matcher utility + tests
+
+**Files:**
+- Create: `packages/shared/src/utils/bookingMatcher.ts`
+- Create: `packages/shared/src/utils/bookingMatcher.test.ts`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `packages/shared/src/utils/bookingMatcher.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { routeProvider, nameSimScore, proximityScore, calculateConfidence } from './bookingMatcher'
+
+describe('routeProvider', () => {
+  it('routes dining to opentable', () => {
+    expect(routeProvider('dining')).toBe('opentable')
+  })
+  it('routes sightseeing to viator', () => {
+    expect(routeProvider('sightseeing')).toBe('viator')
+  })
+  it('routes tour to viator', () => {
+    expect(routeProvider('tour')).toBe('viator')
+  })
+  it('routes museum to viator', () => {
+    expect(routeProvider('museum')).toBe('viator')
+  })
+  it('routes cultural to viator', () => {
+    expect(routeProvider('cultural')).toBe('viator')
+  })
+  it('routes outdoor to viator', () => {
+    expect(routeProvider('outdoor')).toBe('viator')
+  })
+  it('routes event to ticketmaster', () => {
+    expect(routeProvider('event')).toBe('ticketmaster')
+  })
+  it('routes concert to ticketmaster', () => {
+    expect(routeProvider('concert')).toBe('ticketmaster')
+  })
+  it('routes show to ticketmaster', () => {
+    expect(routeProvider('show')).toBe('ticketmaster')
+  })
+  it('routes nightlife to ticketmaster', () => {
+    expect(routeProvider('nightlife')).toBe('ticketmaster')
+  })
+  it('routes entertainment to ticketmaster', () => {
+    expect(routeProvider('entertainment')).toBe('ticketmaster')
+  })
+  it('routes unknown types to amadeus', () => {
+    expect(routeProvider('shopping')).toBe('amadeus')
+    expect(routeProvider('unknown')).toBe('amadeus')
+    expect(routeProvider('')).toBe('amadeus')
+  })
+  it('is case-insensitive', () => {
+    expect(routeProvider('Dining')).toBe('opentable')
+    expect(routeProvider('TOUR')).toBe('viator')
+  })
+})
+
+describe('nameSimScore', () => {
+  it('returns 1 for identical strings', () => {
+    expect(nameSimScore('Eiffel Tower', 'Eiffel Tower')).toBe(1)
+  })
+  it('returns 1 for identical strings case-insensitively', () => {
+    expect(nameSimScore('eiffel tower', 'Eiffel Tower')).toBe(1)
+  })
+  it('returns 0 for completely different strings', () => {
+    expect(nameSimScore('abc', 'xyz')).toBe(0)
+  })
+  it('returns value between 0 and 1 for similar strings', () => {
+    const score = nameSimScore('Eiffel Tower', 'Eiffel Tower Restaurant')
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThan(1)
+  })
+  it('handles empty strings without throwing', () => {
+    expect(() => nameSimScore('', '')).not.toThrow()
+    expect(() => nameSimScore('abc', '')).not.toThrow()
+  })
+})
+
+describe('proximityScore', () => {
+  it('returns 1 for same location', () => {
+    expect(proximityScore(48.8584, 2.2945, 48.8584, 2.2945)).toBe(1)
+  })
+  it('returns 1 for distance <= 100m', () => {
+    // ~50m north
+    expect(proximityScore(48.8584, 2.2945, 48.8589, 2.2945)).toBe(1)
+  })
+  it('returns 0 for distance >= 500m', () => {
+    // ~1km away
+    expect(proximityScore(48.8584, 2.2945, 48.8674, 2.2945)).toBe(0)
+  })
+  it('returns value between 0 and 1 for 100-500m range', () => {
+    // ~300m away
+    const score = proximityScore(48.8584, 2.2945, 48.8611, 2.2945)
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThan(1)
+  })
+})
+
+describe('calculateConfidence', () => {
+  it('returns 1 for perfect name and proximity', () => {
+    expect(calculateConfidence(1, 1)).toBe(1)
+  })
+  it('returns 0 for no name match and no proximity', () => {
+    expect(calculateConfidence(0, 0)).toBe(0)
+  })
+  it('weights name 70% and proximity 30%', () => {
+    expect(calculateConfidence(1, 0)).toBeCloseTo(0.7)
+    expect(calculateConfidence(0, 1)).toBeCloseTo(0.3)
+  })
+  it('reaches 0.6 threshold with good name match and moderate proximity', () => {
+    // nameSim=0.8, proxScore=0.2 → 0.7*0.8 + 0.3*0.2 = 0.56 + 0.06 = 0.62
+    expect(calculateConfidence(0.8, 0.2)).toBeGreaterThanOrEqual(0.6)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd packages/shared && npm test -- --run bookingMatcher
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `bookingMatcher.ts`**
+
+Create `packages/shared/src/utils/bookingMatcher.ts`:
+
+```ts
+// ─── Provider routing ─────────────────────────────────────────
+
+const PROVIDER_MAP: Record<string, string> = {
+  tour: 'viator',
+  sightseeing: 'viator',
+  museum: 'viator',
+  cultural: 'viator',
+  outdoor: 'viator',
+  dining: 'opentable',
+  event: 'ticketmaster',
+  concert: 'ticketmaster',
+  show: 'ticketmaster',
+  nightlife: 'ticketmaster',
+  entertainment: 'ticketmaster',
+}
+
+/** Returns the booking provider name for a given activity type. */
+export function routeProvider(activityType: string): string {
+  return PROVIDER_MAP[activityType.toLowerCase()] ?? 'amadeus'
+}
+
+// ─── Name similarity (normalized Levenshtein) ─────────────────
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+  )
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    }
+  }
+  return dp[m][n]
+}
+
+/** Normalized name similarity score 0–1 (case-insensitive). */
+export function nameSimScore(a: string, b: string): number {
+  const na = a.toLowerCase().trim()
+  const nb = b.toLowerCase().trim()
+  if (na === nb) return 1
+  const maxLen = Math.max(na.length, nb.length)
+  if (maxLen === 0) return 1
+  return 1 - levenshtein(na, nb) / maxLen
+}
+
+// ─── Proximity scoring ────────────────────────────────────────
+
+const MIN_DISTANCE_M = 100
+const MAX_DISTANCE_M = 500
+
+function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371000
+  const φ1 = (lat1 * Math.PI) / 180
+  const φ2 = (lat2 * Math.PI) / 180
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180
+  const a =
+    Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+/** Proximity score 0–1. 1.0 if ≤100m, 0.0 if ≥500m, linear between. */
+export function proximityScore(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const d = haversineMeters(lat1, lon1, lat2, lon2)
+  if (d <= MIN_DISTANCE_M) return 1
+  if (d >= MAX_DISTANCE_M) return 0
+  return 1 - (d - MIN_DISTANCE_M) / (MAX_DISTANCE_M - MIN_DISTANCE_M)
+}
+
+// ─── Combined confidence ─────────────────────────────────────
+
+/** Combined confidence = 0.7 × nameSim + 0.3 × proximity */
+export function calculateConfidence(nameSim: number, proxScore: number): number {
+  return 0.7 * nameSim + 0.3 * proxScore
+}
+```
+
+- [ ] **Step 4: Export from `packages/shared/src/utils/index.ts`**
+
+Append to the end of `packages/shared/src/utils/index.ts`:
+
+```ts
+// Booking matcher utilities
+export { routeProvider, nameSimScore, proximityScore, calculateConfidence } from './bookingMatcher'
+```
+
+These are now available as `import { routeProvider, ... } from '@travyl/shared'`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd packages/shared && npm test -- --run bookingMatcher
+```
+
+Expected: all 26 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/utils/bookingMatcher.ts packages/shared/src/utils/bookingMatcher.test.ts packages/shared/src/utils/index.ts
+git commit -m "feat: add booking matcher utility with routing and confidence scoring"
+```
+
+---
+
+### Task 4: Provider API clients
+
+**Files:**
+- Create: `services/lib/booking/types.ts`
+- Create: `services/lib/booking/viator.ts`
+- Create: `services/lib/booking/opentable.ts`
+- Create: `services/lib/booking/ticketmaster.ts`
+- Create: `services/lib/booking/amadeus.ts`
+
+- [ ] **Step 1: Create shared types**
+
+Create `services/lib/booking/types.ts`:
+
+```ts
+export interface BookingActivity {
+  id: string
+  title: string
+  type: string
+  latitude: number
+  longitude: number
+  /** ISO date string for the activity's scheduled day — used by Ticketmaster date matching */
+  scheduledDate?: string
+}
+
+export interface ProviderMatch {
+  provider: string
+  matchedName: string
+  bookingUrl: string
+  affiliateUrl: string
+  /** Lat/lng of matched venue — used to compute proximity score */
+  lat: number
+  lng: number
+}
+```
+
+- [ ] **Step 2: Create Viator client**
+
+Create `services/lib/booking/viator.ts`:
+
+```ts
+import { Resource } from 'sst'
+import type { BookingActivity, ProviderMatch } from './types'
+
+const BASE_URL = 'https://api.viator.com/partner'
+const AFFILIATE_BASE = 'https://www.viator.com'
+
+interface ViatorProduct {
+  productCode: string
+  title: string
+  webURL: string
+  destinations?: Array<{ ref: string }>
+}
+
+export async function searchViator(
+  activity: BookingActivity,
+): Promise<ProviderMatch | null> {
+  const apiKey = Resource.ViatorAffiliateKey.value
+  if (!apiKey || apiKey === 'placeholder') return null
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const res = await fetch(`${BASE_URL}/products/search`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'exp-api-key': apiKey,
+        'Accept-Language': 'en-US',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        filtering: {
+          destination: '',
+          searchTerm: activity.title,
+          lowestPrice: 0,
+          highestPrice: 999999,
+          startDate: '',
+          endDate: '',
+          includeAutomaticTranslations: false,
+          confirmationType: 'ALL',
+          durationInMinutes: { from: 0, to: 99999 },
+          rating: { from: 0, to: 5 },
+        },
+        sorting: { sort: 'RELEVANCE', order: 'DESCENDING' },
+        pagination: { start: 1, count: 1 },
+        currency: 'USD',
+      }),
+    })
+    clearTimeout(timeout)
+
+    if (!res.ok) return null
+    const data = await res.json()
+    const product: ViatorProduct | undefined = data.products?.[0]
+    if (!product) return null
+
+    const affiliateUrl = `${AFFILIATE_BASE}${product.webURL}${product.webURL.includes('?') ? '&' : '?'}mcid=${apiKey}`
+
+    // Viator doesn't return lat/lng in search — use activity coords for proximity (same city assumed)
+    return {
+      provider: 'viator',
+      matchedName: product.title,
+      bookingUrl: `${AFFILIATE_BASE}${product.webURL}`,
+      affiliateUrl,
+      lat: activity.latitude,
+      lng: activity.longitude,
+    }
+  } catch {
+    clearTimeout(timeout)
+    return null
+  }
+}
+```
+
+- [ ] **Step 3: Create OpenTable client**
+
+Create `services/lib/booking/opentable.ts`:
+
+```ts
+import { Resource } from 'sst'
+import type { BookingActivity, ProviderMatch } from './types'
+
+const BASE_URL = 'https://platform.otgw.ot.tools/restaurants/v1'
+const AFFILIATE_BASE = 'https://www.opentable.com'
+
+interface OTRestaurant {
+  restaurantId: number
+  name: string
+  latitude: number
+  longitude: number
+  profileLink: string
+}
+
+export async function searchOpenTable(
+  activity: BookingActivity,
+): Promise<ProviderMatch | null> {
+  const apiKey = Resource.OpenTableAffiliateKey.value
+  if (!apiKey || apiKey === 'placeholder') return null
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const params = new URLSearchParams({
+      latitude: String(activity.latitude),
+      longitude: String(activity.longitude),
+      radius: '1',
+      name: activity.title,
+    })
+    const res = await fetch(`${BASE_URL}?${params}`, {
+      signal: controller.signal,
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    })
+    clearTimeout(timeout)
+
+    if (!res.ok) return null
+    const data = await res.json()
+    const restaurant: OTRestaurant | undefined = data.restaurants?.[0]
+    if (!restaurant) return null
+
+    const bookingUrl = `${AFFILIATE_BASE}${restaurant.profileLink}`
+    const affiliateUrl = `${bookingUrl}${bookingUrl.includes('?') ? '&' : '?'}ref=travyl`
+
+    return {
+      provider: 'opentable',
+      matchedName: restaurant.name,
+      bookingUrl,
+      affiliateUrl,
+      lat: restaurant.latitude,
+      lng: restaurant.longitude,
+    }
+  } catch {
+    clearTimeout(timeout)
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Create Ticketmaster client**
+
+Create `services/lib/booking/ticketmaster.ts`:
+
+```ts
+import { Resource } from 'sst'
+import type { BookingActivity, ProviderMatch } from './types'
+
+const BASE_URL = 'https://app.ticketmaster.com/discovery/v2'
+
+interface TMEvent {
+  name: string
+  url: string
+  _embedded?: {
+    venues?: Array<{ location?: { latitude: string; longitude: string } }>
+  }
+}
+
+export async function searchTicketmaster(
+  activity: BookingActivity,
+): Promise<ProviderMatch | null> {
+  const apiKey = Resource.TicketmasterApiKey.value
+  if (!apiKey || apiKey === 'placeholder') return null
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const params = new URLSearchParams({
+      apikey: apiKey,
+      keyword: activity.title,
+      latlong: `${activity.latitude},${activity.longitude}`,
+      radius: '25',
+      unit: 'miles',
+      size: '1',
+      sort: 'relevance,desc',
+    })
+    // If the activity has a scheduled date, filter events around that date
+    if (activity.scheduledDate) {
+      const d = new Date(activity.scheduledDate)
+      const start = d.toISOString().split('.')[0] + 'Z'
+      const end = new Date(d.getTime() + 86400000).toISOString().split('.')[0] + 'Z'
+      params.set('startDateTime', start)
+      params.set('endDateTime', end)
+    }
+
+    const res = await fetch(`${BASE_URL}/events.json?${params}`, {
+      signal: controller.signal,
+    })
+    clearTimeout(timeout)
+
+    if (!res.ok) return null
+    const data = await res.json()
+    const event: TMEvent | undefined = data._embedded?.events?.[0]
+    if (!event) return null
+
+    const venue = event._embedded?.venues?.[0]
+    const lat = parseFloat(venue?.location?.latitude ?? String(activity.latitude))
+    const lng = parseFloat(venue?.location?.longitude ?? String(activity.longitude))
+
+    const affiliateUrl = `${event.url}${event.url.includes('?') ? '&' : '?'}utm_source=travyl`
+
+    return {
+      provider: 'ticketmaster',
+      matchedName: event.name,
+      bookingUrl: event.url,
+      affiliateUrl,
+      lat,
+      lng,
+    }
+  } catch {
+    clearTimeout(timeout)
+    return null
+  }
+}
+```
+
+- [ ] **Step 5: Create Amadeus client**
+
+Create `services/lib/booking/amadeus.ts`:
+
+```ts
+import { Resource } from 'sst'
+import type { BookingActivity, ProviderMatch } from './types'
+
+const AUTH_URL = 'https://test.api.amadeus.com/v1/security/oauth2/token'
+const BASE_URL = 'https://test.api.amadeus.com/v1'
+
+interface AmadeusActivity {
+  name: string
+  bookingLink?: string
+  geoCode?: { latitude: number; longitude: number }
+}
+
+async function getAmadeusToken(): Promise<string | null> {
+  const id = Resource.AmadeusApiKey.value
+  const secret = Resource.AmadeusApiSecret.value
+  if (!id || id === 'placeholder') return null
+
+  const res = await fetch(AUTH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `grant_type=client_credentials&client_id=${id}&client_secret=${secret}`,
+  })
+  if (!res.ok) return null
+  const data = await res.json()
+  return data.access_token ?? null
+}
+
+export async function searchAmadeus(
+  activity: BookingActivity,
+): Promise<ProviderMatch | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const token = await getAmadeusToken()
+    if (!token) return null
+
+    const params = new URLSearchParams({
+      latitude: String(activity.latitude),
+      longitude: String(activity.longitude),
+      radius: '1',
+    })
+    const res = await fetch(`${BASE_URL}/shopping/activities?${params}`, {
+      signal: controller.signal,
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    clearTimeout(timeout)
+
+    if (!res.ok) return null
+    const data = await res.json()
+    const items: AmadeusActivity[] = data.data ?? []
+
+    // Find best name match from first 5 results
+    const { nameSimScore } = await import('@travyl/shared')
+    const scored = items.slice(0, 5).map((item) => ({
+      item,
+      sim: nameSimScore(activity.title, item.name),
+    }))
+    const best = scored.sort((a, b) => b.sim - a.sim)[0]
+    if (!best || !best.item.bookingLink) return null
+
+    const affiliateUrl = `${best.item.bookingLink}${best.item.bookingLink.includes('?') ? '&' : '?'}utm_source=travyl`
+
+    return {
+      provider: 'amadeus',
+      matchedName: best.item.name,
+      bookingUrl: best.item.bookingLink,
+      affiliateUrl,
+      lat: best.item.geoCode?.latitude ?? activity.latitude,
+      lng: best.item.geoCode?.longitude ?? activity.longitude,
+    }
+  } catch {
+    clearTimeout(timeout)
+    return null
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/lib/booking/
+git commit -m "feat: add booking provider API clients (Viator, OpenTable, Ticketmaster, Amadeus)"
+```
+
+---
+
+## Chunk 3: Lambda handler
+
+### Task 5: book.ts Lambda
+
+**Files:**
+- Create: `services/book.ts`
+
+- [ ] **Step 1: Create the handler**
+
+Create `services/book.ts`:
+
+```ts
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { Resource } from 'sst'
+import { createClient } from '@supabase/supabase-js'
+import { validateAuth } from './lib/auth'
+import { routeProvider, nameSimScore, proximityScore, calculateConfidence } from '@travyl/shared'
+import { searchViator } from './lib/booking/viator'
+import { searchOpenTable } from './lib/booking/opentable'
+import { searchTicketmaster } from './lib/booking/ticketmaster'
+import { searchAmadeus } from './lib/booking/amadeus'
+import type { BookingActivity } from './lib/booking/types'
+
+const CONFIDENCE_THRESHOLD = 0.6
+
+function getSupabaseAdmin() {
+  return createClient(Resource.SupabaseUrl.value, Resource.SupabaseSecretKey.value)
+}
+
+async function matchActivity(activity: BookingActivity) {
+  const provider = routeProvider(activity.type)
+
+  let match = null
+  try {
+    if (provider === 'viator') match = await searchViator(activity)
+    else if (provider === 'opentable') match = await searchOpenTable(activity)
+    else if (provider === 'ticketmaster') match = await searchTicketmaster(activity)
+    else match = await searchAmadeus(activity)
+  } catch {
+    // provider threw — treat as unmatched
+  }
+
+  if (!match) {
+    return {
+      activityId: activity.id,
+      provider: null,
+      matchedName: null,
+      bookingUrl: null,
+      affiliateUrl: null,
+      confidence: null,
+      status: 'unmatched' as const,
+    }
+  }
+
+  const nameSim = nameSimScore(activity.title, match.matchedName)
+  const proxScore = proximityScore(activity.latitude, activity.longitude, match.lat, match.lng)
+  const confidence = calculateConfidence(nameSim, proxScore)
+
+  if (confidence < CONFIDENCE_THRESHOLD) {
+    return {
+      activityId: activity.id,
+      provider: null,
+      matchedName: null,
+      bookingUrl: null,
+      affiliateUrl: null,
+      confidence,
+      status: 'unmatched' as const,
+    }
+  }
+
+  return {
+    activityId: activity.id,
+    provider: match.provider,
+    matchedName: match.matchedName,
+    bookingUrl: match.bookingUrl,
+    affiliateUrl: match.affiliateUrl,
+    confidence,
+    status: 'matched' as const,
+  }
+}
+
+// ─── POST /book/match ─────────────────────────────────────────
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    await validateAuth(event.headers?.authorization)
+  } catch {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+  }
+
+  let body: { tripId?: string; activities?: BookingActivity[] }
+  try {
+    body = JSON.parse(event.body ?? '{}')
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) }
+  }
+
+  const { tripId, activities } = body
+  if (!tripId || !Array.isArray(activities) || activities.length === 0) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'tripId and activities required' }) }
+  }
+
+  const supabase = getSupabaseAdmin()
+
+  // Filter to activities with coordinates; mark the rest unmatched directly
+  const withCoords = activities.filter((a) => a.latitude != null && a.longitude != null)
+  const withoutCoords = activities.filter((a) => a.latitude == null || a.longitude == null)
+
+  // Upsert uncoordinated activities as unmatched immediately
+  if (withoutCoords.length > 0) {
+    await supabase.from('booking_matches').upsert(
+      withoutCoords.map((a) => ({
+        trip_id: tripId,
+        activity_id: a.id,
+        provider: null,
+        matched_name: null,
+        booking_url: null,
+        affiliate_url: null,
+        confidence: null,
+        status: 'unmatched',
+      })),
+      { onConflict: 'trip_id,activity_id' },
+    )
+  }
+
+  // Fan out provider searches in parallel
+  const results = await Promise.allSettled(withCoords.map(matchActivity))
+
+  const matches = results.map((r, i) =>
+    r.status === 'fulfilled'
+      ? r.value
+      : {
+          activityId: withCoords[i].id,
+          provider: null,
+          matchedName: null,
+          bookingUrl: null,
+          affiliateUrl: null,
+          confidence: null,
+          status: 'unmatched' as const,
+        },
+  )
+
+  // Upsert all matches to Supabase (triggers Realtime events to client)
+  await supabase.from('booking_matches').upsert(
+    matches.map((m) => ({
+      trip_id: tripId,
+      activity_id: m.activityId,
+      provider: m.provider,
+      matched_name: m.matchedName,
+      booking_url: m.bookingUrl,
+      affiliate_url: m.affiliateUrl,
+      confidence: m.confidence,
+      status: m.status,
+    })),
+    { onConflict: 'trip_id,activity_id' },
+  )
+
+  const allMatches = [
+    ...withoutCoords.map((a) => ({
+      activityId: a.id,
+      status: 'unmatched' as const,
+      provider: undefined,
+      matchedName: undefined,
+      affiliateUrl: undefined,
+      confidence: undefined,
+    })),
+    ...matches.map((m) => ({
+      activityId: m.activityId,
+      status: m.status,
+      provider: m.provider ?? undefined,
+      matchedName: m.matchedName ?? undefined,
+      affiliateUrl: m.affiliateUrl ?? undefined,
+      confidence: m.confidence ?? undefined,
+    })),
+  ]
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ total: activities.length, matches: allMatches }),
+  }
+}
+
+// ─── GET /book/status/{tripId} ────────────────────────────────
+
+export const statusHandler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    await validateAuth(event.headers?.authorization)
+  } catch {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+  }
+
+  const tripId = event.pathParameters?.tripId
+  if (!tripId) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'tripId required' }) }
+  }
+
+  const supabase = getSupabaseAdmin()
+  const { data, error } = await supabase
+    .from('booking_matches')
+    .select('activity_id, provider, matched_name, booking_url, affiliate_url, confidence, status, updated_at')
+    .eq('trip_id', tripId)
+
+  if (error) {
+    console.error('[book/status] supabase error:', error)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+
+  const matches = (data ?? []).map((row) => ({
+    activityId: row.activity_id,
+    status: row.status,
+    provider: row.provider ?? undefined,
+    matchedName: row.matched_name ?? undefined,
+    bookingUrl: row.booking_url ?? undefined,
+    affiliateUrl: row.affiliate_url ?? undefined,
+    confidence: row.confidence ?? undefined,
+    updatedAt: row.updated_at,
+  }))
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ matches }),
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors in `services/book.ts` or related files
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/book.ts
+git commit -m "feat: add book Lambda handler for POST /book/match and GET /book/status"
+```
+
+---
+
+## Chunk 4: Frontend hooks
+
+### Task 6: useBookingMatches hook
+
+**Files:**
+- Create: `apps/web/components/calendar/hooks/useBookingMatches.ts`
+
+This hook manages three concerns:
+1. Fetching prior match state on mount (via `GET /book/status`)
+2. Subscribing to Supabase Realtime for live updates
+3. Marking activities as `opened` in the DB
+
+- [ ] **Step 1: Create the hook**
+
+Create `apps/web/components/calendar/hooks/useBookingMatches.ts`:
+
+```ts
+'use client'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getSupabaseBrowser } from '@/lib/supabase-browser'
+
+export type BookingStatus = 'unmatched' | 'matched' | 'opened'
+
+export interface BookingMatch {
+  activityId: string
+  status: BookingStatus
+  provider?: string
+  matchedName?: string
+  bookingUrl?: string
+  affiliateUrl?: string
+  confidence?: number
+  updatedAt?: string
+}
+
+interface UseBookingMatchesOptions {
+  tripId: string
+  apiUrl: string
+  authToken: string
+}
+
+interface UseBookingMatchesReturn {
+  matches: Map<string, BookingMatch>
+  hasMatches: boolean
+  fetchStatus: () => Promise<void>
+  startRealtimeAndMatch: (activities: Array<{
+    id: string; title: string; type: string
+    latitude: number | null; longitude: number | null
+  }>) => Promise<{ total: number; matches: BookingMatch[] }>
+  markOpened: (activityIds: string[]) => Promise<void>
+}
+
+export function useBookingMatches({
+  tripId,
+  apiUrl,
+  authToken,
+}: UseBookingMatchesOptions): UseBookingMatchesReturn {
+  const [matches, setMatches] = useState<Map<string, BookingMatch>>(new Map())
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channelRef = useRef<any>(null)
+
+  const applyRows = useCallback((rows: BookingMatch[]) => {
+    setMatches((prev) => {
+      const next = new Map(prev)
+      for (const row of rows) next.set(row.activityId, row)
+      return next
+    })
+  }, [])
+
+  // Subscribe to Realtime updates for this trip
+  const subscribeRealtime = useCallback(() => {
+    const supabase = getSupabaseBrowser()
+    if (channelRef.current) return // already subscribed
+
+    const channel = supabase
+      .channel(`booking_matches:${tripId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'booking_matches',
+          filter: `trip_id=eq.${tripId}`,
+        },
+        (payload) => {
+          const row = payload.new as any
+          if (!row?.activity_id) return
+          applyRows([{
+            activityId: row.activity_id,
+            status: row.status,
+            provider: row.provider ?? undefined,
+            matchedName: row.matched_name ?? undefined,
+            bookingUrl: row.booking_url ?? undefined,
+            affiliateUrl: row.affiliate_url ?? undefined,
+            confidence: row.confidence ?? undefined,
+            updatedAt: row.updated_at,
+          }])
+        },
+      )
+      .subscribe()
+    channelRef.current = channel
+  }, [tripId, applyRows])
+
+  // Fetch current status from Lambda
+  const fetchStatus = useCallback(async () => {
+    const res = await fetch(`${apiUrl}/book/status/${tripId}`, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    })
+    if (!res.ok) return
+    const data = await res.json()
+    applyRows(data.matches ?? [])
+  }, [tripId, apiUrl, authToken, applyRows])
+
+  // Subscribe Realtime first, then fire POST /book/match
+  const startRealtimeAndMatch = useCallback(async (activities: Array<{
+    id: string; title: string; type: string
+    latitude: number | null; longitude: number | null
+  }>) => {
+    subscribeRealtime()
+
+    const res = await fetch(`${apiUrl}/book/match`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({ tripId, activities }),
+    })
+    if (!res.ok) throw new Error('match request failed')
+    const data = await res.json()
+    return data as { total: number; matches: BookingMatch[] }
+  }, [tripId, apiUrl, authToken, subscribeRealtime])
+
+  // Mark activities as opened in Supabase (client-side update, constrained by RLS to 'opened' only)
+  const markOpened = useCallback(async (activityIds: string[]) => {
+    const supabase = getSupabaseBrowser()
+    for (const activityId of activityIds) {
+      await supabase
+        .from('booking_matches')
+        .update({ status: 'opened' })
+        .eq('trip_id', tripId)
+        .eq('activity_id', activityId)
+    }
+    applyRows(activityIds.map((id) => {
+      const existing = matches.get(id)
+      return { ...(existing ?? { activityId: id, status: 'unmatched' }), status: 'opened' as BookingStatus }
+    }))
+  }, [tripId, matches, applyRows])
+
+  // Fetch prior state on mount
+  useEffect(() => {
+    if (!tripId || !authToken) return
+    fetchStatus()
+    return () => {
+      // Unsubscribe on unmount
+      if (channelRef.current) {
+        getSupabaseBrowser().removeChannel(channelRef.current)
+        channelRef.current = null
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tripId])
+
+  const hasMatches = matches.size > 0
+
+  return { matches, hasMatches, fetchStatus, startRealtimeAndMatch, markOpened }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/hooks/useBookingMatches.ts
+git commit -m "feat: add useBookingMatches hook with Realtime subscription and status management"
+```
+
+---
+
+## Chunk 5: Frontend UI
+
+### Task 7: BookingPanel component
+
+**Files:**
+- Create: `apps/web/components/calendar/BookingPanel.tsx`
+
+Pattern: follow `HistoryDrawer.tsx` — fixed overlay, slide-in from right, `isOpen`/`isVisible` state.
+
+- [ ] **Step 1: Create BookingPanel**
+
+Create `apps/web/components/calendar/BookingPanel.tsx`:
+
+```tsx
+'use client'
+import { useState, useEffect } from 'react'
+import { Xmark, BookmarkSolid } from 'iconoir-react'
+import type { BookingMatch } from './hooks/useBookingMatches'
+
+const PROVIDER_LABELS: Record<string, string> = {
+  viator: 'Viator',
+  opentable: 'OpenTable',
+  ticketmaster: 'Ticketmaster',
+  amadeus: 'Amadeus',
+}
+
+const PROVIDER_COLORS: Record<string, string> = {
+  viator: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  opentable: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  ticketmaster: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  amadeus: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+}
+
+export type BookingPanelMode = 'loading' | 'summary' | 'done'
+
+interface ActivityInfo {
+  id: string
+  title: string
+}
+
+interface BookingPanelProps {
+  isOpen: boolean
+  onClose: () => void
+  mode: BookingPanelMode
+  activities: ActivityInfo[]
+  matches: Map<string, BookingMatch>
+  receivedCount: number
+  total: number
+  onBookAll: () => void
+  onBookOne: (activityId: string) => void
+  failedToOpenIds: string[]
+}
+
+export function BookingPanel({
+  isOpen,
+  onClose,
+  mode,
+  activities,
+  matches,
+  receivedCount,
+  total,
+  onBookAll,
+  onBookOne,
+  failedToOpenIds,
+}: BookingPanelProps) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      const raf = requestAnimationFrame(() => setIsVisible(true))
+      return () => cancelAnimationFrame(raf)
+    } else {
+      setIsVisible(false)
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const matchedActivities = activities.filter((a) => matches.get(a.id)?.status === 'matched' || matches.get(a.id)?.status === 'opened')
+  const unmatchedActivities = activities.filter((a) => {
+    const m = matches.get(a.id)
+    return !m || m.status === 'unmatched'
+  })
+  const bookableCount = matchedActivities.filter((a) => matches.get(a.id)?.status === 'matched').length
+
+  const progress = total > 0 ? Math.round((receivedCount / total) * 100) : 0
+
+  return (
+    <div className="fixed inset-0 z-40 pointer-events-none">
+      <div
+        className={[
+          'absolute right-0 top-0 h-full w-96 bg-white dark:bg-[#0f1a28] border-l border-gray-200 dark:border-[#1e3a5f]/40 shadow-xl pointer-events-auto flex flex-col transition-transform duration-300',
+          isVisible ? 'translate-x-0' : 'translate-x-full',
+        ].join(' ')}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+          <div className="flex items-center gap-2">
+            <BookmarkSolid className="w-4 h-4 text-[#003594] dark:text-[#4a7ab5]" />
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-[#f5efe8]">Book My Trip</h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close booking panel"
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30"
+          >
+            <Xmark className="w-4 h-4 text-gray-500 dark:text-[#7a9cc0]" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+
+          {/* Loading state */}
+          {mode === 'loading' && (
+            <div className="px-4 py-4 space-y-4">
+              <div>
+                <p className="text-sm text-gray-600 dark:text-[#cdd9e5] mb-2">Matching your activities…</p>
+                <div className="h-1.5 bg-gray-100 dark:bg-[#1e3a5f]/30 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-[#003594] rounded-full transition-all duration-300"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <p className="text-[11px] text-gray-400 dark:text-[#4a7ab5] mt-1">{receivedCount} of {total} checked</p>
+              </div>
+
+              {/* Live rows as they arrive */}
+              <div className="space-y-1">
+                {activities.map((a) => {
+                  const m = matches.get(a.id)
+                  return (
+                    <div key={a.id} className="flex items-center gap-2 py-2 border-b border-gray-50 dark:border-[#1e3a5f]/20">
+                      {m ? (
+                        m.status === 'matched' ? (
+                          <span className="h-2 w-2 rounded-full bg-blue-500 shrink-0" />
+                        ) : (
+                          <span className="h-2 w-2 rounded-full bg-gray-300 dark:bg-[#2a4a6a] shrink-0" />
+                        )
+                      ) : (
+                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-[#1e3a5f]/40 animate-pulse shrink-0" />
+                      )}
+                      <span className="text-xs text-gray-700 dark:text-[#cdd9e5] truncate">{a.title || 'Untitled'}</span>
+                      {m?.provider && (
+                        <span className={`ml-auto text-[10px] px-1.5 py-0.5 rounded-full shrink-0 ${PROVIDER_COLORS[m.provider] ?? ''}`}>
+                          {PROVIDER_LABELS[m.provider] ?? m.provider}
+                        </span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Summary state */}
+          {(mode === 'summary' || mode === 'done') && (
+            <div className="px-4 py-4 space-y-4">
+              {/* Count summary */}
+              <p className="text-xs text-gray-500 dark:text-[#7a9cc0]">
+                <span className="font-semibold text-gray-800 dark:text-[#f5efe8]">{bookableCount}</span> of{' '}
+                <span className="font-semibold text-gray-800 dark:text-[#f5efe8]">{total}</span> activities can be booked
+              </p>
+
+              {/* Ready to Book */}
+              {matchedActivities.length > 0 && (
+                <div>
+                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-[#4a7ab5] mb-2">Ready to Book</h3>
+                  <div className="space-y-1">
+                    {matchedActivities.map((a) => {
+                      const m = matches.get(a.id)!
+                      const isOpened = m.status === 'opened'
+                      const isUncertain = m.confidence !== undefined && m.confidence >= 0.6 && m.confidence < 0.75
+                      return (
+                        <div key={a.id} className="flex items-start gap-2 py-2 border-b border-gray-50 dark:border-[#1e3a5f]/20">
+                          <div className="flex-1 min-w-0">
+                            <p className="text-xs font-medium text-gray-800 dark:text-[#f5efe8] truncate">{a.title || 'Untitled'}</p>
+                            <div className="flex items-center gap-1.5 mt-0.5">
+                              {m.provider && (
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${PROVIDER_COLORS[m.provider] ?? ''}`}>
+                                  {PROVIDER_LABELS[m.provider] ?? m.provider}
+                                </span>
+                              )}
+                              {m.matchedName && m.matchedName !== a.title && (
+                                <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5] truncate">→ {m.matchedName}</span>
+                              )}
+                            </div>
+                            {isUncertain && (
+                              <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
+                                Uncertain match — {m.matchedName}
+                              </p>
+                            )}
+                          </div>
+                          {isOpened ? (
+                            <span className="text-[10px] text-green-600 dark:text-green-400 shrink-0 mt-0.5">Opened</span>
+                          ) : (
+                            <button
+                              onClick={() => onBookOne(a.id)}
+                              className="text-[11px] font-medium text-[#003594] dark:text-[#4a7ab5] hover:underline shrink-0 mt-0.5"
+                            >
+                              Book
+                            </button>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Not Available */}
+              {unmatchedActivities.length > 0 && (
+                <div>
+                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-[#4a7ab5] mb-2">Not Available</h3>
+                  <div className="space-y-1">
+                    {unmatchedActivities.map((a) => (
+                      <div key={a.id} className="flex items-center gap-2 py-1.5">
+                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-[#2a4a6a] shrink-0" />
+                        <span className="text-xs text-gray-400 dark:text-[#4a7ab5] truncate">{a.title || 'Untitled'}</span>
+                        <span className="ml-auto text-[10px] text-gray-400 dark:text-[#4a7ab5] shrink-0">No booking found</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Popup blocker fallback */}
+              {failedToOpenIds.length > 0 && (
+                <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40 rounded-lg p-3">
+                  <p className="text-xs text-amber-700 dark:text-amber-400 mb-2">Couldn't open automatically — click each below to book manually:</p>
+                  <div className="space-y-1">
+                    {failedToOpenIds.map((id) => {
+                      const a = activities.find((x) => x.id === id)
+                      const m = matches.get(id)
+                      if (!a || !m?.affiliateUrl) return null
+                      return (
+                        <a
+                          key={id}
+                          href={m.affiliateUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block text-xs text-[#003594] dark:text-[#4a7ab5] hover:underline truncate"
+                        >
+                          {a.title || 'Untitled'}
+                        </a>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        {(mode === 'summary') && bookableCount > 0 && (
+          <div className="px-4 py-3 border-t border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+            <button
+              onClick={onBookAll}
+              className="w-full rounded-lg bg-[#003594] text-white text-sm font-medium py-2 hover:bg-[#002a7a] transition-colors"
+            >
+              Book All ({bookableCount})
+            </button>
+          </div>
+        )}
+
+        {mode === 'done' && (
+          <div className="px-4 py-3 border-t border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+            <p className="text-xs text-center text-green-600 dark:text-green-400 mb-2 font-medium">Booking links opened</p>
+            <button
+              onClick={onClose}
+              className="w-full rounded-lg border border-gray-200 dark:border-[#1e3a5f]/30 text-gray-600 dark:text-[#cdd9e5] text-sm py-2 hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/BookingPanel.tsx
+git commit -m "feat: add BookingPanel slide-in drawer with Loading/Summary/Done states"
+```
+
+---
+
+### Task 8: CalendarToolbar + EventBlock updates
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarToolbar.tsx`
+- Modify: `apps/web/components/calendar/EventBlock.tsx`
+
+- [ ] **Step 1: Update CalendarToolbar props interface**
+
+In `apps/web/components/calendar/CalendarToolbar.tsx`, add these fields to `CalendarToolbarProps` (after `onOpenHistory`):
+
+```ts
+  /** Called when user clicks "Book My Trip" */
+  onBookTrip?: () => void
+  /** When true, shows "View Bookings" button instead of / alongside "Book My Trip" */
+  hasBookingMatches?: boolean
+  /** When true, "Book My Trip" button is disabled (match run in progress) */
+  isBookingInProgress?: boolean
+  /** Called when user clicks "View Bookings" */
+  onViewBookings?: () => void
+```
+
+- [ ] **Step 2: Add "Book My Trip" and "View Bookings" buttons to CalendarToolbar**
+
+In `CalendarToolbar`, inside the right controls `div` (just before the Share button, around line 353 of the original file), add:
+
+```tsx
+          {/* Book My Trip */}
+          {!isSharedView && onBookTrip && canEdit && (
+            <button
+              onClick={isBookingInProgress ? undefined : onBookTrip}
+              disabled={isBookingInProgress}
+              className={[
+                'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors shrink-0',
+                isBookingInProgress
+                  ? 'bg-gray-100 dark:bg-[#1e3a5f]/20 text-gray-400 dark:text-[#4a7ab5] cursor-not-allowed'
+                  : 'border border-[#003594]/30 text-[#003594] dark:text-[#4a7ab5] hover:bg-[#003594]/5 dark:hover:bg-[#1e3a5f]/20',
+              ].join(' ')}
+            >
+              {isBookingInProgress ? 'Matching…' : 'Book My Trip'}
+            </button>
+          )}
+
+          {/* View Bookings (appears once matches exist) */}
+          {!isSharedView && hasBookingMatches && onViewBookings && (
+            <button
+              onClick={onViewBookings}
+              className="flex items-center gap-1.5 rounded-lg border border-green-300 dark:border-green-700/40 bg-green-50 dark:bg-green-900/10 px-3 py-1.5 text-xs font-medium text-green-700 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/20 transition-colors shrink-0"
+            >
+              View Bookings
+            </button>
+          )}
+```
+
+- [ ] **Step 3: Add `bookingStatus` prop to EventBlock**
+
+In `apps/web/components/calendar/EventBlock.tsx`, add to the `EventBlockProps` interface:
+
+```ts
+  bookingStatus?: 'matched' | 'opened' | null
+```
+
+Add to the destructured props in the `EventBlock` function signature:
+
+```ts
+  bookingStatus,
+```
+
+Then, inside the returned JSX (in the outermost `div` that wraps the activity block, immediately before the closing `</div>`), add the badge:
+
+```tsx
+        {/* Booking status badge */}
+        {bookingStatus === 'matched' && (
+          <span
+            title="Bookable"
+            className="absolute bottom-1 right-1 h-2 w-2 rounded-full bg-blue-500 ring-1 ring-white dark:ring-[#0a1520]"
+          />
+        )}
+        {bookingStatus === 'opened' && (
+          <span
+            title="Booking opened"
+            className="absolute bottom-1 right-1 flex items-center justify-center h-3.5 w-3.5 rounded-full bg-green-500 ring-1 ring-white dark:ring-[#0a1520]"
+          >
+            <svg width="7" height="7" viewBox="0 0 10 10" fill="none" aria-hidden>
+              <path d="M1.5 5L4 7.5L8.5 2.5" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </span>
+        )}
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/calendar/CalendarToolbar.tsx apps/web/components/calendar/EventBlock.tsx
+git commit -m "feat: add booking buttons to CalendarToolbar and booking status badge to EventBlock"
+```
+
+---
+
+### Task 9: CalendarDashboard wiring
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarDashboard.tsx`
+
+This is the final wiring task — connecting `useBookingMatches`, `BookingPanel`, and the updated toolbar/EventBlock props.
+
+- [ ] **Step 1: Add imports to CalendarDashboard**
+
+At the top of `apps/web/components/calendar/CalendarDashboard.tsx`, add:
+
+```ts
+import { useBookingMatches } from './hooks/useBookingMatches'
+import { BookingPanel, type BookingPanelMode } from './BookingPanel'
+```
+
+- [ ] **Step 2: Add booking state inside CalendarDashboard (after existing useState declarations)**
+
+```ts
+  const [isBookingPanelOpen, setIsBookingPanelOpen] = useState(false)
+  const [bookingPanelMode, setBookingPanelMode] = useState<BookingPanelMode>('loading')
+  const [bookingTotal, setBookingTotal] = useState(0)
+  const [bookingReceived, setBookingReceived] = useState(0)
+  const [bookingInProgress, setBookingInProgress] = useState(false)
+  const [failedToOpenIds, setFailedToOpenIds] = useState<string[]>([])
+  const bookingFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+```
+
+- [ ] **Step 3: Add useBookingMatches hook call (after existing hook declarations)**
+
+First add a static import at the top of `CalendarDashboard.tsx` with the other imports:
+
+```ts
+import { getSupabaseBrowser } from '@/lib/supabase-browser'
+```
+
+Then add after the `useInteractionTracking` hook call:
+
+```ts
+  const { data: session } = useQuery({
+    queryKey: ['session'],
+    queryFn: async () => {
+      const { data } = await getSupabaseBrowser().auth.getSession()
+      return data.session
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { matches: bookingMatches, hasBookingMatches, startRealtimeAndMatch, markOpened } = useBookingMatches({
+    tripId,
+    apiUrl: process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL ?? '',
+    authToken: session?.access_token ?? '',
+  })
+```
+
+- [ ] **Step 4: Add handleBookTrip and handleBookAll callbacks (after existing handleBulkDuplicate)**
+
+```ts
+  const handleBookTrip = useCallback(async () => {
+    if (bookingInProgress) return
+    setBookingInProgress(true)
+    setBookingPanelMode('loading')
+    setIsBookingPanelOpen(true)
+    setBookingReceived(0)
+    setFailedToOpenIds([])
+
+    try {
+      const activitiesToMatch = scheduledActivities.map((a) => ({
+        id: a.id,
+        title: a.title,
+        type: a.type,
+        latitude: a.latitude ?? null,
+        longitude: a.longitude ?? null,
+      }))
+      setBookingTotal(activitiesToMatch.length)
+
+      // Subscribe Realtime first, then fire POST — result arrives when all parallel calls complete.
+      // Use result.total as the authoritative count; Realtime events update the live rows.
+      const result = await startRealtimeAndMatch(activitiesToMatch)
+      setBookingTotal(result.total)
+
+      // Give Realtime events 2s to arrive after POST returns, then transition to summary.
+      // The 10s fallback in the hook handles the case where Realtime events are lost.
+      if (bookingFallbackTimerRef.current) clearTimeout(bookingFallbackTimerRef.current)
+      bookingFallbackTimerRef.current = setTimeout(() => {
+        setBookingReceived(result.total)
+        setBookingPanelMode('summary')
+        setBookingInProgress(false)
+      }, 2000)
+    } catch {
+      setBookingPanelMode('summary')
+      setBookingInProgress(false)
+    }
+  }, [bookingInProgress, scheduledActivities, startRealtimeAndMatch])
+
+  // Track live Realtime updates for progress bar — clamp to total to avoid overflow
+  useEffect(() => {
+    if (bookingPanelMode !== 'loading' || bookingTotal === 0) return
+    // bookingMatches includes prior-run data on mount; for a new run the map is being
+    // populated from scratch by Realtime events. Use Math.min to avoid showing >100%.
+    setBookingReceived(Math.min(bookingMatches.size, bookingTotal))
+  }, [bookingMatches.size, bookingTotal, bookingPanelMode])
+
+  const handleBookAll = useCallback(() => {
+    const toBook = scheduledActivities.filter((a) => bookingMatches.get(a.id)?.status === 'matched')
+    const failed: string[] = []
+
+    for (const a of toBook) {
+      const m = bookingMatches.get(a.id)
+      if (!m?.affiliateUrl) continue
+      const win = window.open(m.affiliateUrl, '_blank')
+      if (!win) failed.push(a.id)
+    }
+
+    setFailedToOpenIds(failed)
+    const successIds = toBook.map((a) => a.id).filter((id) => !failed.includes(id))
+    if (successIds.length > 0) markOpened(successIds)
+    setBookingPanelMode('done')
+  }, [scheduledActivities, bookingMatches, markOpened])
+
+  const handleBookOne = useCallback((activityId: string) => {
+    const m = bookingMatches.get(activityId)
+    if (!m?.affiliateUrl) return
+    const win = window.open(m.affiliateUrl, '_blank')
+    if (win) {
+      markOpened([activityId])
+    } else {
+      setFailedToOpenIds((prev) => [...prev, activityId])
+    }
+  }, [bookingMatches, markOpened])
+
+  // Cleanup fallback timer on unmount
+  useEffect(() => {
+    return () => {
+      if (bookingFallbackTimerRef.current) clearTimeout(bookingFallbackTimerRef.current)
+    }
+  }, [])
+```
+
+- [ ] **Step 5: Pass new props to CalendarToolbar**
+
+In the `CalendarToolbar` JSX in CalendarDashboard, add:
+
+```tsx
+          onBookTrip={handleBookTrip}
+          hasBookingMatches={hasBookingMatches}
+          isBookingInProgress={bookingInProgress}
+          onViewBookings={() => {
+            setBookingPanelMode('summary')
+            setIsBookingPanelOpen(true)
+          }}
+```
+
+- [ ] **Step 6: Thread bookingStatuses through WeekView → DayColumn and DayView → DayColumn**
+
+**In `apps/web/components/calendar/DayColumn.tsx`:**
+
+Add to `DayColumnProps` interface (after the `onVotePoll` prop):
+
+```ts
+  bookingStatuses?: Map<string, 'matched' | 'opened'>
+```
+
+Add `bookingStatuses,` to the destructured props in `DayColumn` function signature.
+
+In the EventBlock render (around line 238), add the `bookingStatus` prop:
+
+```tsx
+              bookingStatus={bookingStatuses?.get(activity.id) ?? null}
+```
+
+**In `apps/web/components/calendar/WeekView.tsx`:**
+
+Add to `WeekViewProps` interface (after `onVotePoll`):
+
+```ts
+  bookingStatuses?: Map<string, 'matched' | 'opened'>
+```
+
+Add `bookingStatuses,` to the destructured props in `WeekView` function signature.
+
+Pass it to `DayColumn` (inside the `DayColumn` JSX, after `onVotePoll`):
+
+```tsx
+                  bookingStatuses={bookingStatuses}
+```
+
+**In `apps/web/components/calendar/DayView.tsx`:**
+
+Add to `DayViewProps` interface (after `onVotePoll`):
+
+```ts
+  bookingStatuses?: Map<string, 'matched' | 'opened'>
+```
+
+Add `bookingStatuses,` to the destructured props in `DayView` function signature.
+
+Pass it to `DayColumn` (inside the `DayColumn` JSX, after `onVotePoll`):
+
+```tsx
+          bookingStatuses={bookingStatuses}
+```
+
+**In `apps/web/components/calendar/CalendarDashboard.tsx`:**
+
+Build the statuses map (add alongside the other `useMemo` calls):
+
+```ts
+  const bookingStatuses = useMemo(() => {
+    const m = new Map<string, 'matched' | 'opened'>()
+    for (const [id, match] of bookingMatches) {
+      if (match.status === 'matched' || match.status === 'opened') {
+        m.set(id, match.status)
+      }
+    }
+    return m
+  }, [bookingMatches])
+```
+
+Then pass `bookingStatuses={bookingStatuses}` to both `WeekView` and `DayView` in the JSX.
+
+- [ ] **Step 7: Add BookingPanel to CalendarDashboard return JSX**
+
+After the `HistoryDrawer` in the return JSX, add:
+
+```tsx
+    <BookingPanel
+      isOpen={isBookingPanelOpen}
+      onClose={() => setIsBookingPanelOpen(false)}
+      mode={bookingPanelMode}
+      activities={scheduledActivities.map((a) => ({ id: a.id, title: a.title }))}
+      matches={bookingMatches}
+      receivedCount={bookingReceived}
+      total={bookingTotal}
+      onBookAll={handleBookAll}
+      onBookOne={handleBookOne}
+      failedToOpenIds={failedToOpenIds}
+    />
+```
+
+- [ ] **Step 8: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Fix any type errors — most likely related to threading `bookingMatches` through WeekView/DayView/DayColumn.
+
+- [ ] **Step 9: Run all shared tests to confirm nothing broken**
+
+```bash
+cd packages/shared && npm test -- --run
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 10: Final commit**
+
+```bash
+git add apps/web/components/calendar/CalendarDashboard.tsx apps/web/components/calendar/WeekView.tsx apps/web/components/calendar/DayView.tsx apps/web/components/calendar/DayColumn.tsx
+git commit -m "feat: wire Book My Trip into CalendarDashboard — panel, hooks, toolbar, badges"
+```

--- a/docs/superpowers/plans/2026-03-27-local-events.md
+++ b/docs/superpowers/plans/2026-03-27-local-events.md
@@ -1,0 +1,1371 @@
+# Local Events Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface Ticketmaster local events (concerts, sports, theater, festivals) in the trip calendar as read-only day-row pills and a browseable "Events" sidebar tab.
+
+**Architecture:** A new `GET /events` Lambda fetches Ticketmaster events for the trip destination + date range, normalizes them, and caches in DynamoDB (24h). The frontend `useEvents` hook fetches via a Next.js proxy route. `CalendarDashboard` owns the events state and distributes it to `AllDayRow` (for calendar pills) and a new `EventsPanel` inside `SidebarTabs`.
+
+**Tech Stack:** SST v3 Lambda, DynamoDB (existing cache table), Ticketmaster Discovery API, Next.js 16 App Router, React Query v5, Tailwind CSS v4, iconoir-react
+
+---
+
+## File Map
+
+| File | Status | Responsibility |
+|------|--------|----------------|
+| `infra/secrets.ts` | Modify | Add `ticketmasterApiKey` secret |
+| `infra/api.ts` | Modify | Register `GET /events` Lambda route |
+| `services/lib/types.ts` | Modify | Add `LocalEvent` backend type |
+| `services/lib/cache.ts` | Modify | Add `getCachedEvents` / `setCachedEvents` |
+| `services/events.ts` | Create | Lambda handler for `GET /events` |
+| `apps/web/app/api/trip-events/route.ts` | Create | Next.js proxy → Lambda `/events` |
+| `apps/web/components/calendar/types.ts` | Modify | Add `LocalEvent` frontend type |
+| `apps/web/components/calendar/hooks/useEvents.ts` | Create | React Query hook for events |
+| `apps/web/components/calendar/EventCard.tsx` | Create | Single event list-item card |
+| `apps/web/components/calendar/EventsPanel.tsx` | Create | Events sidebar tab panel |
+| `apps/web/components/calendar/SidebarTabs.tsx` | Modify | Add "Events" tab, integrate into CalendarDashboard |
+| `apps/web/components/calendar/AllDayRow.tsx` | Modify | Add event pills sub-row |
+| `apps/web/components/calendar/CalendarToolbar.tsx` | Modify | Add events toggle button |
+| `apps/web/components/calendar/CalendarDashboard.tsx` | Modify | Wire useEvents, SidebarTabs, AllDayRow |
+
+---
+
+## Chunk 1: Backend + Proxy Route + Hook
+
+### Task 1: Add `LocalEvent` to backend types and cache functions
+
+**Files:**
+- Modify: `services/lib/types.ts`
+- Modify: `services/lib/cache.ts`
+
+- [ ] **Step 1: Add `LocalEvent` to `services/lib/types.ts`**
+
+Open `services/lib/types.ts`. It currently has `SuggestionCard`, `SuggestResponse`, `SearchResponse`, `InteractRequest`. Append:
+
+```ts
+export interface LocalEvent {
+  id: string
+  name: string
+  category: 'music' | 'sports' | 'arts' | 'family' | 'festival' | 'other'
+  date: string          // YYYY-MM-DD
+  startTime: string     // HH:mm (24h)
+  endTime?: string      // HH:mm, optional
+  venueName: string
+  venueAddress?: string
+  imageUrl?: string
+  ticketUrl: string
+  priceMin?: number
+  priceMax?: number
+  currency?: string
+}
+
+export interface EventsResponse {
+  events: LocalEvent[]
+}
+```
+
+- [ ] **Step 2: Add cache functions to `services/lib/cache.ts`**
+
+Open `services/lib/cache.ts`. The current import is:
+```ts
+import type { SuggestionCard } from './types'
+```
+
+Update it to:
+```ts
+import type { SuggestionCard, LocalEvent } from './types'
+```
+
+Then append at the bottom of the file (after all existing code):
+
+```ts
+interface EventsCacheEntry {
+  pk: string
+  sk: string
+  events: LocalEvent[]
+  expiresAt: number
+}
+
+export async function getCachedEvents(
+  destination: string,
+  startDate: string,
+  endDate: string,
+): Promise<LocalEvent[] | null> {
+  const result = await client.send(
+    new GetCommand({
+      TableName: Resource.RecommendationCache.name,
+      Key: { pk: `events:${destination}:${startDate}:${endDate}`, sk: 'events' },
+    }),
+  )
+  if (!result.Item) return null
+  const entry = result.Item as EventsCacheEntry
+  if (entry.expiresAt < Math.floor(Date.now() / 1000)) return null
+  return entry.events
+}
+
+export async function setCachedEvents(
+  destination: string,
+  startDate: string,
+  endDate: string,
+  events: LocalEvent[],
+  ttlSeconds = 86400,
+): Promise<void> {
+  await client.send(
+    new PutCommand({
+      TableName: Resource.RecommendationCache.name,
+      Item: {
+        pk: `events:${destination}:${startDate}:${endDate}`,
+        sk: 'events',
+        events,
+        expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+      },
+    }),
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors in `services/lib/cache.ts` or `services/lib/types.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/lib/types.ts services/lib/cache.ts
+git commit -m "feat(events): add LocalEvent type and DynamoDB cache functions"
+```
+
+---
+
+### Task 2: Add Ticketmaster secret + Lambda handler + infra route
+
+**Files:**
+- Modify: `infra/secrets.ts`
+- Modify: `infra/api.ts`
+- Create: `services/events.ts`
+
+- [ ] **Step 1: Add secret to `infra/secrets.ts`**
+
+Open `infra/secrets.ts`. Find the events section (line ~27, marked `// ─── Events ─────────────────────────────────────────────────`, which has `eventbriteApiKey` and `predicthqApiKey`). Add after the existing two exports in that section:
+
+```ts
+export const ticketmasterApiKey = new sst.Secret('TicketmasterApiKey')
+```
+
+- [ ] **Step 2: Register the route in `infra/api.ts`**
+
+Open `infra/api.ts`. The secrets import at line 3 currently ends with `foursquareApiKey`. Update it to also import `ticketmasterApiKey`:
+
+```ts
+import { supabaseSecretKey, supabaseUrl, serpApiKey, pexels, foursquareApiKey, ticketmasterApiKey } from './secrets'
+```
+
+Then add this route at the end of the file (before the closing brace if any, or after the last `api.route()` call):
+
+```ts
+api.route('GET /events', {
+  handler: 'services/events.handler',
+  link: [cacheTable, supabaseSecretKey, supabaseUrl, ticketmasterApiKey],
+})
+```
+
+- [ ] **Step 3: Create `services/events.ts`**
+
+```ts
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { Resource } from 'sst'
+import { validateAuth } from './lib/auth'
+import { getCachedEvents, setCachedEvents } from './lib/cache'
+import type { LocalEvent, EventsResponse } from './lib/types'
+
+const FESTIVAL_KEYWORDS = ['festival', 'fair', 'carnival', 'expo', 'parade']
+
+function mapCategory(classificationName: string, eventName: string): LocalEvent['category'] {
+  switch (classificationName) {
+    case 'Music': return 'music'
+    case 'Sports': return 'sports'
+    case 'Arts & Theatre': return 'arts'
+    case 'Family': return 'family'
+    case 'Miscellaneous': {
+      const lower = eventName.toLowerCase()
+      if (FESTIVAL_KEYWORDS.some(kw => lower.includes(kw))) return 'festival'
+      return 'other'
+    }
+    default: return 'other'
+  }
+}
+
+function normalizeEvent(raw: any): LocalEvent | null {
+  try {
+    const date = raw.dates?.start?.localDate as string | undefined
+    const startTime = raw.dates?.start?.localTime as string | undefined
+    if (!date || !startTime) {
+      console.warn('[events] skipping event missing date/time:', raw.id, raw.name)
+      return null
+    }
+
+    const classification = raw.classifications?.[0]
+    const classificationName: string = classification?.segment?.name ?? ''
+    const venueName: string = raw._embedded?.venues?.[0]?.name ?? 'Unknown venue'
+    const venueAddress: string | undefined = raw._embedded?.venues?.[0]?.address?.line1
+
+    // Prefer 16:9 image at ≥640px width, else first image
+    const images: any[] = raw.images ?? []
+    const image = images.find((img: any) => img.ratio === '16_9' && img.width >= 640) ?? images[0]
+
+    return {
+      id: raw.id as string,
+      name: raw.name as string,
+      category: mapCategory(classificationName, raw.name as string),
+      date,
+      startTime: startTime.slice(0, 5), // HH:mm
+      venueName,
+      venueAddress,
+      imageUrl: image?.url,
+      ticketUrl: raw.url as string,
+      priceMin: raw.priceRanges?.[0]?.min,
+      priceMax: raw.priceRanges?.[0]?.max,
+      currency: raw.priceRanges?.[0]?.currency,
+    }
+  } catch {
+    return null
+  }
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  try {
+    await validateAuth(event.headers.authorization)
+
+    const { destination, startDate, endDate } = event.queryStringParameters ?? {}
+    if (!destination || !startDate || !endDate) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'destination, startDate, and endDate are required' }),
+      }
+    }
+
+    const cached = await getCachedEvents(destination, startDate, endDate)
+    if (cached) {
+      console.log('[events] cache hit:', cached.length, 'events')
+      const response: EventsResponse = { events: cached }
+      return { statusCode: 200, body: JSON.stringify(response) }
+    }
+
+    const city = destination.split(',')[0].trim()
+    console.log('[events] cache miss, fetching Ticketmaster for:', city)
+
+    const params = new URLSearchParams({
+      city,
+      startDateTime: `${startDate}T00:00:00Z`,
+      endDateTime: `${endDate}T23:59:59Z`,
+      size: '200',
+      apikey: Resource.TicketmasterApiKey.value,
+    })
+
+    const res = await fetch(
+      `https://app.ticketmaster.com/discovery/v2/events.json?${params}`,
+    )
+
+    if (!res.ok) {
+      console.error('[events] Ticketmaster error:', res.status, await res.text().catch(() => ''))
+      return { statusCode: 500, body: JSON.stringify({ error: 'Failed to fetch events' }) }
+    }
+
+    const data = await res.json()
+    const rawEvents: any[] = data._embedded?.events ?? []
+
+    const events: LocalEvent[] = rawEvents
+      .map(normalizeEvent)
+      .filter((e): e is LocalEvent => e !== null)
+      .filter(e => e.date >= startDate && e.date <= endDate)
+
+    console.log('[events] normalized', events.length, 'events from', rawEvents.length, 'raw')
+
+    await setCachedEvents(destination, startDate, endDate, events)
+
+    const response: EventsResponse = { events }
+    return { statusCode: 200, body: JSON.stringify(response) }
+  } catch (err: any) {
+    if (err.message === 'Invalid token' || err.message?.includes('Authorization')) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('[events] error:', err)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) }
+  }
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no new errors in `services/events.ts`, `infra/secrets.ts`, `infra/api.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/secrets.ts infra/api.ts services/events.ts
+git commit -m "feat(events): add Ticketmaster Lambda handler and infra wiring"
+```
+
+---
+
+### Task 3: Next.js proxy route + `useEvents` hook
+
+**Files:**
+- Create: `apps/web/app/api/trip-events/route.ts`
+- Modify: `apps/web/components/calendar/types.ts`
+- Create: `apps/web/components/calendar/hooks/useEvents.ts`
+
+Note: `/api/events` is already taken (proxies to a different endpoint). Our new route is at `/api/trip-events`.
+
+- [ ] **Step 1: Create `apps/web/app/api/trip-events/route.ts`**
+
+```ts
+import { NextRequest } from 'next/server'
+import { getRequiredParams, proxyToBackend } from '@/lib/api-utils'
+
+export async function GET(req: NextRequest) {
+  const params = getRequiredParams(req, 'destination', 'startDate', 'endDate')
+  if (params instanceof Response) return params
+
+  return proxyToBackend('/events', req, { params })
+}
+```
+
+- [ ] **Step 2: Add `LocalEvent` to `apps/web/components/calendar/types.ts`**
+
+Open `apps/web/components/calendar/types.ts` and append:
+
+```ts
+export interface LocalEvent {
+  id: string
+  name: string
+  category: 'music' | 'sports' | 'arts' | 'family' | 'festival' | 'other'
+  date: string
+  startTime: string
+  endTime?: string
+  venueName: string
+  venueAddress?: string
+  imageUrl?: string
+  ticketUrl: string
+  priceMin?: number
+  priceMax?: number
+  currency?: string
+}
+```
+
+- [ ] **Step 3: Create `apps/web/components/calendar/hooks/useEvents.ts`**
+
+```ts
+'use client'
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { LocalEvent } from '../types'
+
+interface UseEventsParams {
+  destination: string
+  startDate: string   // YYYY-MM-DD
+  endDate: string     // YYYY-MM-DD
+}
+
+interface UseEventsReturn {
+  events: LocalEvent[]
+  eventsByDate: Record<string, LocalEvent[]>
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+async function fetchEvents(
+  destination: string,
+  startDate: string,
+  endDate: string,
+): Promise<LocalEvent[]> {
+  const params = new URLSearchParams({ destination, startDate, endDate })
+  const res = await fetch(`/api/trip-events?${params}`)
+  if (!res.ok) throw new Error(`Failed to fetch events: ${res.status}`)
+  const data = await res.json()
+  return (data.events ?? []) as LocalEvent[]
+}
+
+export function useEvents({
+  destination,
+  startDate,
+  endDate,
+}: UseEventsParams): UseEventsReturn {
+  const {
+    data: events = [],
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['trip-events', destination, startDate, endDate],
+    queryFn: () => fetchEvents(destination, startDate, endDate),
+    enabled: !!destination && !!startDate && !!endDate,
+    staleTime: 1000 * 60 * 60,        // 1h
+    gcTime: 2 * 60 * 60 * 1000,       // 2h
+  })
+
+  const eventsByDate = useMemo(() => {
+    const map: Record<string, LocalEvent[]> = {}
+    for (const event of events) {
+      if (!map[event.date]) map[event.date] = []
+      map[event.date].push(event)
+    }
+    return map
+  }, [events])
+
+  return {
+    events,
+    eventsByDate,
+    isLoading,
+    error: error as Error | null,
+    refetch,
+  }
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no new errors
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run lint 2>&1 | head -40
+```
+
+Expected: no new warnings or errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/api/trip-events/route.ts apps/web/components/calendar/types.ts apps/web/components/calendar/hooks/useEvents.ts
+git commit -m "feat(events): add proxy route and useEvents hook"
+```
+
+---
+
+## Chunk 2: Frontend UI Components
+
+### Task 4: `EventCard` component
+
+**Files:**
+- Create: `apps/web/components/calendar/EventCard.tsx`
+
+- [ ] **Step 1: Create `apps/web/components/calendar/EventCard.tsx`**
+
+```tsx
+'use client'
+
+import type { LocalEvent } from './types'
+
+const CATEGORY_COLORS: Record<LocalEvent['category'], string> = {
+  music:    '#7C3AED',
+  sports:   '#059669',
+  arts:     '#D97706',
+  family:   '#DB2777',
+  festival: '#CA8A04',
+  other:    '#6B7280',
+}
+
+const CATEGORY_LABELS: Record<LocalEvent['category'], string> = {
+  music:    'Music',
+  sports:   'Sports',
+  arts:     'Arts',
+  family:   'Family',
+  festival: 'Festival',
+  other:    'Other',
+}
+
+function formatEventDate(date: string, startTime: string): string {
+  const [year, month, day] = date.split('-').map(Number)
+  const [hour, minute] = startTime.split(':').map(Number)
+  const d = new Date(Date.UTC(year, month - 1, day, hour, minute))
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })
+  const monthLabel = d.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
+  const dayLabel = d.toLocaleDateString('en-US', { day: 'numeric', timeZone: 'UTC' })
+  const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' })
+  return `${weekday} ${monthLabel} ${dayLabel} · ${time}`
+}
+
+interface EventCardProps {
+  event: LocalEvent
+}
+
+export function EventCard({ event }: EventCardProps) {
+  const color = CATEGORY_COLORS[event.category]
+
+  return (
+    <div className="flex items-start gap-3 px-3 py-2.5 hover:bg-[var(--cal-border-light)] transition-colors rounded-lg">
+      {/* Thumbnail */}
+      <div
+        className="shrink-0 w-12 h-12 rounded-lg overflow-hidden"
+        style={{ backgroundColor: `${color}22` }}
+      >
+        {event.imageUrl ? (
+          <img src={event.imageUrl} alt="" className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <div className="w-4 h-4 rounded-full" style={{ backgroundColor: color }} />
+          </div>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] font-medium text-[var(--cal-text)] line-clamp-2 leading-snug">
+          {event.name}
+        </p>
+        <p className="text-[11px] text-[var(--cal-text-secondary)] mt-0.5">
+          {formatEventDate(event.date, event.startTime)}
+        </p>
+        <p className="text-[11px] text-[var(--cal-text-tertiary)] truncate">
+          {event.venueName}
+        </p>
+        <span
+          className="inline-block mt-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
+          style={{ backgroundColor: `${color}22`, color }}
+        >
+          {CATEGORY_LABELS[event.category]}
+        </span>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/EventCard.tsx
+git commit -m "feat(events): add EventCard component"
+```
+
+---
+
+### Task 5: `EventsPanel` component
+
+**Files:**
+- Create: `apps/web/components/calendar/EventsPanel.tsx`
+
+- [ ] **Step 1: Create `apps/web/components/calendar/EventsPanel.tsx`**
+
+```tsx
+'use client'
+
+import { useState, useMemo } from 'react'
+import { EventCard } from './EventCard'
+import type { LocalEvent } from './types'
+
+const FILTER_CHIPS = ['All', 'Music', 'Sports', 'Arts', 'Family', 'Festivals'] as const
+type FilterChip = (typeof FILTER_CHIPS)[number]
+
+const CHIP_TO_CATEGORY: Record<FilterChip, LocalEvent['category'] | null> = {
+  All:       null,
+  Music:     'music',
+  Sports:    'sports',
+  Arts:      'arts',
+  Family:    'family',
+  Festivals: 'festival',
+}
+
+function formatDateRange(startDate: string, endDate: string): string {
+  if (!startDate || !endDate) return ''
+  const fmt = (d: string) => {
+    const [y, m, day] = d.split('-').map(Number)
+    return new Date(Date.UTC(y, m - 1, day)).toLocaleDateString('en-US', {
+      month: 'short', day: 'numeric', timeZone: 'UTC',
+    })
+  }
+  return `${fmt(startDate)}–${fmt(endDate)}`
+}
+
+interface EventsPanelProps {
+  events: LocalEvent[]
+  isLoading: boolean
+  destination: string
+  startDate: string
+  endDate: string
+  onRetry?: () => void
+}
+
+export function EventsPanel({
+  events,
+  isLoading,
+  destination,
+  startDate,
+  endDate,
+  onRetry,
+}: EventsPanelProps) {
+  const [activeChip, setActiveChip] = useState<FilterChip>('All')
+
+  const filtered = useMemo(() => {
+    const category = CHIP_TO_CATEGORY[activeChip]
+    const sorted = [...events].sort((a, b) =>
+      a.date === b.date
+        ? a.startTime.localeCompare(b.startTime)
+        : a.date.localeCompare(b.date),
+    )
+    return category ? sorted.filter(e => e.category === category) : sorted
+  }, [events, activeChip])
+
+  const dateRange = formatDateRange(startDate, endDate)
+  const isDisabled = !startDate || !endDate
+  const cityName = destination.split(',')[0]
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="p-3.5 pb-3 border-b border-[var(--cal-border-light)]">
+        <h2 className="text-sm font-semibold text-[var(--cal-text)]">
+          Events{cityName ? ` in ${cityName}` : ''}
+        </h2>
+        {dateRange && (
+          <p className="text-[11px] text-[var(--cal-text-secondary)] mt-0.5">{dateRange}</p>
+        )}
+      </div>
+
+      {/* Filter chips */}
+      <div className="flex gap-1.5 px-3.5 pt-2.5 pb-0 overflow-x-auto">
+        {FILTER_CHIPS.map(chip => (
+          <button
+            key={chip}
+            onClick={() => setActiveChip(chip)}
+            className={[
+              'text-[11px] font-medium px-2.5 py-1 rounded-full whitespace-nowrap transition-all border',
+              activeChip === chip
+                ? 'bg-[#003594] border-[#003594] text-white'
+                : 'border-[var(--cal-border)] text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)]',
+            ].join(' ')}
+          >
+            {chip}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="h-0 grow overflow-y-auto py-2 scrollbar-thin">
+        {isDisabled ? (
+          <div className="flex items-center justify-center h-full px-4 text-center">
+            <p className="text-sm text-[var(--cal-text-secondary)]">
+              Add trip dates to see local events
+            </p>
+          </div>
+        ) : isLoading ? (
+          <div className="px-3 space-y-3 pt-2">
+            {[0, 1].map(i => (
+              <div key={i} className="flex gap-3">
+                <div className="w-12 h-12 rounded-lg bg-[var(--cal-border)] animate-pulse shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 bg-[var(--cal-border)] animate-pulse rounded w-3/4" />
+                  <div className="h-2.5 bg-[var(--cal-border)] animate-pulse rounded w-1/2" />
+                  <div className="h-2.5 bg-[var(--cal-border)] animate-pulse rounded w-2/3" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : onRetry && events.length === 0 ? (
+          // Error state takes precedence over empty state when onRetry is provided
+          <div className="flex flex-col items-center justify-center h-full gap-2 px-4 text-center">
+            <p className="text-sm text-[var(--cal-text-secondary)]">Couldn't load events</p>
+            <button
+              onClick={onRetry}
+              className="text-xs text-[var(--cal-accent)] hover:underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full px-4 text-center">
+            <p className="text-sm text-[var(--cal-text-secondary)]">
+              No events found in {cityName} during your trip
+            </p>
+          </div>
+        ) : (
+          filtered.map(event => <EventCard key={event.id} event={event} />)
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/EventsPanel.tsx
+git commit -m "feat(events): add EventsPanel component"
+```
+
+---
+
+### Task 6: Update `SidebarTabs` with Events tab
+
+**Files:**
+- Modify: `apps/web/components/calendar/SidebarTabs.tsx`
+
+- [ ] **Step 1: Replace `apps/web/components/calendar/SidebarTabs.tsx`**
+
+The current file has `'for-you' | 'map'` tab type. Replace the entire file:
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+
+type Tab = 'for-you' | 'events' | 'map'
+
+interface SidebarTabsProps {
+  forYouContent: React.ReactNode
+  eventsContent: React.ReactNode
+  mapContent: React.ReactNode
+}
+
+export default function SidebarTabs({
+  forYouContent,
+  eventsContent,
+  mapContent,
+}: SidebarTabsProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('for-you')
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'for-you', label: 'For You' },
+    { id: 'events', label: 'Events' },
+    { id: 'map', label: 'Map' },
+  ]
+
+  const content =
+    activeTab === 'for-you' ? forYouContent
+    : activeTab === 'events' ? eventsContent
+    : mapContent
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex border-b border-[var(--cal-border)] shrink-0">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={[
+              'px-4 py-2 text-sm font-medium transition-colors',
+              activeTab === tab.id
+                ? 'text-[#003594] border-b-2 border-[#003594]'
+                : 'text-[var(--cal-text-secondary)] hover:text-[var(--cal-text)]',
+            ].join(' ')}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {content}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/SidebarTabs.tsx
+git commit -m "feat(events): update SidebarTabs with Events tab"
+```
+
+---
+
+### Task 7: Update `AllDayRow` with event pills
+
+**Files:**
+- Modify: `apps/web/components/calendar/AllDayRow.tsx`
+
+The `days` prop currently carries `{ dayIndex }`. In Task 9, `TRIP_DAYS` will be extended to include `isoDate`. Here we update `AllDayRow` to accept `isoDate` on each day and use it for the event lookup. The `eventsByDate` lookup is wired in this task — no placeholder needed.
+
+- [ ] **Step 1: Replace `apps/web/components/calendar/AllDayRow.tsx`**
+
+```tsx
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import type { LocalEvent } from './types'
+
+export interface FlightBanner {
+  id: string
+  label: string
+  dayIndex: number
+  direction: 'arrival' | 'departure'
+}
+
+export interface HotelBanner {
+  id: string
+  label: string
+  startDayIndex: number
+  endDayIndex: number
+}
+
+const CATEGORY_COLORS: Record<LocalEvent['category'], string> = {
+  music:    '#7C3AED',
+  sports:   '#059669',
+  arts:     '#D97706',
+  family:   '#DB2777',
+  festival: '#CA8A04',
+  other:    '#6B7280',
+}
+
+function formatPillTime(startTime: string): string {
+  const [h, m] = startTime.split(':').map(Number)
+  const d = new Date(0)
+  d.setUTCHours(h, m)
+  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' })
+}
+
+interface EventPillProps {
+  event: LocalEvent
+}
+
+function EventPill({ event }: EventPillProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const color = CATEGORY_COLORS[event.category]
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="w-full text-left text-[10px] px-1 py-0.5 rounded truncate leading-tight"
+        style={{
+          backgroundColor: `${color}26`,
+          borderLeft: `2px solid ${color}`,
+          color: 'var(--cal-text)',
+        }}
+        title={event.name}
+      >
+        {event.name}
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-[var(--cal-surface-elevated)] border border-[var(--cal-border)] rounded-lg shadow-lg p-3 text-left">
+          <p className="text-[13px] font-semibold text-[var(--cal-text)] leading-snug mb-1">
+            {event.name}
+          </p>
+          <p className="text-[11px] text-[var(--cal-text-secondary)]">
+            {formatPillTime(event.startTime)}
+            {event.endTime ? ` – ${formatPillTime(event.endTime)}` : ''}
+          </p>
+          <p className="text-[11px] text-[var(--cal-text-tertiary)] mt-0.5 truncate">
+            {event.venueName}
+          </p>
+          <a
+            href={event.ticketUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block mt-2 text-[11px] font-medium text-[#003594] hover:underline"
+          >
+            Get tickets →
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface OverflowPillProps {
+  events: LocalEvent[]
+}
+
+function OverflowPill({ events }: OverflowPillProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="w-full text-left text-[10px] px-1 py-0.5 rounded truncate leading-tight text-[var(--cal-text-secondary)] bg-[var(--cal-border-light)] hover:bg-[var(--cal-border)] transition-colors"
+      >
+        +{events.length} more
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-[var(--cal-surface-elevated)] border border-[var(--cal-border)] rounded-lg shadow-lg py-1">
+          {events.map(event => {
+            const color = CATEGORY_COLORS[event.category]
+            return (
+              <div key={event.id} className="flex items-start gap-2 px-3 py-2 hover:bg-[var(--cal-border-light)] transition-colors">
+                <div
+                  className="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0"
+                  style={{ backgroundColor: color }}
+                />
+                <div className="min-w-0">
+                  <p className="text-[12px] font-medium text-[var(--cal-text)] truncate">{event.name}</p>
+                  <p className="text-[10px] text-[var(--cal-text-secondary)]">
+                    {formatPillTime(event.startTime)} · {event.venueName}
+                  </p>
+                  <a
+                    href={event.ticketUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[10px] text-[#003594] hover:underline"
+                  >
+                    Tickets →
+                  </a>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const MAX_PILLS = 3
+
+interface AllDayRowProps {
+  days: { dayIndex: number; isoDate?: string }[]
+  flights?: FlightBanner[]
+  hotels?: HotelBanner[]
+  eventsByDate?: Record<string, LocalEvent[]>
+  showEvents?: boolean
+}
+
+export function AllDayRow({
+  days,
+  flights = [],
+  hotels = [],
+  eventsByDate = {},
+  showEvents = true,
+}: AllDayRowProps) {
+  const hasEvents = showEvents && Object.values(eventsByDate).some(arr => arr.length > 0)
+  if (flights.length === 0 && hotels.length === 0 && !hasEvents) return null
+
+  return (
+    <div className="flex border-b border-[var(--cal-border)] min-h-[2rem]">
+      {/* Gutter spacer matching TimeGutter width */}
+      <div className="flex-shrink-0 w-14" />
+
+      {/* Per-day cells */}
+      <div className="flex flex-1 min-w-0">
+        {days.map(({ dayIndex, isoDate }) => {
+          const dayFlights = flights.filter(f => f.dayIndex === dayIndex)
+          const dayHotels = hotels.filter(
+            h => h.startDayIndex <= dayIndex && dayIndex <= h.endDayIndex,
+          )
+          const dayEvents: LocalEvent[] = showEvents && isoDate
+            ? (eventsByDate[isoDate] ?? [])
+            : []
+
+          return (
+            <div
+              key={dayIndex}
+              className="flex-1 min-w-0 border-l border-[var(--cal-border-light)] px-1 py-0.5 flex flex-col gap-0.5"
+            >
+              {/* Hotel banners */}
+              {dayHotels.map(hotel => {
+                const isStart = hotel.startDayIndex === dayIndex
+                const isEnd = hotel.endDayIndex === dayIndex
+                return (
+                  <div
+                    key={hotel.id}
+                    title={hotel.label}
+                    className={[
+                      'text-[10px] font-medium px-1 py-0.5 bg-amber-100 text-amber-800 overflow-hidden',
+                      isStart && isEnd ? 'rounded'
+                        : isStart ? 'rounded-l pr-0'
+                        : isEnd ? 'rounded-r pl-0'
+                        : 'rounded-none px-0',
+                    ].join(' ')}
+                  >
+                    {isStart ? (
+                      <span className="truncate block">{hotel.label}</span>
+                    ) : (
+                      <span className="text-amber-400">— — —</span>
+                    )}
+                  </div>
+                )
+              })}
+
+              {/* Flight banners */}
+              {dayFlights.map(flight => (
+                <div
+                  key={flight.id}
+                  title={flight.label}
+                  className={[
+                    'text-[10px] font-medium px-1 py-0.5 rounded truncate',
+                    flight.direction === 'arrival'
+                      ? 'bg-[var(--cal-accent-bg)] text-[var(--cal-accent)]'
+                      : 'bg-red-50 text-red-700',
+                  ].join(' ')}
+                >
+                  {flight.direction === 'arrival' ? '→ ' : '← '}
+                  {flight.label}
+                </div>
+              ))}
+
+              {/* Event pills */}
+              {dayEvents.slice(0, MAX_PILLS).map(event => (
+                <EventPill key={event.id} event={event} />
+              ))}
+              {dayEvents.length > MAX_PILLS && (
+                <OverflowPill events={dayEvents.slice(MAX_PILLS)} />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/calendar/AllDayRow.tsx
+git commit -m "feat(events): add AllDayRow event pills with popover"
+```
+
+---
+
+### Task 8: Update `CalendarToolbar` with Events toggle
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarToolbar.tsx`
+
+`Calendar` is confirmed to exist in the installed version of iconoir-react.
+
+- [ ] **Step 1: Add `showEvents` and `onToggleEvents` to `CalendarToolbarProps`**
+
+Open `CalendarToolbar.tsx`. Find `interface CalendarToolbarProps` (search for it with grep if unsure of line):
+
+```bash
+grep -n "interface CalendarToolbarProps" /c/Users/justi/dev/travyl2/travyl-frontend/apps/web/components/calendar/CalendarToolbar.tsx
+```
+
+Add two props to the interface:
+
+```ts
+showEvents: boolean
+onToggleEvents: () => void
+```
+
+- [ ] **Step 2: Destructure the new props and add `Calendar` to iconoir-react import**
+
+Find the iconoir-react import line. It currently imports `Plus, ShareAndroid, Clock`. Add `Calendar`:
+
+```ts
+import { Plus, ShareAndroid, Clock, Calendar } from 'iconoir-react'
+```
+
+Destructure the new props in the component function signature alongside existing ones.
+
+- [ ] **Step 3: Add the Events toggle button to the toolbar JSX**
+
+Find where the existing toolbar icon buttons are rendered (near the theme toggle or the share button). Add the Events toggle button:
+
+```tsx
+{/* Events layer toggle */}
+<button
+  onClick={onToggleEvents}
+  title={showEvents ? 'Hide events' : 'Show events'}
+  className={[
+    'flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors',
+    showEvents
+      ? 'bg-[#003594]/10 text-[#003594]'
+      : 'text-[var(--cal-text-secondary)] hover:text-[var(--cal-text)] hover:bg-[var(--cal-border-light)]',
+  ].join(' ')}
+>
+  <Calendar width={14} height={14} strokeWidth={1.5} />
+  <span>Events</span>
+</button>
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -40
+```
+
+Expected: no errors. If `Calendar` is not found, check the import — confirmed available in this codebase's iconoir-react version.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/components/calendar/CalendarToolbar.tsx
+git commit -m "feat(events): add Events toggle to CalendarToolbar"
+```
+
+---
+
+### Task 9: Wire everything in `CalendarDashboard`
+
+**Files:**
+- Modify: `apps/web/components/calendar/CalendarDashboard.tsx`
+
+This task has the most moving parts. Make each change carefully and typecheck after the full set of edits.
+
+- [ ] **Step 1: Add imports**
+
+Open `CalendarDashboard.tsx`. Add to the existing component imports (near `ForYouPanel`):
+
+```ts
+import SidebarTabs from './SidebarTabs'
+import { EventsPanel } from './EventsPanel'
+import { useEvents } from './hooks/useEvents'
+```
+
+- [ ] **Step 2: Add `isoDate` to `TRIP_DAYS`**
+
+Find the `TRIP_DAYS` `useMemo` (around line 235). It currently returns `{ dayIndex, label }`. Add `isoDate`:
+
+```ts
+const TRIP_DAYS = useMemo(() => Array.from({ length: tripTotalDays }, (_, i) => {
+  const date = new Date(parsedStartMs + i * 24 * 60 * 60 * 1000)
+  return {
+    dayIndex: i,
+    label: date.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }),
+    isoDate: date.toISOString().slice(0, 10),
+  }
+}), [tripTotalDays, parsedStartMs])
+```
+
+- [ ] **Step 3: Add `useEvents` call and `showEvents` state**
+
+All hooks in `CalendarDashboard` are called before any early returns (before lines 398–400). Add these two lines in the hooks section (after the existing `useInteractionTracking` call is a good place):
+
+```ts
+const { events, eventsByDate, isLoading: eventsLoading, error: eventsError, refetch: refetchEvents } = useEvents({
+  destination: trip?.destination ?? '',
+  startDate: trip?.start_date ?? '',
+  endDate: trip?.end_date ?? '',
+})
+const [showEvents, setShowEvents] = useState(true)
+```
+
+`useEvents` is safe to call with empty strings — the query will not fire (`enabled: false`) until all three params are non-empty. This is how all guarded hooks work in this file.
+
+- [ ] **Step 4: Pass `showEvents` + `onToggleEvents` to `CalendarToolbar`**
+
+Find the `<CalendarToolbar` JSX (around line 529). Add:
+
+```tsx
+showEvents={showEvents}
+onToggleEvents={() => setShowEvents(v => !v)}
+```
+
+- [ ] **Step 5: Pass `eventsByDate` + `showEvents` to `AllDayRow`**
+
+Find `<AllDayRow days={visibleDays} />` (around line 567). Replace with:
+
+```tsx
+<AllDayRow
+  days={visibleDays}
+  eventsByDate={eventsByDate}
+  showEvents={showEvents}
+/>
+```
+
+- [ ] **Step 6: Replace `<ForYouPanel>` with `<SidebarTabs>`**
+
+Find this block (around lines 662–669):
+
+```tsx
+{/* Right column: For You panel */}
+<ForYouPanel
+  destination={trip?.destination ?? ''}
+  tripId={trip?.id ?? ''}
+  scheduledActivityIds={droppedSuggestionIds}
+  width={forYouWidth}
+/>
+```
+
+Replace with:
+
+```tsx
+{/* Right column: tabbed sidebar */}
+<div
+  style={{ width: forYouWidth }}
+  className="relative flex flex-col shrink-0 self-stretch overflow-hidden"
+>
+  <SidebarTabs
+    forYouContent={
+      <ForYouPanel
+        destination={trip?.destination ?? ''}
+        tripId={trip?.id ?? ''}
+        scheduledActivityIds={droppedSuggestionIds}
+        width={forYouWidth}
+      />
+    }
+    eventsContent={
+      <EventsPanel
+        events={events}
+        isLoading={eventsLoading}
+        destination={trip?.destination ?? ''}
+        startDate={trip?.start_date ?? ''}
+        endDate={trip?.end_date ?? ''}
+        onRetry={eventsError ? refetchEvents : undefined}
+      />
+    }
+    mapContent={null}
+  />
+</div>
+```
+
+Note: The wrapper `<div>` uses only layout classes (`flex-col shrink-0 self-stretch overflow-hidden`) and does NOT add `border-l` or `bg-[var(--cal-surface-elevated)]`. These styles are already provided by `ForYouPanel`'s `<aside>` on the "For You" tab, and by `EventsPanel`'s own layout. Adding them to the wrapper would cause a double-border visible on the "For You" tab.
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1 | head -60
+```
+
+Expected: zero errors. Fix any type mismatches before the next step.
+
+- [ ] **Step 8: Lint**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run lint 2>&1 | head -40
+```
+
+Expected: zero new errors.
+
+- [ ] **Step 9: Start dev server and manually verify**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run web
+```
+
+Open a trip at `http://localhost:3000/trip/[id]`. Verify:
+1. Right sidebar shows "For You", "Events", "Map" tabs
+2. Clicking "Events" shows skeleton → EventsPanel with content
+3. Clicking "For You" returns to ForYouPanel with no double border
+4. "Events" toggle in CalendarToolbar hides/shows AllDayRow pills
+5. Event pills in AllDayRow are clickable — popover shows name, time, venue, ticket link
+6. "+N more" chip opens a list with time + venue + ticket link per event
+7. EventsPanel filter chips work (Music, Sports, etc.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/web/components/calendar/CalendarDashboard.tsx
+git commit -m "feat(events): wire CalendarDashboard — events state, SidebarTabs, AllDayRow pills, toolbar toggle"
+```
+
+---
+
+### Task 10: Final checks + secret setup
+
+- [ ] **Step 1: Full typecheck**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run typecheck 2>&1
+```
+
+Expected: zero errors across all workspaces.
+
+- [ ] **Step 2: Full lint**
+
+```bash
+cd /c/Users/justi/dev/travyl2/travyl-frontend && npm run lint 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Set the Ticketmaster API key secret (required before production deploy)**
+
+Get a free API key from the Ticketmaster developer portal (developer.ticketmaster.com → Apps). Then:
+
+```bash
+AWS_PROFILE=525610233002_AdministratorAccess npx sst secret set TicketmasterApiKey <your-api-key> --stage production
+```
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git status
+# If any uncommitted changes:
+git add <files>
+git commit -m "chore(events): final cleanup"
+```

--- a/packages/shared/src/utils/gapCompute.test.ts
+++ b/packages/shared/src/utils/gapCompute.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { computeGaps } from './gapCompute'
+
+describe('computeGaps', () => {
+  it('returns full day as one gap when no activities', () => {
+    const result = computeGaps([])
+    expect(result).toEqual([{ startHour: 8, endHour: 22, durationHours: 14 }])
+  })
+
+  it('returns gap before first activity', () => {
+    const result = computeGaps([{ startHour: 11, duration: 1 }])
+    expect(result).toContainEqual({ startHour: 8, endHour: 11, durationHours: 3 })
+  })
+
+  it('returns gap after last activity', () => {
+    const result = computeGaps([{ startHour: 9, duration: 2 }])
+    expect(result).toContainEqual({ startHour: 11, endHour: 22, durationHours: 11 })
+  })
+
+  it('returns gap between two activities', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 1 },
+      { startHour: 14, duration: 2 },
+    ])
+    expect(result).toContainEqual({ startHour: 10, endHour: 14, durationHours: 4 })
+  })
+
+  it('filters out gaps shorter than 1 hour', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 1 },
+      { startHour: 9.5, duration: 2 },  // overlapping; leaves 0.5h before
+    ])
+    // The gap before (8–9) is 1h, included
+    // The gap after (11.5–22) is included
+    // No sub-1h gaps
+    result.forEach((g) => expect(g.durationHours).toBeGreaterThanOrEqual(1))
+  })
+
+  it('handles activities that overlap (cursor advances past overlapping end)', () => {
+    const result = computeGaps([
+      { startHour: 9, duration: 3 },  // 9–12
+      { startHour: 10, duration: 1 }, // 10–11 (inside first)
+    ])
+    // Cursor ends at 12, not 11
+    const afterGap = result.find((g) => g.startHour === 12)
+    expect(afterGap).toBeDefined()
+    expect(afterGap?.endHour).toBe(22)
+  })
+
+  it('respects custom dayStart and dayEnd', () => {
+    const result = computeGaps([], 6, 24)
+    expect(result).toEqual([{ startHour: 6, endHour: 24, durationHours: 18 }])
+  })
+
+  it('returns empty when day is fully scheduled', () => {
+    const result = computeGaps([{ startHour: 8, duration: 14 }]) // 8–22
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/shared/src/utils/gapCompute.ts
+++ b/packages/shared/src/utils/gapCompute.ts
@@ -1,0 +1,29 @@
+export interface Gap {
+  startHour: number
+  endHour: number
+  durationHours: number
+}
+
+export function computeGaps(
+  activities: Array<{ startHour: number; duration: number }>,
+  dayStart = 8,
+  dayEnd = 22,
+): Gap[] {
+  const sorted = [...activities].sort((a, b) => a.startHour - b.startHour)
+  const gaps: Gap[] = []
+  let cursor = dayStart
+
+  for (const act of sorted) {
+    if (act.startHour > cursor) {
+      const duration = act.startHour - cursor
+      gaps.push({ startHour: cursor, endHour: act.startHour, durationHours: duration })
+    }
+    cursor = Math.max(cursor, act.startHour + act.duration)
+  }
+
+  if (cursor < dayEnd) {
+    gaps.push({ startHour: cursor, endHour: dayEnd, durationHours: dayEnd - cursor })
+  }
+
+  return gaps.filter((g) => g.durationHours >= 1)
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -136,3 +136,7 @@ export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: numb
     Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
   return 6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
 }
+
+// Gap computation utility
+export { computeGaps } from './gapCompute'
+export type { Gap } from './gapCompute'

--- a/services/lib/cache.ts
+++ b/services/lib/cache.ts
@@ -1,7 +1,7 @@
 import { Resource } from 'sst'
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb'
-import type { SuggestionCard } from './types'
+import type { SuggestionCard, LocalEvent } from './types'
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
@@ -42,6 +42,50 @@ export async function setCachedSuggestions(
         pk: `${destination}:${category}`,
         sk: 'suggestions',
         suggestions,
+        expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+      },
+    }),
+  )
+}
+
+interface EventsCacheEntry {
+  pk: string
+  sk: string
+  events: LocalEvent[]
+  expiresAt: number
+}
+
+export async function getCachedEvents(
+  destination: string,
+  startDate: string,
+  endDate: string,
+): Promise<LocalEvent[] | null> {
+  const result = await client.send(
+    new GetCommand({
+      TableName: Resource.RecommendationCache.name,
+      Key: { pk: `events:${destination}:${startDate}:${endDate}`, sk: 'events' },
+    }),
+  )
+  if (!result.Item) return null
+  const entry = result.Item as EventsCacheEntry
+  if (entry.expiresAt < Math.floor(Date.now() / 1000)) return null
+  return entry.events
+}
+
+export async function setCachedEvents(
+  destination: string,
+  startDate: string,
+  endDate: string,
+  events: LocalEvent[],
+  ttlSeconds = 86400,
+): Promise<void> {
+  await client.send(
+    new PutCommand({
+      TableName: Resource.RecommendationCache.name,
+      Item: {
+        pk: `events:${destination}:${startDate}:${endDate}`,
+        sk: 'events',
+        events,
         expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
       },
     }),

--- a/services/lib/types.ts
+++ b/services/lib/types.ts
@@ -17,3 +17,23 @@ export interface InteractRequest {
   tripId: string
   category?: string
 }
+
+export interface LocalEvent {
+  id: string
+  name: string
+  category: 'music' | 'sports' | 'arts' | 'family' | 'festival' | 'other'
+  date: string          // YYYY-MM-DD
+  startTime: string     // HH:mm (24h)
+  endTime?: string      // HH:mm, optional
+  venueName: string
+  venueAddress?: string
+  imageUrl?: string
+  ticketUrl: string
+  priceMin?: number
+  priceMax?: number
+  currency?: string
+}
+
+export interface EventsResponse {
+  events: LocalEvent[]
+}

--- a/supabase/migrations/20260327000001_add_booking_matches.sql
+++ b/supabase/migrations/20260327000001_add_booking_matches.sql
@@ -1,0 +1,51 @@
+create table booking_matches (
+  id uuid primary key default gen_random_uuid(),
+  trip_id uuid not null references trips(id) on delete cascade,
+  activity_id text not null,
+  provider text,
+  matched_name text,
+  booking_url text,
+  affiliate_url text,
+  confidence float,
+  status text not null default 'unmatched',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint booking_matches_trip_activity_key unique (trip_id, activity_id)
+);
+
+create or replace function set_booking_matches_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger booking_matches_updated_at
+  before update on booking_matches
+  for each row execute function set_booking_matches_updated_at();
+
+alter table booking_matches enable row level security;
+
+create policy "booking_matches_select"
+  on booking_matches for select
+  using (
+    trip_id in (
+      select id from trips where user_id = auth.uid()
+      union
+      select trip_id from trip_collaborators where user_id = auth.uid() and invite_status = 'accepted'
+    )
+  );
+
+create policy "booking_matches_update_opened"
+  on booking_matches for update
+  using (
+    trip_id in (
+      select id from trips where user_id = auth.uid()
+      union
+      select trip_id from trip_collaborators where user_id = auth.uid() and invite_status = 'accepted'
+    )
+  )
+  with check (status = 'opened');
+
+alter publication supabase_realtime add table booking_matches;


### PR DESCRIPTION
## Summary

- Fix `fetchPublicTrips` and `fetchUserPublicTrips` to query `visibility = 'public'` — both were querying `is_public` which doesn't exist in the DB, causing Explore to always be empty
- Fix `forkTrip`: remove `is_shared: false` insert (column doesn't exist, was causing fork mutations to fail), set forked trip `visibility = 'private'` explicitly
- Fix fork count increment: replace raw `.update()` (blocked by RLS) with `increment_fork_count` security-definer RPC
- Add `PublicSharingSection` toggle to ShareModal — owner-only, makes a trip appear on `/explore`
- Post-fork UX: navigate directly to the new trip on success, show inline error on failure
- Unauthenticated users see "Sign in to fork" button with redirect back to current page
- Remove phantom `is_public` / `is_shared` fields from `Trip` type and mock data (columns don't exist in DB)

## Test plan

- [ ] Trip owner opens Share modal → sees "Public on Explore" toggle
- [ ] Toggle on → trip appears in `/explore`
- [ ] Toggle off → trip disappears from `/explore`
- [ ] Logged-in non-owner visits `/explore` → fork button present, clicking forks and navigates to new trip
- [ ] Logged-out user visits `/explore` → sees "Sign in to fork", clicking redirects to `/login?redirect=/explore`
- [ ] Trip owner does not see fork button on their own public trips