### PR TITLE
fix: centralize Supabase key + resolve duplicate computeGaps export

### DIFF
--- a/apps/web/app/api/stats/route.ts
+++ b/apps/web/app/api/stats/route.ts
@@ -1,12 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
-
-function getSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
+import { getSupabase } from '@/lib/api-utils'
 
 export async function GET() {
   try {

--- a/apps/web/app/api/stats/route.ts
+++ b/apps/web/app/api/stats/route.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js'
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 

--- a/apps/web/app/api/trips/create/route.ts
+++ b/apps/web/app/api/trips/create/route.ts
@@ -5,7 +5,7 @@ import { checkOrigin, rateLimit } from '@/lib/api-utils'
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 

--- a/apps/web/app/api/trips/create/route.ts
+++ b/apps/web/app/api/trips/create/route.ts
@@ -1,13 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
-import { checkOrigin, rateLimit } from '@/lib/api-utils'
-
-function getSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
+import { getSupabase, checkOrigin, rateLimit } from '@/lib/api-utils'
 
 const CITY_AIRPORTS: Record<string, string> = {
   'Paris': 'CDG', 'London': 'LHR', 'Tokyo': 'NRT', 'Rome': 'FCO',

--- a/apps/web/app/api/trips/delete/route.ts
+++ b/apps/web/app/api/trips/delete/route.ts
@@ -5,7 +5,7 @@ import { checkOrigin, rateLimit } from '@/lib/api-utils'
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
       // Logged-in user — verify they own the trip
       const { data: { user }, error: authErr } = await createClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
         { global: { headers: { Authorization: authHeader } } }
       ).auth.getUser()
 

--- a/apps/web/app/api/trips/delete/route.ts
+++ b/apps/web/app/api/trips/delete/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { checkOrigin, rateLimit } from '@/lib/api-utils'
-
-function getSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
+import { getSupabase, supabaseUrl, supabaseKey, checkOrigin, rateLimit } from '@/lib/api-utils'
 
 export async function POST(req: NextRequest) {
   try {
@@ -26,8 +19,7 @@ export async function POST(req: NextRequest) {
     if (authHeader) {
       // Logged-in user — verify they own the trip
       const { data: { user }, error: authErr } = await createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+        supabaseUrl, supabaseKey,
         { global: { headers: { Authorization: authHeader } } }
       ).auth.getUser()
 

--- a/apps/web/app/api/trips/enrich/route.ts
+++ b/apps/web/app/api/trips/enrich/route.ts
@@ -7,7 +7,7 @@ const BACKEND_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL || ''
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 

--- a/apps/web/app/api/trips/enrich/route.ts
+++ b/apps/web/app/api/trips/enrich/route.ts
@@ -1,15 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
-import { rateLimit } from '@/lib/api-utils'
+import { getSupabase, rateLimit } from '@/lib/api-utils'
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL || ''
-
-function getSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
 
 const COUNTRY_CUISINE: Record<string, string> = {
   France: 'French', Spain: 'Spanish', Italy: 'Italian', Japan: 'Japanese',

--- a/apps/web/app/api/trips/route.ts
+++ b/apps/web/app/api/trips/route.ts
@@ -5,7 +5,7 @@ import { createClient } from '@supabase/supabase-js'
 function getAnonSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 

--- a/apps/web/app/api/trips/route.ts
+++ b/apps/web/app/api/trips/route.ts
@@ -1,19 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
-import { createClient } from '@supabase/supabase-js'
-
-function getAnonSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
+import { getSupabase, supabaseUrl, supabaseKey } from '@/lib/api-utils'
 
 export async function GET(req: NextRequest) {
   // Try to get user session from cookies
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    supabaseUrl,
+    supabaseKey,
     {
       cookies: {
         getAll() {
@@ -46,7 +39,7 @@ export async function GET(req: NextRequest) {
   if (tripIds.length === 0) return NextResponse.json([])
 
   // Anon key can read public trips via RLS policy
-  const { data, error } = await getAnonSupabase()
+  const { data, error } = await getSupabase()
     .from('trips')
     .select('*')
     .in('id', tripIds)

--- a/apps/web/app/api/trips/update/route.ts
+++ b/apps/web/app/api/trips/update/route.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
-
-function getSupabase() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  )
-}
+import { getSupabase } from '@/lib/api-utils'
 
 const CITY_AIRPORTS: Record<string, string> = {
   'Paris': 'CDG', 'London': 'LHR', 'Tokyo': 'NRT', 'Rome': 'FCO',

--- a/apps/web/app/api/trips/update/route.ts
+++ b/apps/web/app/api/trips/update/route.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js'
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   )
 }
 

--- a/apps/web/lib/api-utils.ts
+++ b/apps/web/lib/api-utils.ts
@@ -1,5 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
 import { createServerClient } from '@supabase/ssr'
+
+// ─── Shared Supabase client for API routes ──────────────────
+
+export const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+export const supabaseKey = (
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+)!
+
+export function getSupabase() {
+  return createClient(supabaseUrl, supabaseKey)
+}
 
 // ─── Parameter extraction + validation ───────────────────────
 
@@ -117,9 +130,8 @@ export async function proxyToBackend(
   if (!auth) {
     try {
       const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        (process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)!,
+        supabaseUrl,
+        supabaseKey,
         {
           cookies: {
             getAll() { return req.cookies.getAll() },

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -126,8 +126,8 @@ export type { RescoperOperation } from './rescoper'
 export { mergeSearchResults, deduplicateResults } from './entitySearch'
 export type { SpotlightResult } from './entitySearch'
 
-// Gap computation
-export { computeGaps } from './gaps'
+// Gap computation (calendar time gaps)
+export { computeGaps as computeTimeGaps } from './gaps'
 export type { TimeGap } from './gaps'
 
 /** Returns distance in km between two lat/lng points (Haversine formula) */
@@ -144,6 +144,6 @@ export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: numb
 // Booking matcher utilities
 export { routeProvider, nameSimScore, proximityScore, calculateConfidence } from './bookingMatcher'
 
-// Gap computation utility
+// Gap computation utility (day planner)
 export { computeGaps } from './gapCompute'
 export type { Gap } from './gapCompute'


### PR DESCRIPTION
## Summary
- **Centralize Supabase client**: Single `getSupabase()` + `supabaseKey` in `@/lib/api-utils` replaces 6 duplicate functions. Resolves `supabaseKey is required` 500 errors on Amplify where only `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` is set.
- **Fix duplicate `computeGaps` export**: Merge conflict brought in two gap files both exporting `computeGaps`. Renamed `gaps.ts` version to `computeTimeGaps`.

## Test plan
- [x] TypeScript compiles clean
- [x] `/api/stats` returns real data locally
- [x] Trip generation works end-to-end