### PR TITLE
refactor: deduplicate hotels/[id] and restaurants/[id] API routes

### DIFF
--- a/apps/web/app/api/restaurants/[id]/route.ts
+++ b/apps/web/app/api/restaurants/[id]/route.ts
@@ -1,10 +1,4 @@
-import { NextRequest } from 'next/server'
-import { proxyToBackend } from '@/lib/api-utils'
+import { GET } from '@/app/api/hotels/[id]/route'
 
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params
-  return proxyToBackend(`/api/places/${encodeURIComponent(id)}`, req)
-}
+// Re-export the hotels handler to avoid duplication
+export { GET }


### PR DESCRIPTION
## Summary

`/api/hotels/[id]` and `/api/restaurants/[id]` were identical — both proxied to the same Lambda endpoint (`proxyToBackend(/api/places/${id})`).

## Changes
- Restaurants route now re-exports the hotels handler instead of duplicating code
- Kept both URL paths working (existing frontend references unchanged)
- Verified foursquare/tripadvisor are NOT duplicates (different param handling)

## Verification
- `npm run typecheck` passes
- All 236 existing tests pass