### PR TITLE
fix(TRA-301): handle missing trip in settings page instead of infinite loading

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/settings/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/settings/page.tsx
@@ -786,6 +786,17 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
     );
   }
 
+  if (!trip) {
+    return (
+      <div className="max-w-2xl mx-auto py-16 text-center">
+        <p className="text-gray-500 mb-4">Trip not found or you don't have access.</p>
+        <button onClick={() => router.push('/trips')} className="text-sm text-blue-600 hover:underline">
+          Back to trips
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-2xl mx-auto pb-24 divide-y divide-gray-200">
       {/* Theme & Colors */}

--- a/apps/web/app/api/destinations/[name]/route.ts
+++ b/apps/web/app/api/destinations/[name]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import type { DestinationDetail } from '@travyl/shared'
-import { jsonResponse } from '../../lib/response'
+import { jsonResponse } from '@/lib/api-utils'
 
 // ─── Hardcoded destination metadata ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Settings page showed Loading spinner forever when the trip could not be loaded (anonymous user, RLS block, deleted trip, etc).

## Changes
- Added fallback state when trip is null after loading completes
- Shows not found message with back link
- Anonymous/non-owner users already see the page correctly with disabled controls

## Verification
- tsc --noEmit passes