### PR TITLE
fix: wire up Book Flight button to navigate to flights tab

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -933,7 +933,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
           </div>
         <div ref={contentRef}>
           {isFirstDay && arrivalFlight && (
-            <FlightSection flight={arrivalFlight} collapsed={allCollapsedOverride ?? undefined} />
+            <FlightSection flight={arrivalFlight} collapsed={allCollapsedOverride ?? undefined} onBookFlight={() => { window.location.href = `/trip/${id}/flights` }} />
           )}
           {/* Flight placeholder on first day — links to Flights tab */}
           {isFirstDay && !arrivalFlight && tripFlight && (
@@ -1097,7 +1097,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
                   </div>
                 </section>
               )}
-              {returnFlight && <FlightSection flight={returnFlight} collapsed={allCollapsedOverride ?? undefined} />}
+              {returnFlight && <FlightSection flight={returnFlight} collapsed={allCollapsedOverride ?? undefined} onBookFlight={() => { window.location.href = `/trip/${id}/flights` }} />}
               {!returnFlight && tripFlight && (
                 <section className="mb-3.5">
                   <a href={`/trip/${id}/flights`} className="block rounded-lg p-3 shadow-sm border border-blue-200/60 bg-gradient-to-r from-blue-50 to-indigo-50 hover:shadow-md transition-shadow group">

--- a/apps/web/app/api/destinations/[name]/route.ts
+++ b/apps/web/app/api/destinations/[name]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import type { DestinationDetail } from '@travyl/shared'
-import { jsonResponse } from '../../lib/response'
+import { jsonResponse } from '@/lib/api-utils'
 
 // ─── Hardcoded destination metadata ──────────────────────────────────────────
 

--- a/apps/web/components/itinerary/FlightSection.tsx
+++ b/apps/web/components/itinerary/FlightSection.tsx
@@ -8,9 +8,10 @@ import type { MockFlightDetail } from '@travyl/shared';
 interface FlightSectionProps {
   flight: MockFlightDetail;
   collapsed?: boolean;
+  onBookFlight?: () => void;
 }
 
-export function FlightSection({ flight, collapsed }: FlightSectionProps) {
+export function FlightSection({ flight, collapsed, onBookFlight }: FlightSectionProps) {
   const [expanded, setExpanded] = useState(false);
   const toggle = () => setExpanded((prev) => !prev);
 
@@ -173,6 +174,7 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
                     : 'text-white hover:bg-trip-base-light'
                 }`}
                 style={!flight.isBooked ? { backgroundColor: 'var(--trip-base)' } : undefined}
+                onClick={!flight.isBooked ? onBookFlight : undefined}
               >
                 {flight.isBooked ? (
                   <>


### PR DESCRIPTION
## Summary

The Book Flight button on the itinerary flight cards had no onClick handler.

## Changes
- Added onBookFlight prop to FlightSection component
- Button navigates to /trip/{id}/flights for non-booked flights
- Booked flights still show the green checkmark (no action)
- Both arrival and return flight cards are wired up

## Verification
- tsc --noEmit passes