### PR TITLE
fix(TRA-306): wire up Apple/Facebook/Microsoft OAuth buttons on mobile

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -85,6 +85,15 @@ export default function LoginScreen() {
     if (error) Alert.alert('Sign in failed', error.message);
   };
 
+  const handleSocialSignIn = async (provider: 'apple' | 'facebook' | 'azure') => {
+    const redirectTo = Linking.createURL('login-callback');
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo },
+    });
+    if (error) Alert.alert('Sign in failed', error.message);
+  };
+
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.surface }}>
       <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
@@ -118,11 +127,11 @@ export default function LoginScreen() {
           {/* Social login */}
           <View style={{ flexDirection: 'row', gap: 8, marginBottom: 16 }}>
             <View style={{ flex: 1 }}><SocialButton label="Google" iconName="google" iconColor="#EA4335" onPress={handleGoogleSignIn} /></View>
-            <View style={{ flex: 1 }}><SocialButton label="Apple" iconName="apple" iconColor="#000" onPress={() => {}} /></View>
+            <View style={{ flex: 1 }}><SocialButton label="Apple" iconName="apple" iconColor="#000" onPress={() => handleSocialSignIn('apple')} /></View>
           </View>
           <View style={{ flexDirection: 'row', gap: 8, marginBottom: 20 }}>
-            <View style={{ flex: 1 }}><SocialButton label="Facebook" iconName="facebook" iconColor="#1877F2" onPress={() => {}} /></View>
-            <View style={{ flex: 1 }}><SocialButton label="Microsoft" iconName="windows" iconColor="#00a4ef" onPress={() => {}} /></View>
+            <View style={{ flex: 1 }}><SocialButton label="Facebook" iconName="facebook" iconColor="#1877F2" onPress={() => handleSocialSignIn('facebook')} /></View>
+            <View style={{ flex: 1 }}><SocialButton label="Microsoft" iconName="windows" iconColor="#00a4ef" onPress={() => handleSocialSignIn('azure')} /></View>
           </View>
 
           {/* Divider */}

--- a/apps/web/app/api/destinations/[name]/route.ts
+++ b/apps/web/app/api/destinations/[name]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 import type { DestinationDetail } from '@travyl/shared'
-import { jsonResponse } from '../../lib/response'
+import { jsonResponse } from '@/lib/api-utils'
 
 // ─── Hardcoded destination metadata ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Apple, Facebook, and Microsoft social login buttons on mobile had empty onPress handlers. Google was the only one wired up.

## Changes
- Added handleSocialSignIn helper that calls supabase.auth.signInWithOAuth
- Uses Linking.createURL('login-callback') for deep link redirect (same as Google)
- Shows Alert if OAuth fails
- All four providers now use consistent flow

## Note
Requires the corresponding OAuth providers to be enabled in the Supabase dashboard (Authentication > Providers). The code is correct but Apple/Facebook/Microsoft won't work until configured there.

## Verification
- tsc --noEmit passes (pre-existing mobile errors unrelated)