### PR TITLE
fix(TRA-302): auto-generate packing suggestions for new trips

### DIFF
--- a/apps/web/app/api/trips/enrich/route.ts
+++ b/apps/web/app/api/trips/enrich/route.ts
@@ -313,6 +313,41 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Auto-generate packing suggestions if none exist yet
+  try {
+    const { count: existingSuggestions } = await supabase
+      .from('packing_suggestions')
+      .select('id', { count: 'exact', head: true })
+      .eq('trip_id', tripId)
+
+    if ((existingSuggestions ?? 0) === 0) {
+      const { generatePackingSuggestions } = await import('@travyl/shared')
+      const userId = trip.user_id ?? ''
+      const suggestions = generatePackingSuggestions(
+        {
+          destination: trip.destination ?? '',
+          country: country,
+          startDate: trip.start_date ?? undefined,
+          endDate: trip.end_date ?? undefined,
+          durationDays,
+          weather: weatherData ? {
+            current: weatherData.current ? { temp_f: weatherData.current.temp_f, conditions: weatherData.current.conditions } : undefined,
+            forecast: weatherData.forecast?.map((d: any) => ({ high: d.high, low: d.low, conditions: d.conditions })),
+          } : undefined,
+          travelers: trip.trip_context?.travelers ?? undefined,
+        },
+        userId,
+      )
+
+      if (suggestions.length > 0) {
+        const rows = suggestions.map((s) => ({ ...s, trip_id: tripId }))
+        await supabase.from('packing_suggestions').insert(rows)
+      }
+    }
+  } catch {
+    // Non-critical — don't fail enrichment if packing generation fails
+  }
+
   // Update trip
   const { error: updateErr } = await supabase
     .from('trips').update({ trip_context: merged }).eq('id', tripId)

--- a/packages/shared/src/hooks/usePackingSuggestions.ts
+++ b/packages/shared/src/hooks/usePackingSuggestions.ts
@@ -2,73 +2,36 @@ import { useEffect, useMemo, useCallback, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../services/supabase'
 import { fetchPackingSuggestions, updateSuggestionStatus } from '../services/packingService'
+import { generatePackingSuggestions } from '../services/packingSuggestions'
 import { useTrip } from './useTrip'
 import type { PackingSuggestion, DbPackingItem } from '../types'
 
 // Generate sensible default packing suggestions based on trip data
+// Uses the smart catalog-based generator from packingSuggestions.ts
 function generateLocalSuggestions(trip: any): PackingSuggestion[] {
-  const dest = trip?.destination ?? ''
-  const duration = trip?.start_date && trip?.end_date
+  if (!trip) return []
+
+  const duration = trip.start_date && trip.end_date
     ? Math.max(1, Math.ceil((new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000))
     : 5
-  const weather = trip?.trip_context?.weather?.forecast?.[0]
-  const isWarm = weather ? weather.high > 20 : true
-  const isCold = weather ? weather.low < 10 : false
 
-  const items: { name: string; category: string }[] = [
-    // Essentials
-    { name: 'Passport', category: 'documents' },
-    { name: 'Travel insurance docs', category: 'documents' },
-    { name: 'Phone charger', category: 'electronics' },
-    { name: 'Power adapter', category: 'electronics' },
-    { name: 'Headphones', category: 'electronics' },
-    { name: 'Wallet & cards', category: 'documents' },
-    // Toiletries
-    { name: 'Toothbrush & toothpaste', category: 'toiletries' },
-    { name: 'Deodorant', category: 'toiletries' },
-    { name: 'Sunscreen', category: 'toiletries' },
-    { name: 'Shampoo (travel size)', category: 'toiletries' },
-    { name: 'Medications', category: 'health' },
-    // Clothing — adjust for weather
-    { name: `T-shirts (${Math.min(duration, 7)})`, category: 'clothing' },
-    { name: `Underwear (${Math.min(duration + 1, 8)})`, category: 'clothing' },
-    { name: `Socks (${Math.min(duration, 7)} pairs)`, category: 'clothing' },
-    { name: 'Comfortable walking shoes', category: 'clothing' },
-    { name: 'Sleepwear', category: 'clothing' },
-  ]
-
-  if (isWarm) {
-    items.push({ name: 'Shorts (2-3)', category: 'clothing' })
-    items.push({ name: 'Sunglasses', category: 'accessories' })
-    items.push({ name: 'Hat / cap', category: 'accessories' })
-    items.push({ name: 'Sandals / flip-flops', category: 'clothing' })
-    items.push({ name: 'Swimsuit', category: 'clothing' })
-  }
-  if (isCold) {
-    items.push({ name: 'Warm jacket', category: 'clothing' })
-    items.push({ name: 'Scarf', category: 'accessories' })
-    items.push({ name: 'Gloves', category: 'accessories' })
-    items.push({ name: 'Thermal layers', category: 'clothing' })
-  }
-  if (!isWarm && !isCold) {
-    items.push({ name: 'Light jacket', category: 'clothing' })
-    items.push({ name: 'Jeans / pants (2)', category: 'clothing' })
-  }
-
-  // Extras
-  items.push({ name: 'Reusable water bottle', category: 'accessories' })
-  items.push({ name: 'Day bag / backpack', category: 'accessories' })
-  items.push({ name: 'Travel pillow', category: 'comfort' })
-
-  return items.map((item, i) => ({
+  const weather = trip.trip_context?.weather
+  return generatePackingSuggestions(
+    {
+      destination: trip.destination ?? '',
+      country: undefined,
+      startDate: trip.start_date ?? undefined,
+      endDate: trip.end_date ?? undefined,
+      durationDays: duration,
+      weather: weather ? {
+        current: weather.current ? { temp_f: weather.current.temp_f, conditions: weather.current.conditions } : undefined,
+        forecast: weather.forecast?.map((d: any) => ({ high: d.high, low: d.low, conditions: d.conditions })),
+      } : undefined,
+    },
+    trip.user_id ?? '',
+  ).map((s, i) => ({
+    ...s,
     id: `local-${i}`,
-    trip_id: trip?.id ?? '',
-    user_id: null as any,
-    name: item.name,
-    category: item.category,
-    reason: null as any,
-    source: 'auto' as const,
-    status: 'pending' as const,
     created_at: new Date().toISOString(),
   }))
 }

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -56,3 +56,7 @@ export {
   updateSuggestionStatus,
   dismissAllSuggestions,
 } from './packingService';
+
+export {
+  generatePackingSuggestions,
+} from './packingSuggestions';

--- a/packages/shared/src/services/packingSuggestions.ts
+++ b/packages/shared/src/services/packingSuggestions.ts
@@ -1,0 +1,251 @@
+/**
+ * Generates packing suggestions based on trip context.
+ *
+ * Uses the PACKING_CATALOG as the source of truth and selects items
+ * based on weather, duration, destination, and trip metadata.
+ *
+ * Returns items with a `reason` explaining why they're suggested.
+ */
+
+import type { CatalogItem, PackingSuggestion } from '../types'
+import { PACKING_CATALOG } from '../config/packingCatalog'
+
+interface TripContext {
+  destination: string
+  country?: string
+  startDate?: string
+  endDate?: string
+  durationDays: number
+  weather?: {
+    current?: { temp_f?: number; conditions?: string }
+    forecast?: Array<{ high?: number; low?: number; conditions?: string }>
+  } | null
+  travelers?: { adults?: number; children?: number }
+  tripTheme?: string // e.g. "beach", "hiking", "business", "city", "adventure"
+  cuisine?: string[]
+  hotels?: Array<{ name?: string; stars?: number }>
+}
+
+type WeatherTag = 'hot' | 'cold' | 'mild' | 'rainy' | 'snowy' | 'beach' | 'winter' | 'summer'
+
+function inferWeatherTags(ctx: TripContext): Set<WeatherTag> {
+  const tags = new Set<WeatherTag>()
+  const forecast = ctx.weather?.forecast
+  const current = ctx.weather?.current
+
+  // Use forecast if available, otherwise current
+  const temps = forecast
+    ? forecast.map((d) => d.high ?? d.low ?? 70)
+    : current
+      ? [current.temp_f ?? 70]
+      : []
+
+  const avgTemp = temps.length > 0 ? temps.reduce((a, b) => a + b, 0) / temps.length : 70
+
+  if (avgTemp >= 85) tags.add('hot')
+  if (avgTemp >= 75) tags.add('summer')
+  if (avgTemp <= 40) tags.add('cold')
+  if (avgTemp <= 32) tags.add('snowy')
+  if (avgTemp <= 55) tags.add('winter')
+  if (avgTemp > 55 && avgTemp < 75) tags.add('mild')
+
+  // Check conditions
+  const conditions = [
+    ...(forecast?.map((d) => d.conditions ?? '') ?? []),
+    current?.conditions ?? '',
+  ].join(' ').toLowerCase()
+
+  if (conditions.includes('rain') || conditions.includes('drizzle') || conditions.includes('shower')) {
+    tags.add('rainy')
+  }
+  if (conditions.includes('snow') || conditions.includes('blizzard')) {
+    tags.add('snowy')
+  }
+
+  // Destination-based tags
+  const dest = ctx.destination.toLowerCase()
+  const theme = ctx.tripTheme?.toLowerCase() ?? ''
+  if (dest.includes('beach') || theme.includes('beach') || theme.includes('resort')) {
+    tags.add('beach')
+  }
+
+  return tags
+}
+
+function inferTripType(ctx: TripContext): Set<string> {
+  const types = new Set<string>()
+  const dest = ctx.destination.toLowerCase()
+  const theme = ctx.tripTheme?.toLowerCase() ?? ''
+
+  if (dest.includes('beach') || theme.includes('beach') || theme.includes('resort') || theme.includes('tropical')) {
+    types.add('beach')
+  }
+  if (dest.includes('hike') || dest.includes('mountain') || dest.includes('trek') || theme.includes('hiking') || theme.includes('adventure') || theme.includes('outdoor')) {
+    types.add('outdoor')
+  }
+  if (theme.includes('business') || theme.includes('work') || (ctx.hotels?.some((h) => (h.stars ?? 0) >= 4))) {
+    types.add('business')
+  }
+  if (dest.includes('city') || theme.includes('city') || theme.includes('urban') || theme.includes('cultural')) {
+    types.add('city')
+  }
+
+  return types
+}
+
+/**
+ * Determines if a catalog item should be suggested for this trip.
+ * Returns a reason string or null if not suggested.
+ */
+function shouldSuggest(item: CatalogItem, weatherTags: Set<WeatherTag>, tripTypes: Set<string>, durationDays: number): string | null {
+  const tags = new Set(item.tags.map((t) => t.toLowerCase()))
+  const name = item.name.toLowerCase()
+  const category = item.category.toLowerCase()
+
+  // ── Always suggest these ──
+  if (category === 'essentials') return 'Essential for any trip'
+  if (category === 'documents' && ['passport', 'credit cards', 'cash', 'copies of documents', 'emergency contacts'].some((d) => name.includes(d))) {
+    return 'Important travel documents'
+  }
+
+  // ── Toiletries: always suggest basics ──
+  if (category === 'toiletries') {
+    const basics = ['toothbrush', 'toothpaste', 'deodorant', 'medications', 'pain reliever', 'band-aids']
+    if (basics.some((b) => name.includes(b))) return 'Toiletry essentials'
+  }
+
+  // ── Weather-based clothing ──
+  if (category === 'clothing' || category === 'accessories') {
+    // Hot/summer
+    if (weatherTags.has('hot') || weatherTags.has('summer')) {
+      if (tags.has('warm') || tags.has('thermal') || tags.has('fleece') || tags.has('cold') || tags.has('winter')) return null
+      if (tags.has('swim') || tags.has('beach')) return `Hot weather in ${weatherTags.has('hot') ? 'your destination' : 'summer'}`
+      if (tags.has('shorts') || tags.has('summer')) return 'Light clothing for warm weather'
+    }
+
+    // Cold/winter
+    if (weatherTags.has('cold') || weatherTags.has('winter') || weatherTags.has('snowy')) {
+      if (tags.has('shorts') || tags.has('swim') || tags.has('bathing') || tags.has('beach')) return null
+      if (tags.has('warm') || tags.has('thermal') || tags.has('cold') || tags.has('winter') || tags.has('fleece') || tags.has('hat') || tags.has('scarf') || tags.has('gloves')) {
+        return 'Warm layers for cold weather'
+      }
+      if (tags.has('jacket') || tags.has('coat') || tags.has('outerwear')) return 'Warm outerwear needed'
+    }
+
+    // Rainy
+    if (weatherTags.has('rainy')) {
+      if (tags.has('rain') || tags.has('waterproof') || tags.has('umbrella')) {
+        return 'Rain expected at your destination'
+      }
+    }
+
+    // Beach
+    if (weatherTags.has('beach') || tripTypes.has('beach')) {
+      if (tags.has('swim') || tags.has('beach') || tags.has('sandals') || tags.has('sun') || tags.has('sunscreen')) {
+        return 'Beach trip essentials'
+      }
+    }
+
+    // Outdoor/hiking
+    if (tripTypes.has('outdoor')) {
+      if (tags.has('hiking') || tags.has('trail') || tags.has('outdoor') || tags.has('trekking')) {
+        return 'Great for outdoor activities'
+      }
+    }
+  }
+
+  // ── Electronics ──
+  if (category === 'electronics') {
+    const always = ['phone charger', 'power adapter', 'portable battery', 'headphones']
+    if (always.some((a) => name.includes(a))) return 'Essential electronics'
+    // Camera for longer trips or outdoor trips
+    if (durationDays >= 5 || tripTypes.has('outdoor')) {
+      if (tags.has('camera') || tags.has('photo')) return 'Capture memories on your trip'
+    }
+  }
+
+  // ── Toiletries: weather-specific ──
+  if (category === 'toiletries') {
+    if ((weatherTags.has('hot') || weatherTags.has('summer') || weatherTags.has('beach')) && tags.has('sun') && tags.has('spf')) {
+      return 'Sun protection needed'
+    }
+    if ((weatherTags.has('cold') || weatherTags.has('winter')) && tags.has('lip')) {
+      return 'Protect from cold/dry air'
+    }
+    if (tripTypes.has('outdoor') && (tags.has('bug') || tags.has('insect'))) {
+      return 'Bug protection for outdoor activities'
+    }
+    if (tags.has('motion') || tags.has('nausea') || tags.has('travel')) {
+      return 'Useful for travel'
+    }
+  }
+
+  // ── Business trip extras ──
+  if (tripTypes.has('business')) {
+    if (category === 'clothing' && (tags.has('formal') || tags.has('dress') || tags.has('loafer'))) {
+      return 'Business-appropriate attire'
+    }
+    if (category === 'electronics' && (tags.has('laptop') || tags.has('computer'))) {
+      return 'Work essentials'
+    }
+  }
+
+  // ── Duration-based ──
+  if (durationDays >= 5) {
+    if (tags.has('laundry') || tags.has('wash')) return 'Useful for longer trips'
+    if (category === 'toiletries' && tags.has('hair')) return 'Hair care for extended stay'
+  }
+
+  // ── Accessories: always suggest a few ──
+  if (category === 'accessories') {
+    if (tags.has('sun') && (weatherTags.has('hot') || weatherTags.has('summer'))) {
+      return 'Sun protection'
+    }
+    if (tags.has('water bottle') || tags.has('hydration')) return 'Stay hydrated while traveling'
+  }
+
+  return null
+}
+
+/**
+ * Generate packing suggestions for a trip.
+ *
+ * @param ctx - Trip context (destination, weather, dates, etc.)
+ * @param userId - User ID for the suggestions
+ * @returns Array of PackingSuggestion objects
+ */
+export function generatePackingSuggestions(
+  ctx: TripContext,
+  userId: string,
+): Omit<PackingSuggestion, 'id' | 'created_at'>[] {
+  const weatherTags = inferWeatherTags(ctx)
+  const tripTypes = inferTripType(ctx)
+  const suggestions: Omit<PackingSuggestion, 'id' | 'created_at'>[] = []
+
+  for (const item of PACKING_CATALOG) {
+    const reason = shouldSuggest(item, weatherTags, tripTypes, ctx.durationDays)
+    if (reason) {
+      suggestions.push({
+        trip_id: '', // caller fills in
+        user_id: userId,
+        name: item.name,
+        category: item.category,
+        reason,
+        status: 'pending',
+      })
+    }
+  }
+
+  // Sort by category order, then by name
+  const categoryOrder: Record<string, number> = {
+    essentials: 0, documents: 1, clothing: 2, toiletries: 3,
+    electronics: 4, accessories: 5,
+  }
+  suggestions.sort((a, b) => {
+    const catDiff = (categoryOrder[a.category] ?? 99) - (categoryOrder[b.category] ?? 99)
+    if (catDiff !== 0) return catDiff
+    return a.name.localeCompare(b.name)
+  })
+
+  return suggestions
+}


### PR DESCRIPTION
## Summary

Packing list tab was empty for new trips. Now generates contextual packing suggestions based on destination, weather, duration, and trip type.

## How it works

**Smart catalog-based generator** (no AI/LLM needed):
- Uses the existing PACKING_CATALOG (100+ items with category + tags)
- Selects items based on weather data from the enrich pipeline
- Hot weather → shorts, swimsuit, sunscreen, sunglasses
- Cold weather → warm jacket, thermal layers, scarf, gloves
- Rain → rain jacket, umbrella
- Beach trip → sandals, swimsuit, beach accessories
- Hiking → hiking boots, outdoor gear
- Business trip → formal shoes, dress, laptop
- Duration-based: laundry bag for 5+ days, camera for longer trips

**Each suggestion includes a reason**: e.g. 'Warm layers for cold weather', 'Beach trip essentials'

## Changes
1. New shared service: `packages/shared/src/services/packingSuggestions.ts`
2. Enrich route auto-generates suggestions on first enrichment (if none exist)
3. `usePackingSuggestions` hook upgraded — local fallback now uses the smart generator

## Verification
- `tsc --noEmit` passes for both apps/web and packages/shared