### PR TITLE
fix(TRA-302): trigger packing suggestions via SST on trip enrichment

### DIFF
--- a/apps/web/app/api/trips/enrich/route.ts
+++ b/apps/web/app/api/trips/enrich/route.ts
@@ -321,5 +321,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: updateErr.message }, { status: 500 })
   }
 
+  // Auto-generate packing suggestions via SST (fire-and-forget)
+  if (BACKEND_URL) {
+    const { data: existingSuggestions } = await supabase
+      .from('packing_suggestions')
+      .select('id', { count: 'exact', head: true })
+      .eq('trip_id', tripId)
+
+    if ((existingSuggestions ?? []).length === 0) {
+      // Get auth token to forward to the packing-suggest SST function
+      const authHeader = req.headers.get('authorization')
+      const body = JSON.stringify({ tripId })
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (authHeader) headers['Authorization'] = authHeader
+
+      fetch(`${BACKEND_URL}/packing-suggest`, { method: 'POST', headers, body })
+        .catch((err) => console.error('[enrich] packing-suggest failed:', err))
+    }
+  }
+
   return NextResponse.json({ status: 'enriched', keys: Object.keys(merged) })
 }

--- a/packages/shared/src/hooks/usePackingSuggestions.ts
+++ b/packages/shared/src/hooks/usePackingSuggestions.ts
@@ -145,7 +145,7 @@ export function usePackingSuggestions(
       const session = await supabase.auth.getSession()
       if (session.data.session?.access_token) {
         hasAttemptedGeneration.current = true
-        generateSuggestions(false)
+        await generateSuggestions(false)
       } else if (tripQuery.data) {
         hasAttemptedGeneration.current = true
         setLocalSuggestions(generateLocalSuggestions(tripQuery.data))


### PR DESCRIPTION
## Summary

The SST `packing-suggest` endpoint (Claude 3 Haiku via Bedrock) already exists and generates smart packing lists based on destination, weather, activities, and travelers. But it was only called client-side from the `usePackingSuggestions` hook — meaning new trips showed an empty packing list until the user manually visited the packing tab.

## Changes

1. **Enrich route triggers packing-suggest** — after enrichment completes, fires a POST to the SST endpoint (fire-and-forget, non-blocking)
   - Only triggers if no suggestions exist yet (no duplicates)
   - Forwards the user's auth token
   - Uses the same SST function that calls Claude 3 Haiku with full trip context

2. **Fixed `usePackingSuggestions` hook** — `generateSuggestions()` was called without `await`, causing query invalidation races

## Why this approach

The SST endpoint already uses Claude 3 Haiku to generate personalized suggestions based on:
- Destination + dates + duration
- Weather forecast
- Planned activities from the itinerary
- Already-packed items (avoids duplicates)
- Traveler count and child ages

No need to reinvent this with a client-side rule engine.

## Verification
- `tsc --noEmit` passes