### PR TITLE
fix: add 'use client' to shared hooks for Next.js 16 Turbopack

### DIFF
--- a/packages/shared/src/hooks/useActivityFilters.ts
+++ b/packages/shared/src/hooks/useActivityFilters.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useMemo, useEffect } from 'react';
 import type { DiscoverItem } from '../types';
 import type { ItineraryDayViewModel } from '../viewmodels/itineraryViewModel';

--- a/packages/shared/src/hooks/useExploreData.ts
+++ b/packages/shared/src/hooks/useExploreData.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { shuffle } from '../utils';

--- a/packages/shared/src/hooks/useExploreRows.ts
+++ b/packages/shared/src/hooks/useExploreRows.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useCallback, useMemo } from 'react';
 import { getCyclicGradient } from '../config/homeData';
 import { useExploreData } from './useExploreData';

--- a/packages/shared/src/hooks/useHomeCurrency.ts
+++ b/packages/shared/src/hooks/useHomeCurrency.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useCallback } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useExchangeRates } from './useExchangeRates'

--- a/packages/shared/src/hooks/useHomeScreen.ts
+++ b/packages/shared/src/hooks/useHomeScreen.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useMemo, useCallback } from 'react';
 import { useAuthStore } from '../stores';
 import { useTrips } from './useTrips';

--- a/packages/shared/src/hooks/useInspirationCards.ts
+++ b/packages/shared/src/hooks/useInspirationCards.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchInspirationCards } from '../services/api';

--- a/packages/shared/src/hooks/useItineraryScreen.ts
+++ b/packages/shared/src/hooks/useItineraryScreen.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useMemo, useCallback } from 'react';
 import { useTrip } from './useTrip';
 import { useItineraryDays } from './useItineraryDays';

--- a/packages/shared/src/hooks/useMosaicTiles.ts
+++ b/packages/shared/src/hooks/useMosaicTiles.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchMosaicTiles } from '../services/api';

--- a/packages/shared/src/hooks/usePackingList.ts
+++ b/packages/shared/src/hooks/usePackingList.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useEffect, useMemo, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../services/supabase'

--- a/packages/shared/src/hooks/usePackingSuggestions.ts
+++ b/packages/shared/src/hooks/usePackingSuggestions.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useEffect, useMemo, useCallback, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../services/supabase'

--- a/packages/shared/src/hooks/useRestaurantFilters.ts
+++ b/packages/shared/src/hooks/useRestaurantFilters.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useMemo, useEffect } from 'react';
 import type { DiscoverItem } from '../types';
 

--- a/packages/shared/src/hooks/useSimilarPlaces.ts
+++ b/packages/shared/src/hooks/useSimilarPlaces.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useMemo } from 'react';
 import type { PlaceItem } from '../types';
 import { haversineKm } from '../utils';

--- a/packages/shared/src/hooks/useTagUsDestinations.ts
+++ b/packages/shared/src/hooks/useTagUsDestinations.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useMemo } from 'react';
 import { useMosaicTiles } from './useMosaicTiles';
 import { useInspirationCards } from './useInspirationCards';

--- a/packages/shared/src/hooks/useTripBudget.ts
+++ b/packages/shared/src/hooks/useTripBudget.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useItineraryDays } from './useItineraryDays'

--- a/packages/shared/src/hooks/useTripPlanner.ts
+++ b/packages/shared/src/hooks/useTripPlanner.ts
@@ -1,3 +1,4 @@
+"use client"
 import { useState, useCallback, useRef } from 'react';
 
 // On web: use our own API proxy routes (relative URLs, no prefix needed)


### PR DESCRIPTION
## Problem
Deploy failing with `Turbopack build failed with 16 errors`. Next.js 16 Turbopack requires `"use client"` on files using React hooks from shared packages.

## Fix
Added `"use client"` to 15 hook files in `packages/shared/src/hooks/`.

## Notes
- Harmless for React Native (Metro ignores the directive)
- tsc --noEmit passes for both apps/web and packages/shared