### PR TITLE
Fix: Amplify build — add 'use client' to shared barrels

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": false,
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { useTrips, saveAnonTripId } from './useTrips';
 export { useHomeScreen } from './useHomeScreen';
 export { useExploreRows } from './useExploreRows';

--- a/packages/shared/src/stores/index.ts
+++ b/packages/shared/src/stores/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { useAuthStore } from './authStore';
 export { useSettingsStore } from './settingsStore';
 export type { Currency, DistanceUnits, TravelStyle } from './settingsStore';


### PR DESCRIPTION
## Summary
- Add `'use client'` directive to `packages/shared/src/hooks/index.ts` and `stores/index.ts`
- Add `"sideEffects": false` to `packages/shared/package.json`

Turbopack build failed with 16 errors because Server Components importing types from `@travyl/shared` pulled in the entire hook dependency tree (zustand, react state). The `'use client'` directive tells Turbopack these module trees are client-only.

## Test plan
- [x] `next build` passes locally
- [ ] Amplify deploy succeeds on develop