### PR TITLE
Mobile: AI trip planner, homepage alignment, persistence fixes

### DIFF
--- a/apps/mobile/app/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/(tabs)/(home)/index.tsx
@@ -85,10 +85,11 @@ const QUOTE_SLIDES = [
 
 const PILLS_VISIBLE = 3;
 
-const STATS = [
-  { numericValue: 500, suffix: 'K+', decimals: 0, label: 'DESTINATIONS', desc: 'Discover unexpected gems, even in your own backyard.' },
-  { numericValue: 95, suffix: 'M+', decimals: 0, label: 'FELLOW TRAVELERS', desc: 'Share your adventures and learn from our global community.' },
-  { numericValue: 2.0, suffix: 'B+', decimals: 1, label: 'TRIPS PLANNED', desc: 'Navigate your way and keep a record of all your travels.' },
+// Stats fetched from API — fallback to 0
+const STATS_FALLBACK = [
+  { numericValue: 0, suffix: '+', decimals: 0, label: 'DESTINATIONS', desc: 'Real places our community has explored.' },
+  { numericValue: 0, suffix: '', decimals: 0, label: 'TRAVELERS', desc: 'People planning their next adventure.' },
+  { numericValue: 0, suffix: '+', decimals: 0, label: 'TRIPS PLANNED', desc: 'AI-powered itineraries created and counting.' },
 ];
 
 function AnimatedCounter({
@@ -168,6 +169,21 @@ function StatsSection({ scrollY, screenHeight }: { scrollY: { value: number }; s
   const [visible, setVisible] = useState(false);
   const sectionY = useSharedValue(0);
   const triggered = useSharedValue(false);
+  const [liveStats, setLiveStats] = useState(STATS_FALLBACK);
+
+  // Fetch real stats from API
+  useEffect(() => {
+    const API = process.env.EXPO_PUBLIC_WEB_API_URL || '';
+    fetch(`${API}/api/stats`).then(r => r.ok ? r.json() : null).then(data => {
+      if (data) {
+        setLiveStats([
+          { numericValue: data.destinations ?? 0, suffix: '+', decimals: 0, label: 'DESTINATIONS', desc: 'Real places our community has explored.' },
+          { numericValue: data.travelers ?? 0, suffix: '', decimals: 0, label: 'TRAVELERS', desc: 'People planning their next adventure.' },
+          { numericValue: data.trips ?? 0, suffix: '+', decimals: 0, label: 'TRIPS PLANNED', desc: 'AI-powered itineraries created and counting.' },
+        ]);
+      }
+    }).catch(() => {});
+  }, []);
 
   useAnimatedReaction(
     () => scrollY.value,
@@ -194,7 +210,7 @@ function StatsSection({ scrollY, screenHeight }: { scrollY: { value: number }; s
       }}
     >
       <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-        {STATS.map((item, i) => (
+        {liveStats.map((item, i) => (
           <Animated.View
             key={item.label}
             entering={FadeInUp.duration(500).delay(i * 150)}
@@ -348,15 +364,37 @@ export default function HomeScreen() {
     return () => clearInterval(interval);
   }, []);
 
+  // Error state
+  const [plannerError, setPlannerError] = useState<string | null>(null);
+
+  // Destination autocomplete
+  const [autocompleteSuggestions, setAutocompleteSuggestions] = useState<{ name: string; country: string; fullName: string }[]>([]);
+  const autocompleteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (autocompleteTimer.current) clearTimeout(autocompleteTimer.current);
+    const q = tripQuery.trim();
+    if (q.length < 2 || convStep >= 0) { setAutocompleteSuggestions([]); return; }
+    autocompleteTimer.current = setTimeout(async () => {
+      try {
+        const API = process.env.EXPO_PUBLIC_WEB_API_URL || '';
+        const res = await fetch(`${API}/api/autocomplete?q=${encodeURIComponent(q)}&mode=destination&limit=4`);
+        if (!res.ok) { setAutocompleteSuggestions([]); return; }
+        const data = await res.json();
+        setAutocompleteSuggestions(Array.isArray(data) ? data.slice(0, 4) : []);
+      } catch { setAutocompleteSuggestions([]); }
+    }, 250);
+    return () => { if (autocompleteTimer.current) clearTimeout(autocompleteTimer.current); };
+  }, [tripQuery, convStep]);
+
   // Conversational flow state
   const [convStep, setConvStep] = useState(-1);
   const [answers, setAnswers] = useState<TripAnswers>({});
-  const isConversing = convStep >= 0 && convStep < TRIP_QUESTIONS.length;
-  const isComplete = convStep >= TRIP_QUESTIONS.length;
-  const chainSentence = buildChainSentence(answers);
+  const isConversing = false; // Disabled — direct AI planner flow
+  const isComplete = false;
   const inputRef = useRef<TextInput>(null);
 
   const sendButtonRef = useRef<View>(null);
+  const clarifyRetries = useRef(0);
   const [showTakeoff, setShowTakeoff] = useState(false);
   const buttonLayoutRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const [buttonLayout, setButtonLayout] = useState<{
@@ -368,9 +406,29 @@ export default function HomeScreen() {
 
   // When planner completes, save trip and navigate
   useEffect(() => {
+    console.log('[HOME] planner phase:', planner.state.phase, 'showTakeoff:', showTakeoff);
     if (!showTakeoff) return;
     const s = planner.state;
+    // Auto-answer clarifying questions during takeoff — pick first option for each (max 1 retry)
+    if (s.phase === 'clarifying' && s.questions?.length) {
+      if (clarifyRetries.current >= 2) {
+        console.log('[HOME] Max clarify retries — showing error');
+        planner.reset();
+        setShowTakeoff(false);
+        setPlannerError('Trip needs more details. Try the "Plan a Trip" button for guided planning.');
+        return;
+      }
+      clarifyRetries.current += 1;
+      console.log('[HOME] Auto-answering clarifying questions (attempt', clarifyRetries.current, ')');
+      const autoAnswers: Record<string, string> = {};
+      for (const q of s.questions) {
+        autoAnswers[q.id] = q.options?.[0] ?? '';
+      }
+      planner.submitAnswers(autoAnswers);
+      return;
+    }
     if (s.phase === 'complete' && s.plan) {
+      console.log('[HOME] Plan complete, saving...');
       (async () => {
         try {
           const tripId = await savePlanToSupabase(s.plan as any);
@@ -378,18 +436,20 @@ export default function HomeScreen() {
           planner.reset();
           setShowTakeoff(false);
           router.push(`/trip/${tripId}` as any);
-        } catch (err) {
-          console.error('Failed to save trip:', err);
+        } catch (err: any) {
+          console.error('Failed to save trip:', err?.message || err);
           planner.reset();
           setShowTakeoff(false);
-          router.push('/(tabs)/trips');
+          setPlannerError(`Trip save failed: ${err?.message || 'Unknown error'}`);
         }
       })();
     } else if (s.phase === 'error') {
       console.error('Trip planning failed:', s.message);
       planner.reset();
       setShowTakeoff(false);
-      router.push('/(tabs)/trips');
+      setPlannerError(s.message.includes('400')
+        ? "Couldn't find that destination — try being more specific."
+        : `Something went wrong: ${s.message}`);
     }
   }, [planner.state.phase, showTakeoff]);
 
@@ -410,7 +470,7 @@ export default function HomeScreen() {
     setTripQuery(query);
     setButtonLayout(buttonLayoutRef.current);
     setShowTakeoff(true);
-    // Start planning in background
+    clarifyRetries.current = 0;
     planner.submitPrompt(query);
   }, [setTripQuery, planner]);
 
@@ -432,58 +492,9 @@ export default function HomeScreen() {
   const onSearch = () => {
     const val = tripQuery.trim();
     if (!val) return;
-
-    // Not conversing yet — parse input and start flow
-    if (convStep === -1) {
-      const parsed = parseInitialInput(val);
-      setAnswers(parsed);
-      const firstUnanswered = TRIP_QUESTIONS.findIndex((q) => !parsed[q.key]);
-      if (firstUnanswered === -1) {
-        const fullQuery = buildChainSentence(parsed);
-        setConvStep(TRIP_QUESTIONS.length);
-        setTripQuery(fullQuery);
-        setTimeout(() => launchTakeoff(fullQuery), 1500);
-      } else {
-        setConvStep(firstUnanswered);
-        setTripQuery('');
-        setTimeout(() => inputRef.current?.focus(), 50);
-      }
-      return;
-    }
-
-    // In conversation — save answer and advance
-    if (isConversing) {
-      const currentQ = TRIP_QUESTIONS[convStep];
-      let normalized = val;
-      if (currentQ.key === 'duration') {
-        if (/^\d+$/.test(val.trim())) normalized = `${val.trim()} days`;
-        else if (!/day|night|week/i.test(val)) normalized = `${val.trim()} days`;
-      } else if (currentQ.key === 'companions') {
-        if (/^\d+$/.test(val.trim())) normalized = `${val.trim()} people`;
-      } else if (currentQ.key === 'destination') {
-        normalized = val.trim().replace(/\b\w/g, (c: string) => c.toUpperCase());
-      }
-      const newAnswers = { ...answers, [currentQ.key]: normalized };
-      setAnswers(newAnswers);
-      setTripQuery('');
-      const nextUnanswered = TRIP_QUESTIONS.findIndex((q, i) => i > convStep && !newAnswers[q.key]);
-      if (nextUnanswered === -1) {
-        setConvStep(TRIP_QUESTIONS.length);
-        const fullQuery = buildChainSentence(newAnswers);
-        setTripQuery(fullQuery);
-        setTimeout(() => launchTakeoff(fullQuery), 1500);
-      } else {
-        setConvStep(nextUnanswered);
-        setTimeout(() => inputRef.current?.focus(), 50);
-      }
-      return;
-    }
-
-    // Fallback
-    if (handleSearch()) {
-      setButtonLayout(buttonLayoutRef.current);
-      setShowTakeoff(true);
-    }
+    // Send directly to AI planner — no conversational flow
+    setAutocompleteSuggestions([]);
+    launchTakeoff(val);
   };
 
   return (
@@ -565,70 +576,23 @@ export default function HomeScreen() {
           </Animated.Text>
         </View>
 
-        {/* Chain pill — shows trip so far during conversation */}
-        {isConversing && chainSentence ? (
+        {/* Error banner */}
+        {plannerError && (
           <Animated.View
-            entering={FadeInUp.duration(300)}
-            exiting={FadeOut.duration(200)}
+            entering={FadeIn.duration(300)}
             style={{
-              width: '100%',
-              backgroundColor: 'rgba(0,0,0,0.3)',
-              borderRadius: 24,
-              paddingHorizontal: 20,
-              paddingVertical: 10,
-              marginBottom: 12,
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              borderWidth: 1,
-              borderColor: 'rgba(255,255,255,0.15)',
+              width: '100%', backgroundColor: 'rgba(239,68,68,0.15)',
+              borderRadius: 12, padding: 12, marginBottom: 12,
+              flexDirection: 'row', alignItems: 'center', gap: 10,
             }}
           >
-            <Text style={{ ...TextStyles.bodyLgEm, flex: 1, color: '#fff', marginRight: 8 }} numberOfLines={1}>
-              {chainSentence}
-            </Text>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 3 }}>
-              {TRIP_QUESTIONS.map((_, i) => (
-                <View
-                  key={i}
-                  style={{
-                    width: 4,
-                    height: 4,
-                    borderRadius: 2,
-                    backgroundColor: i < convStep ? 'rgba(255,255,255,0.4)' : i === convStep ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.12)',
-                  }}
-                />
-              ))}
-              <Pressable onPress={handleConvReset} style={{ marginLeft: 4, padding: 4 }}>
-                <FontAwesome name="refresh" size={10} color="rgba(255,255,255,0.5)" />
-              </Pressable>
-            </View>
+            <FontAwesome name="exclamation-circle" size={16} color="#ef4444" />
+            <Text style={{ ...TextStyles.body, color: '#fff', flex: 1 }}>{plannerError}</Text>
+            <Pressable onPress={() => setPlannerError(null)} hitSlop={8}>
+              <FontAwesome name="times" size={14} color="rgba(255,255,255,0.6)" />
+            </Pressable>
           </Animated.View>
-        ) : null}
-
-        {/* Final summary pill before takeoff */}
-        {isComplete && !showTakeoff && chainSentence ? (
-          <Animated.View
-            entering={FadeInUp.duration(400)}
-            style={{
-              width: '100%',
-              backgroundColor: 'rgba(0,0,0,0.3)',
-              borderRadius: 24,
-              paddingHorizontal: 20,
-              paddingVertical: 12,
-              marginBottom: 12,
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 8,
-              borderWidth: 1,
-              borderColor: 'rgba(255,255,255,0.15)',
-            }}
-          >
-            <Text style={{ ...TextStyles.bodyXlEm, color: '#fff' }}>{chainSentence}</Text>
-            <ActivityIndicator size="small" color="rgba(255,255,255,0.6)" />
-          </Animated.View>
-        ) : null}
+        )}
 
         {/* Search Bar */}
         <Animated.View
@@ -673,9 +637,9 @@ export default function HomeScreen() {
             <TextInput
               ref={inputRef}
               value={tripQuery}
-              onChangeText={setTripQuery}
+              onChangeText={(v) => { setTripQuery(v); if (plannerError) setPlannerError(null); }}
               onSubmitEditing={onSearch}
-              placeholder={isConversing ? TRIP_QUESTIONS[convStep].placeholder : (heroConfig?.search_placeholder ?? '7 days in Paris with my partner...')}
+              placeholder={heroConfig?.search_placeholder ?? '7 days in Paris with my partner...'}
               placeholderTextColor={colors.textTertiary}
               returnKeyType="search"
               style={{ flex: 1, fontSize: FontSize.bodyXl, color: colors.text, paddingVertical: 8 }}
@@ -698,6 +662,38 @@ export default function HomeScreen() {
               <PaperPlane size={22} color="#fff" />
             </Pressable>
           </View>
+
+          {/* Autocomplete dropdown */}
+          {autocompleteSuggestions.length > 0 && (
+            <View style={{
+              marginHorizontal: 4, marginTop: -4,
+              backgroundColor: 'rgba(255,255,255,0.95)', borderRadius: 12,
+              overflow: 'hidden', borderWidth: 1, borderColor: 'rgba(0,0,0,0.06)',
+            }}>
+              {autocompleteSuggestions.map((s, i) => (
+                <Pressable
+                  key={`${s.name}-${i}`}
+                  onPress={() => {
+                    setTripQuery(`trip to ${s.name}, ${s.country}`);
+                    setAutocompleteSuggestions([]);
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: 'row', alignItems: 'center', gap: 10,
+                    paddingHorizontal: 14, paddingVertical: 11,
+                    backgroundColor: pressed ? 'rgba(0,0,0,0.03)' : 'transparent',
+                    borderBottomWidth: i < autocompleteSuggestions.length - 1 ? 1 : 0,
+                    borderBottomColor: 'rgba(0,0,0,0.04)',
+                  })}
+                >
+                  <FontAwesome name="map-marker" size={12} color="#9ca3af" />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ ...TextStyles.bodyLg, color: '#111827' }}>{s.name}</Text>
+                    <Text style={{ ...TextStyles.caption, color: '#9ca3af' }}>{s.country}</Text>
+                  </View>
+                </Pressable>
+              ))}
+            </View>
+          )}
         </Animated.View>
 
         {/* Cycling Suggestion Pills — only before conversation */}

--- a/apps/mobile/app/trip/[id]/budget.tsx
+++ b/apps/mobile/app/trip/[id]/budget.tsx
@@ -1,8 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { View, Text, ScrollView, Pressable, TextInput, Dimensions } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { useItineraryScreen, TextStyles, FontSize } from '@travyl/shared';
+import { useItineraryScreen, TextStyles, FontSize, supabase } from '@travyl/shared';
 import type { BudgetItem, BudgetExpense } from '@travyl/shared';
 import { PageTransition, useTabAccent } from './_layout';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -136,6 +136,44 @@ export default function BudgetScreen() {
 
   /* ── State ── */
   const [budgetData, setBudgetData] = useState<BudgetItem[]>(initialBudget);
+  const seeded = useRef(false);
+
+  // Load saved budget from trip_context if available
+  useEffect(() => {
+    if (trip && !seeded.current) {
+      const saved = (trip.trip_context as any)?.budget_data;
+      if (saved && Array.isArray(saved) && saved.length > 0) {
+        setBudgetData(saved);
+      } else {
+        setBudgetData(initialBudget);
+      }
+      seeded.current = true;
+    }
+  }, [trip, initialBudget]);
+
+  // Debounce-save budget to trip_context
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const persistBudget = useCallback((data: BudgetItem[]) => {
+    if (!seeded.current || !id) return;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      supabase.from('trips').select('trip_context').eq('id', id).single().then(({ data: row }) => {
+        if (row) {
+          const ctx = (row.trip_context || {}) as Record<string, unknown>;
+          ctx.budget_data = data;
+          supabase.from('trips').update({ trip_context: ctx }).eq('id', id).then(() => {});
+        }
+      });
+    }, 1500);
+  }, [id]);
+
+  const updateBudget = useCallback((updater: BudgetItem[] | ((prev: BudgetItem[]) => BudgetItem[])) => {
+    setBudgetData((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      persistBudget(next);
+      return next;
+    });
+  }, [persistBudget]);
 
   /* Editing total budget */
   const [isEditingTotal, setIsEditingTotal] = useState(false);
@@ -249,7 +287,7 @@ export default function BudgetScreen() {
     const newTotal = parseFloat(tempTotal) || 0;
     if (newTotal > 0 && totalBudgeted > 0) {
       const ratio = newTotal / totalBudgeted;
-      setBudgetData((prev) =>
+      updateBudget((prev) =>
         prev.map((item) => ({ ...item, budgeted: Math.round(item.budgeted * ratio * 100) / 100 })),
       );
     }
@@ -264,7 +302,7 @@ export default function BudgetScreen() {
 
   const handleSaveEdit = () => {
     if (editingItemId) {
-      setBudgetData((prev) =>
+      updateBudget((prev) =>
         prev.map((item) =>
           item.id === editingItemId ? { ...item, budgeted: parseFloat(tempBudgeted) || 0 } : item,
         ),
@@ -279,7 +317,7 @@ export default function BudgetScreen() {
   };
 
   const handleDeleteCategory = (catId: string) => {
-    setBudgetData((prev) => prev.filter((item) => item.id !== catId));
+    updateBudget((prev) => prev.filter((item) => item.id !== catId));
   };
 
   const handleAddExpense = (categoryId: string) => {
@@ -289,7 +327,7 @@ export default function BudgetScreen() {
         description: newExpenseDesc,
         amount: parseFloat(newExpenseAmount) || 0,
       };
-      setBudgetData((prev) =>
+      updateBudget((prev) =>
         prev.map((item) => {
           if (item.id === categoryId) {
             const expenses = [...(item.expenses || []), expense];
@@ -306,7 +344,7 @@ export default function BudgetScreen() {
   };
 
   const handleDeleteExpense = (categoryId: string, expenseId: string) => {
-    setBudgetData((prev) =>
+    updateBudget((prev) =>
       prev.map((item) => {
         if (item.id === categoryId) {
           const expenses = (item.expenses || []).filter((exp) => exp.id !== expenseId);
@@ -320,7 +358,7 @@ export default function BudgetScreen() {
 
   const handleAddCategory = () => {
     if (newCategory.trim()) {
-      setBudgetData((prev) => [
+      updateBudget((prev) => [
         ...prev,
         {
           id: `custom-${Date.now()}`,
@@ -328,6 +366,7 @@ export default function BudgetScreen() {
           budgeted: parseFloat(newBudgeted) || 0,
           actual: parseFloat(newActual) || 0,
           fixed: false,
+          expenses: [],
         },
       ]);
       setNewCategory('');

--- a/apps/mobile/app/trip/[id]/favorites.tsx
+++ b/apps/mobile/app/trip/[id]/favorites.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { View, Text, ScrollView, Pressable, Image } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useItineraryScreen } from '@travyl/shared';
 import type { DiscoverItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -360,8 +361,22 @@ export default function FavoritesScreen() {
   const { trip, isLoading } = useItineraryScreen(id);
 
   const [activeFilter, setActiveFilter] = useState<CategoryFilter>('All');
-  const [activityFavorites, setActivityFavorites] = useState<string[]>(INITIAL_ACTIVITY_FAVORITES);
-  const [restaurantFavorites, setRestaurantFavorites] = useState<string[]>(INITIAL_RESTAURANT_FAVORITES);
+  const [activityFavorites, setActivityFavorites] = useState<string[]>([]);
+  const [restaurantFavorites, setRestaurantFavorites] = useState<string[]>([]);
+
+  // Load favorites from AsyncStorage on mount
+  useEffect(() => {
+    AsyncStorage.getItem('travyl-favorites').then((val) => {
+      if (val) {
+        try {
+          const all = JSON.parse(val) as string[];
+          // Split into activity vs restaurant based on what items we have
+          setActivityFavorites(all);
+          setRestaurantFavorites(all);
+        } catch {}
+      }
+    });
+  }, []);
   const [destinationFavorites, setDestinationFavorites] = useState<string[]>(INITIAL_DESTINATION_FAVORITES);
   const colors = useThemeColors();
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
@@ -381,12 +396,24 @@ export default function FavoritesScreen() {
 
   const totalFavorites = favoritedActivities.length + favoritedRestaurants.length + favoritedDestinations.length;
 
+  const persistFavorites = useCallback((ids: string[]) => {
+    AsyncStorage.setItem('travyl-favorites', JSON.stringify(ids)).catch(() => {});
+  }, []);
+
   const removeActivityFavorite = (itemId: string) => {
-    setActivityFavorites((prev) => prev.filter((f) => f !== itemId));
+    setActivityFavorites((prev) => {
+      const next = prev.filter((f) => f !== itemId);
+      persistFavorites(next);
+      return next;
+    });
   };
 
   const removeRestaurantFavorite = (itemId: string) => {
-    setRestaurantFavorites((prev) => prev.filter((f) => f !== itemId));
+    setRestaurantFavorites((prev) => {
+      const next = prev.filter((f) => f !== itemId);
+      persistFavorites(next);
+      return next;
+    });
   };
 
   const removeDestinationFavorite = (itemId: string) => {

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -54,10 +54,11 @@ interface HotelData {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Mock Data                                                          */
+/*  Constants                                                          */
 /* ------------------------------------------------------------------ */
 
-const SELECTED_HOTEL: HotelData = {
+// Mock data removed — hotels now come from trip_context only
+const _LEGACY_SELECTED_HOTEL: HotelData = {
   id: 'h1',
   name: 'H\u00f4tel Le Marais',
   stars: 4,
@@ -1297,12 +1298,14 @@ export default function HotelsScreen() {
       </View>
 
       {/* ── Other Hotels ── */}
-      <View style={{ paddingHorizontal: 16, marginTop: 20 }}>
-        <Text style={{ ...TextStyles.subhead, color: colors.text, marginBottom: 12 }}>Other Hotels</Text>
-        {OTHER_HOTELS.map((h) => (
-          <OtherHotelCard key={h.id} hotel={h} />
-        ))}
-      </View>
+      {realHotels.length > 1 && (
+        <View style={{ paddingHorizontal: 16, marginTop: 20 }}>
+          <Text style={{ ...TextStyles.subhead, color: colors.text, marginBottom: 12 }}>Other Hotels</Text>
+          {realHotels.slice(1).map((h: any) => (
+            <OtherHotelCard key={h.id} hotel={h} />
+          ))}
+        </View>
+      )}
 
       {/* ── Add Hotel Button (dashed border) ── */}
       <View style={{ paddingHorizontal: 16, marginTop: 6 }}>

--- a/apps/mobile/components/places/PlaceDetailModal.tsx
+++ b/apps/mobile/components/places/PlaceDetailModal.tsx
@@ -13,7 +13,17 @@ import {
   Platform,
 } from 'react-native';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import MapView, { Marker } from 'react-native-maps';
+
+// Conditionally import react-native-maps (crashes on web)
+let MapView: any = View;
+let Marker: any = View;
+if (Platform.OS !== 'web') {
+  try {
+    const maps = require('react-native-maps');
+    MapView = maps.default;
+    Marker = maps.Marker;
+  } catch {}
+}
 import { Navy, type PlaceItem, useSimilarPlaces } from '@travyl/shared';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -98,7 +108,7 @@ const PlaceDetailModal = memo(function PlaceDetailModal({
   useEffect(() => { setImageIndex(0); }, [deckIndex]);
 
   // Map ref — recenter when place changes
-  const mapRef = useRef<MapView>(null);
+  const mapRef = useRef<any>(null);
   useEffect(() => {
     if (currentPlace?.latitude != null && currentPlace?.longitude != null) {
       mapRef.current?.animateToRegion({

--- a/apps/mobile/components/trips/CreateTripModal.tsx
+++ b/apps/mobile/components/trips/CreateTripModal.tsx
@@ -1,371 +1,314 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
-  View,
-  Text,
-  TextInput,
-  Pressable,
-  Modal,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  ActivityIndicator,
-  useWindowDimensions,
+  View, Text, TextInput, Pressable, Modal, KeyboardAvoidingView,
+  Platform, ScrollView, ActivityIndicator,
 } from 'react-native';
-import Animated, { FadeIn, FadeOut, SlideInUp, SlideOutUp } from 'react-native-reanimated';
+import Animated, { FadeIn, SlideInDown } from 'react-native-reanimated';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import DateTimePicker from '@react-native-community/datetimepicker';
 import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
-import { TextStyles, FontSize, FontFamily, Navy, useAuthStore, supabase } from '@travyl/shared';
+import {
+  TextStyles, FontSize, FontFamily, Navy,
+  useTripPlanner, savePlanToSupabase,
+} from '@travyl/shared';
 import { saveAnonTripId } from '@travyl/shared/src/hooks/useTrips';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PaperPlane } from '@/components/icons/PaperPlane';
-import { WebView } from 'react-native-webview';
-
-interface NominatimResult {
-  place_id: number;
-  display_name: string;
-  lat: string;
-  lon: string;
-}
 
 interface CreateTripModalProps {
   visible: boolean;
   onClose: () => void;
+  prefillPrompt?: string;
 }
 
-function MiniMap({ lat, lon, name }: { lat: number; lon: number; name: string }) {
-  const html = `
-    <!DOCTYPE html><html><head>
-    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <style>body{margin:0}#map{width:100%;height:100%}</style>
-    </head><body><div id="map"></div><script>
-    var map=L.map('map',{zoomControl:false,attributionControl:false}).setView([${lat},${lon}],12);
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',{maxZoom:19}).addTo(map);
-    L.circleMarker([${lat},${lon}],{radius:8,fillColor:'#1e3a5f',fillOpacity:1,color:'#fff',weight:3}).addTo(map)
-     .bindPopup('${name.replace(/'/g, "\\'")}').openPopup();
-    </script></body></html>`;
-  return (
-    <WebView
-      source={{ html }}
-      style={{ flex: 1 }}
-      scrollEnabled={false}
-      javaScriptEnabled
-    />
-  );
-}
+const SUGGESTION_CHIPS = [
+  '7 days in Rome',
+  'Weekend in Bali',
+  'Tokyo with friends',
+  'Romantic Paris getaway',
+  'Budget trip to Thailand',
+  'Family vacation Orlando',
+];
 
-export function CreateTripModal({ visible, onClose }: CreateTripModalProps) {
+const PROGRESS_MESSAGES = [
+  'Understanding your trip...',
+  'Finding the best destinations...',
+  'Building your itinerary...',
+  'Searching for hotels & flights...',
+  'Curating local experiences...',
+  'Almost there...',
+];
+
+export function CreateTripModal({ visible, onClose, prefillPrompt }: CreateTripModalProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const user = useAuthStore((s) => s.user);
   const insets = useSafeAreaInsets();
-  const { height: screenHeight } = useWindowDimensions();
+  const planner = useTripPlanner();
 
-  const [title, setTitle] = useState('');
-  const [destination, setDestination] = useState('');
-  const [startDate, setStartDate] = useState(new Date());
-  const [endDate, setEndDate] = useState(new Date());
-  const [showStartPicker, setShowStartPicker] = useState(false);
-  const [showEndPicker, setShowEndPicker] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [prompt, setPrompt] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [progressMsg, setProgressMsg] = useState(0);
+  const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
 
-  const [suggestions, setSuggestions] = useState<NominatimResult[]>([]);
-  const [selectedCoords, setSelectedCoords] = useState<{ lat: number; lon: number; name: string } | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
+  // Reset on open
   useEffect(() => {
     if (visible) {
-      setTitle('');
-      setDestination('');
-      setStartDate(new Date());
-      setEndDate(new Date());
-      setShowStartPicker(false);
-      setShowEndPicker(false);
-      setError(null);
-      setSubmitting(false);
-      setSuggestions([]);
-      setSelectedCoords(null);
+      setPrompt(prefillPrompt || '');
+      setSaving(false);
+      setProgressMsg(0);
+      setCurrentQuestionIdx(0);
+      setAnswers({});
+      planner.reset();
     }
   }, [visible]);
 
-  // Debounced Nominatim fetch
+  // Cycle progress messages during planning
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    const q = destination.trim();
-    if (q.length < 2) { setSuggestions([]); return; }
-    debounceRef.current = setTimeout(async () => {
+    if (planner.state.phase !== 'planning' && planner.state.phase !== 'extracting') return;
+    const timer = setInterval(() => {
+      setProgressMsg((i) => (i + 1) % PROGRESS_MESSAGES.length);
+    }, 2500);
+    return () => clearInterval(timer);
+  }, [planner.state.phase]);
+
+  // Auto-save when plan completes
+  useEffect(() => {
+    if (planner.state.phase !== 'complete' || saving) return;
+    const plan = planner.state.plan;
+    (async () => {
+      setSaving(true);
       try {
-        const res = await fetch(
-          `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=4`,
-          { headers: { 'Accept-Language': 'en' } }
-        );
-        const data: NominatimResult[] = await res.json();
-        setSuggestions(data);
-      } catch {
-        setSuggestions([]);
+        const tripId = await savePlanToSupabase(plan as any, () => {});
+        await saveAnonTripId(tripId);
+        await queryClient.invalidateQueries({ queryKey: ['trips'] });
+        onClose();
+        router.push(`/trip/${tripId}` as never);
+      } catch (err) {
+        console.error('Save failed:', err);
+        setSaving(false);
       }
-    }, 350);
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  }, [destination]);
+    })();
+  }, [planner.state.phase]);
 
-  const selectSuggestion = useCallback((s: NominatimResult) => {
-    setDestination(s.display_name);
-    setSelectedCoords({ lat: parseFloat(s.lat), lon: parseFloat(s.lon), name: s.display_name.split(',')[0] });
-    setSuggestions([]);
-  }, []);
+  const handleSubmit = useCallback(() => {
+    const text = prompt.trim();
+    if (!text) return;
+    planner.submitPrompt(text);
+  }, [prompt, planner]);
 
-  const formatDate = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  const toISO = (d: Date) => d.toISOString().split('T')[0];
+  const handleSelectAnswer = useCallback((questionId: string, value: string) => {
+    const newAnswers = { ...answers, [questionId]: value };
+    setAnswers(newAnswers);
 
-  async function handleSubmit() {
-    setError(null);
-    if (!title.trim()) { setError('Trip name is required'); return; }
-    if (!destination.trim()) { setError('Destination is required'); return; }
-
-    setSubmitting(true);
-    try {
-      const { data, error: insertError } = await supabase
-        .from('trips')
-        .insert({
-          title: title.trim(),
-          destination: destination.trim(),
-          start_date: toISO(startDate),
-          end_date: toISO(endDate),
-          status: 'planning',
-          user_id: user?.id ?? null,
-        })
-        .select()
-        .single();
-
-      if (insertError) { setError(insertError.message); return; }
-
-      await saveAnonTripId(data.id);
-      await queryClient.invalidateQueries({ queryKey: ['trips'] });
-      onClose();
-      router.push(`/trip/${data.id}` as never);
-    } finally {
-      setSubmitting(false);
+    // If more questions, advance
+    if (planner.state.phase === 'clarifying') {
+      const questions = planner.state.questions;
+      if (currentQuestionIdx < questions.length - 1) {
+        setTimeout(() => setCurrentQuestionIdx((i) => i + 1), 300);
+      } else {
+        // All answered — submit
+        setTimeout(() => planner.submitAnswers(newAnswers), 400);
+      }
     }
-  }
+  }, [answers, currentQuestionIdx, planner]);
 
-  const mapHeight = screenHeight * 0.3;
+  const handleRetry = useCallback(() => {
+    planner.reset();
+    setCurrentQuestionIdx(0);
+    setAnswers({});
+  }, [planner]);
+
+  const phase = planner.state.phase;
+  const isWorking = phase === 'extracting' || phase === 'planning' || saving;
+  const isIdle = phase === 'idle';
+  const isClarifying = phase === 'clarifying';
+  const isError = phase === 'error';
 
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
       <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-        <View style={{ flex: 1, backgroundColor: '#f9fafb' }}>
+        <View style={{ flex: 1, backgroundColor: '#fff' }}>
 
-          {/* Top — map appears only after selecting a destination */}
-          <View style={{ height: selectedCoords ? screenHeight * 0.35 : 0, overflow: 'hidden' }}>
-            {selectedCoords && (
-              <Animated.View
-                entering={SlideInUp.duration(400)}
-                exiting={SlideOutUp.duration(300)}
-                style={{ flex: 1, backgroundColor: '#e5e7eb' }}
+          {/* Header */}
+          <View style={{
+            flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+            paddingHorizontal: 20, paddingTop: insets.top + 12, paddingBottom: 12,
+            borderBottomWidth: 1, borderBottomColor: '#f3f4f6',
+          }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <View style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: Navy.DEFAULT, alignItems: 'center', justifyContent: 'center' }}>
+                <PaperPlane size={14} color="#fff" style={{ transform: [{ rotate: '-12deg' }] }} />
+              </View>
+              <Text style={{ ...TextStyles.subhead, fontFamily: FontFamily.sansBold, color: Navy.DEFAULT }}>Plan a Trip</Text>
+            </View>
+            <Pressable onPress={onClose} hitSlop={12}>
+              <FontAwesome name="times" size={18} color="#9ca3af" />
+            </Pressable>
+          </View>
+
+          {/* ─── Idle: Prompt input ─── */}
+          {isIdle && (
+            <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 20 }} keyboardShouldPersistTaps="handled">
+              <Text style={{ ...TextStyles.title, color: Navy.DEFAULT, marginBottom: 4 }}>Where do you want to go?</Text>
+              <Text style={{ ...TextStyles.body, color: '#6b7280', marginBottom: 20 }}>
+                Describe your dream trip — destination, dates, who's going, what you like.
+              </Text>
+
+              <TextInput
+                value={prompt}
+                onChangeText={setPrompt}
+                placeholder="7 days in Paris with my partner..."
+                placeholderTextColor="#9ca3af"
+                multiline
+                autoFocus
+                style={{
+                  minHeight: 80, paddingHorizontal: 16, paddingVertical: 14, borderRadius: 16,
+                  borderWidth: 1.5, borderColor: prompt.trim() ? Navy.DEFAULT : '#e5e7eb',
+                  fontSize: FontSize.bodyLg, color: '#111827', fontFamily: FontFamily.sans,
+                  textAlignVertical: 'top', backgroundColor: '#f9fafb',
+                }}
+                onSubmitEditing={handleSubmit}
+              />
+
+              {/* Suggestion chips */}
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
+                {SUGGESTION_CHIPS.map((chip) => (
+                  <Pressable
+                    key={chip}
+                    onPress={() => { setPrompt(chip); }}
+                    style={({ pressed }) => ({
+                      paddingHorizontal: 14, paddingVertical: 8, borderRadius: 20,
+                      backgroundColor: pressed ? '#e0e7ff' : '#f3f4f6',
+                    })}
+                  >
+                    <Text style={{ ...TextStyles.caption, color: '#4b5563' }}>{chip}</Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              {/* Submit button */}
+              <Pressable
+                onPress={handleSubmit}
+                disabled={!prompt.trim()}
+                style={({ pressed }) => ({
+                  height: 48, borderRadius: 14, backgroundColor: Navy.DEFAULT,
+                  alignItems: 'center', justifyContent: 'center', marginTop: 24,
+                  opacity: !prompt.trim() ? 0.4 : pressed ? 0.85 : 1,
+                })}
               >
-                <MiniMap lat={selectedCoords.lat} lon={selectedCoords.lon} name={selectedCoords.name} />
-                {/* Destination label */}
+                <Text style={{ ...TextStyles.button, color: '#fff' }}>Plan My Trip</Text>
+              </Pressable>
+            </ScrollView>
+          )}
+
+          {/* ─── Working: Progress animation ─── */}
+          {isWorking && (
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 }}>
+              <Animated.View entering={FadeIn.duration(300)}>
                 <View style={{
-                  position: 'absolute', bottom: 12, left: 16, right: 16,
-                  backgroundColor: 'rgba(255,255,255,0.92)', borderRadius: 10,
-                  paddingHorizontal: 12, paddingVertical: 8,
-                  flexDirection: 'row', alignItems: 'center', gap: 6,
-                  shadowColor: '#000', shadowOpacity: 0.1, shadowRadius: 8, shadowOffset: { width: 0, height: 2 },
+                  width: 64, height: 64, borderRadius: 32,
+                  backgroundColor: `${Navy.DEFAULT}15`, alignItems: 'center', justifyContent: 'center',
+                  marginBottom: 20,
                 }}>
-                  <FontAwesome name="map-marker" size={12} color={Navy.DEFAULT} />
-                  <Text style={{ ...TextStyles.bodyLgEm, color: Navy.DEFAULT, flex: 1 }} numberOfLines={1}>
-                    {selectedCoords.name}
-                  </Text>
+                  <PaperPlane size={28} color={Navy.DEFAULT} style={{ transform: [{ rotate: '-12deg' }] }} />
                 </View>
-                {/* Close button on map */}
+              </Animated.View>
+              <ActivityIndicator size="small" color={Navy.DEFAULT} style={{ marginBottom: 16 }} />
+              <Text style={{ ...TextStyles.bodyLgEm, color: Navy.DEFAULT, textAlign: 'center', marginBottom: 6 }}>
+                {saving ? 'Saving your trip...' : PROGRESS_MESSAGES[progressMsg]}
+              </Text>
+              <Text style={{ ...TextStyles.caption, color: '#9ca3af', textAlign: 'center' }}>
+                This usually takes 10–20 seconds
+              </Text>
+            </View>
+          )}
+
+          {/* ─── Clarifying questions ─── */}
+          {isClarifying && planner.state.phase === 'clarifying' && (
+            <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 20 }}>
+              <Text style={{ ...TextStyles.captionEm, color: '#6b7280', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4 }}>
+                Question {currentQuestionIdx + 1} of {planner.state.questions.length}
+              </Text>
+
+              {(() => {
+                const q = planner.state.questions[currentQuestionIdx];
+                if (!q) return null;
+                return (
+                  <Animated.View key={q.id} entering={SlideInDown.duration(300)}>
+                    <Text style={{ ...TextStyles.subhead, color: Navy.DEFAULT, marginBottom: 16 }}>{q.question}</Text>
+                    <View style={{ gap: 10 }}>
+                      {q.options.map((opt) => {
+                        const selected = answers[q.id] === opt;
+                        return (
+                          <Pressable
+                            key={opt}
+                            onPress={() => handleSelectAnswer(q.id, opt)}
+                            style={({ pressed }) => ({
+                              paddingHorizontal: 16, paddingVertical: 14, borderRadius: 14,
+                              borderWidth: 1.5,
+                              borderColor: selected ? Navy.DEFAULT : '#e5e7eb',
+                              backgroundColor: selected ? `${Navy.DEFAULT}10` : pressed ? '#f9fafb' : '#fff',
+                            })}
+                          >
+                            <Text style={{
+                              ...TextStyles.bodyLg,
+                              color: selected ? Navy.DEFAULT : '#374151',
+                              fontFamily: selected ? FontFamily.sansBold : FontFamily.sans,
+                            }}>
+                              {opt}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                  </Animated.View>
+                );
+              })()}
+            </ScrollView>
+          )}
+
+          {/* ─── Error ─── */}
+          {isError && planner.state.phase === 'error' && (
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 }}>
+              <View style={{
+                width: 56, height: 56, borderRadius: 28,
+                backgroundColor: '#fef2f2', alignItems: 'center', justifyContent: 'center',
+                marginBottom: 16,
+              }}>
+                <FontAwesome name="exclamation-circle" size={24} color="#ef4444" />
+              </View>
+              <Text style={{ ...TextStyles.bodyLgEm, color: '#111827', textAlign: 'center', marginBottom: 6 }}>
+                {planner.state.message.includes('400') ? "Couldn't find that destination" : 'Something went wrong'}
+              </Text>
+              <Text style={{ ...TextStyles.caption, color: '#6b7280', textAlign: 'center', marginBottom: 20, maxWidth: 280 }}>
+                {planner.state.message.includes('400')
+                  ? 'Try a more specific location — like "Rome, Italy" instead of just "Rome".'
+                  : planner.state.message}
+              </Text>
+              <View style={{ flexDirection: 'row', gap: 12 }}>
+                <Pressable
+                  onPress={handleRetry}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: 20, paddingVertical: 10, borderRadius: 12,
+                    backgroundColor: Navy.DEFAULT, opacity: pressed ? 0.85 : 1,
+                  })}
+                >
+                  <Text style={{ ...TextStyles.button, color: '#fff' }}>Try Again</Text>
+                </Pressable>
                 <Pressable
                   onPress={onClose}
-                  hitSlop={12}
-                  style={{
-                    position: 'absolute', top: insets.top + 8, right: 16,
-                    width: 32, height: 32, borderRadius: 16,
-                    backgroundColor: 'rgba(255,255,255,0.9)', alignItems: 'center', justifyContent: 'center',
-                    shadowColor: '#000', shadowOpacity: 0.1, shadowRadius: 4, shadowOffset: { width: 0, height: 1 },
-                  }}
+                  style={({ pressed }) => ({
+                    paddingHorizontal: 20, paddingVertical: 10, borderRadius: 12,
+                    borderWidth: 1, borderColor: '#e5e7eb', opacity: pressed ? 0.85 : 1,
+                  })}
                 >
-                  <FontAwesome name="times" size={14} color="#6b7280" />
-                </Pressable>
-              </Animated.View>
-            )}
-          </View>
-
-          {/* Bottom card — form */}
-          <View style={{
-            flex: 1, backgroundColor: '#fff',
-            borderTopLeftRadius: selectedCoords ? 20 : 0,
-            borderTopRightRadius: selectedCoords ? 20 : 0,
-            marginTop: selectedCoords ? -16 : 0,
-            shadowColor: '#000', shadowOpacity: selectedCoords ? 0.08 : 0, shadowRadius: 12, shadowOffset: { width: 0, height: -4 },
-          }}>
-            {/* Header */}
-            <View style={{
-              flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-              paddingHorizontal: 20,
-              paddingTop: selectedCoords ? 16 : insets.top + 12,
-              paddingBottom: 10,
-            }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: Navy.DEFAULT, alignItems: 'center', justifyContent: 'center' }}>
-                  <PaperPlane size={12} color="#fff" style={{ transform: [{ rotate: '-12deg' }] }} />
-                </View>
-                <Text style={{ ...TextStyles.subhead, fontFamily: FontFamily.sansBold, color: Navy.DEFAULT }}>Plan a Trip</Text>
-              </View>
-              {!selectedCoords && (
-                <Pressable onPress={onClose} hitSlop={12}>
-                  <FontAwesome name="times" size={18} color="#9ca3af" />
-                </Pressable>
-              )}
-            </View>
-
-            {/* Form */}
-            <ScrollView
-            style={{ flex: 1 }}
-            contentContainerStyle={{ padding: 16, gap: 14 }}
-            keyboardShouldPersistTaps="handled"
-          >
-            {error && (
-              <View style={{ backgroundColor: '#fef2f2', borderWidth: 1, borderColor: '#fecaca', borderRadius: 10, padding: 10 }}>
-                <Text style={{ ...TextStyles.caption, color: '#dc2626' }}>{error}</Text>
-              </View>
-            )}
-
-            {/* Trip name */}
-            <View>
-              <Text style={{ ...TextStyles.captionEm, color: '#6b7280', marginBottom: 4 }}>Trip name</Text>
-              <TextInput
-                value={title}
-                onChangeText={setTitle}
-                placeholder="e.g. Paris Adventure"
-                placeholderTextColor="#9ca3af"
-                style={{
-                  height: 42, paddingHorizontal: 12, borderRadius: 12,
-                  borderWidth: 1, borderColor: '#e5e7eb',
-                  fontSize: FontSize.bodyLg, color: '#111827', fontFamily: FontFamily.sans,
-                }}
-              />
-            </View>
-
-            {/* Destination */}
-            <View>
-              <Text style={{ ...TextStyles.captionEm, color: '#6b7280', marginBottom: 4 }}>Destination</Text>
-              <TextInput
-                value={destination}
-                onChangeText={(v) => { setDestination(v); setSelectedCoords(null); }}
-                placeholder="e.g. Paris, France"
-                placeholderTextColor="#9ca3af"
-                autoCorrect={false}
-                style={{
-                  height: 42, paddingHorizontal: 12, borderRadius: 12,
-                  borderWidth: 1, borderColor: '#e5e7eb',
-                  fontSize: FontSize.bodyLg, color: '#111827', fontFamily: FontFamily.sans,
-                }}
-              />
-              {suggestions.length > 0 && (
-                <View style={{
-                  marginTop: 4, borderRadius: 12, borderWidth: 1, borderColor: '#e5e7eb',
-                  backgroundColor: '#fff', overflow: 'hidden',
-                }}>
-                  {suggestions.map((s) => (
-                    <Pressable
-                      key={s.place_id}
-                      onPress={() => selectSuggestion(s)}
-                      style={({ pressed }) => ({
-                        flexDirection: 'row', alignItems: 'center', gap: 8,
-                        paddingHorizontal: 12, paddingVertical: 10,
-                        backgroundColor: pressed ? '#f9fafb' : '#fff',
-                        borderBottomWidth: 1, borderBottomColor: '#f3f4f6',
-                      })}
-                    >
-                      <FontAwesome name="map-marker" size={12} color="#9ca3af" />
-                      <Text style={{ ...TextStyles.body, color: '#374151', flex: 1 }} numberOfLines={1}>{s.display_name}</Text>
-                    </Pressable>
-                  ))}
-                </View>
-              )}
-            </View>
-
-            {/* Dates — side by side */}
-            <View style={{ flexDirection: 'row', gap: 10 }}>
-              <View style={{ flex: 1 }}>
-                <Text style={{ ...TextStyles.captionEm, color: '#6b7280', marginBottom: 4 }}>Start date</Text>
-                <Pressable
-                  onPress={() => { setShowStartPicker(!showStartPicker); setShowEndPicker(false); }}
-                  style={{
-                    height: 42, paddingHorizontal: 12, borderRadius: 12,
-                    borderWidth: 1, borderColor: showStartPicker ? Navy.DEFAULT : '#e5e7eb',
-                    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-                  }}
-                >
-                  <Text style={{ ...TextStyles.bodyLg, color: '#111827' }}>{formatDate(startDate)}</Text>
-                  <FontAwesome name="calendar" size={12} color="#9ca3af" />
-                </Pressable>
-              </View>
-              <View style={{ flex: 1 }}>
-                <Text style={{ ...TextStyles.captionEm, color: '#6b7280', marginBottom: 4 }}>End date</Text>
-                <Pressable
-                  onPress={() => { setShowEndPicker(!showEndPicker); setShowStartPicker(false); }}
-                  style={{
-                    height: 42, paddingHorizontal: 12, borderRadius: 12,
-                    borderWidth: 1, borderColor: showEndPicker ? Navy.DEFAULT : '#e5e7eb',
-                    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-                  }}
-                >
-                  <Text style={{ ...TextStyles.bodyLg, color: '#111827' }}>{formatDate(endDate)}</Text>
-                  <FontAwesome name="calendar" size={12} color="#9ca3af" />
+                  <Text style={{ ...TextStyles.button, color: '#6b7280' }}>Cancel</Text>
                 </Pressable>
               </View>
             </View>
+          )}
 
-            {/* Date pickers — inline, toggleable */}
-            {showStartPicker && (
-              <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(150)}>
-                <DateTimePicker
-                  value={startDate}
-                  mode="date"
-                  display="inline"
-                  onChange={(_, date) => { if (Platform.OS !== 'ios') setShowStartPicker(false); if (date) setStartDate(date); }}
-                />
-              </Animated.View>
-            )}
-            {showEndPicker && (
-              <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(150)}>
-                <DateTimePicker
-                  value={endDate}
-                  mode="date"
-                  display="inline"
-                  minimumDate={startDate}
-                  onChange={(_, date) => { if (Platform.OS !== 'ios') setShowEndPicker(false); if (date) setEndDate(date); }}
-                />
-              </Animated.View>
-            )}
-
-            {/* Submit */}
-            <Pressable
-              onPress={handleSubmit}
-              disabled={submitting}
-              style={({ pressed }) => ({
-                height: 44, borderRadius: 12, backgroundColor: Navy.DEFAULT,
-                alignItems: 'center', justifyContent: 'center',
-                opacity: submitting ? 0.5 : pressed ? 0.85 : 1,
-              })}
-            >
-              {submitting ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <Text style={{ ...TextStyles.button, color: '#fff' }}>Create Trip</Text>
-              )}
-            </Pressable>
-          </ScrollView>
-          </View>
         </View>
       </KeyboardAvoidingView>
     </Modal>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": false,
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { useTrips, saveAnonTripId } from './useTrips';
 export { useHomeScreen } from './useHomeScreen';
 export { useExploreRows } from './useExploreRows';

--- a/packages/shared/src/hooks/useTripPlanner.ts
+++ b/packages/shared/src/hooks/useTripPlanner.ts
@@ -1,11 +1,10 @@
 import { useState, useCallback, useRef } from 'react';
 
 // On web: use our own API proxy routes (relative URLs, no prefix needed)
-// On mobile: use the backend API directly, falling back to web proxy
+// On mobile: use the web proxy (Next.js API routes for extract/plan), NOT the backend API
 const IS_WEB = typeof (globalThis as any).document !== 'undefined' && !process.env.EXPO_PUBLIC_SUPABASE_URL;
-const BACKEND_API = process.env.EXPO_PUBLIC_RECOMMENDATION_API_URL ?? process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL;
 const WEB_PROXY = process.env.EXPO_PUBLIC_WEB_API_URL;
-const API_URL = IS_WEB ? '' : (BACKEND_API ?? WEB_PROXY);
+const API_URL = IS_WEB ? '' : (WEB_PROXY ?? '');
 
 // Mirrors backend schemas
 export interface FollowUpQuestion {

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -687,7 +687,8 @@ export async function savePlanToSupabase(
   // Fire enrichment in the background (fills wiki, news, phrases, cuisine, cost_of_living, etc.)
   onProgress?.('Enriching trip details...', 95)
   try {
-    const enrichRes = await fetch('/api/trips/enrich', {
+    const enrichBase = process.env.EXPO_PUBLIC_WEB_API_URL || ''
+    const enrichRes = await fetch(`${enrichBase}/api/trips/enrich`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tripId }),

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -684,6 +684,20 @@ export async function savePlanToSupabase(
     if (actErr) console.error('Failed to save activities:', actErr)
   }
 
+  // Fire enrichment in the background (fills wiki, news, phrases, cuisine, cost_of_living, etc.)
+  onProgress?.('Enriching trip details...', 95)
+  try {
+    const enrichRes = await fetch('/api/trips/enrich', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tripId }),
+    })
+    if (!enrichRes.ok) console.error('Enrichment failed:', enrichRes.status)
+  } catch (e) {
+    // Non-blocking — overview page will auto-enrich on first visit as fallback
+    console.error('Enrichment error:', e)
+  }
+
   onProgress?.('Done!', 100)
   return tripId
 }

--- a/packages/shared/src/stores/index.ts
+++ b/packages/shared/src/stores/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { useAuthStore } from './authStore';
 export { useSettingsStore } from './settingsStore';
 export type { Currency, DistanceUnits, TravelStyle } from './settingsStore';


### PR DESCRIPTION
## Summary
- **TRA-393**: CreateTripModal rewritten — AI trip planner replaces manual CRUD form. Natural language input → extraction → clarifying questions → full plan with hotels/flights/itinerary
- **TRA-394**: Homepage aligned with web — direct AI search (no 5-step conversation), destination autocomplete, live stats from /api/stats, error banner
- **TRA-395**: react-native-maps conditional import to prevent Metro web bundle crash
- **TRA-385**: Budget expenses persist to trip_context.budget_data
- **TRA-387**: Favorites persist via AsyncStorage
- **TRA-391**: Hotels "Other Hotels" section uses real trip_context data instead of hardcoded mocks
- useTripPlanner API URL fix — uses EXPO_PUBLIC_WEB_API_URL for mobile
- savePlanToSupabase enrichment URL prefix for mobile
- Includes Amplify build fix + auto-enrich at creation

## Test plan
- [ ] Trip generation from homepage search — type prompt, see animation, navigate to trip
- [ ] Trip generation from CreateTripModal — natural language input with clarifying questions
- [ ] Budget expenses survive app restart
- [ ] Favorites persist across sessions
- [ ] Hotels tab shows real trip_context data
- [ ] Web bundle (Expo web) doesn't crash on react-native-maps