### PR TITLE
Fix(TRA-403): Route OAuth redirects to correct domain (dev vs prod)

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/'
+
+  if (code) {
+    const res = NextResponse.redirect(`${origin}${next}`)
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll()
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              res.cookies.set(name, value, options)
+            })
+          },
+        },
+      }
+    )
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return res
+    }
+  }
+
+  // Auth code exchange failed — redirect to login with error
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -78,7 +78,11 @@ function LoginPageInner() {
 
   const handleSocialSignIn = async (provider: 'google' | 'facebook' | 'azure' | 'apple') => {
     setError('');
-    const { error } = await supabase.auth.signInWithOAuth({ provider });
+    const redirectTo = `${window.location.origin}/auth/callback`;
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo },
+    });
     if (error) setError(error.message);
   };
 

--- a/packages/shared/src/stores/authStore.ts
+++ b/packages/shared/src/stores/authStore.ts
@@ -9,7 +9,7 @@ interface AuthState {
   initialize: () => () => void;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string, name?: string) => Promise<void>;
-  signInWithOAuth: (provider: 'google' | 'apple' | 'facebook') => Promise<void>;
+  signInWithOAuth: (provider: 'google' | 'apple' | 'facebook', redirectTo?: string) => Promise<void>;
   signOut: () => Promise<void>;
 }
 
@@ -60,9 +60,12 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
 
-  signInWithOAuth: async (provider) => {
+  signInWithOAuth: async (provider, redirectTo?) => {
     if (!supabase) throw new Error('Supabase is not configured');
-    await supabase.auth.signInWithOAuth({ provider });
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: redirectTo ? { redirectTo } : undefined,
+    });
   },
 
   signOut: async () => {

--- a/planning/TRA-403.md
+++ b/planning/TRA-403.md
@@ -1,0 +1,32 @@
+# TRA-403: Fix Auth Routing (Dev vs Prod)
+
+## Goal
+OAuth and auth flows should redirect back to the correct domain — `dev.gotravyl.com` when on dev, `gotravyl.com` when on prod.
+
+## Problem
+`signInWithOAuth()` did not pass a `redirectTo` URL, so Supabase used its default site URL (prod) regardless of which domain the user was on.
+
+## Solution
+1. Pass `redirectTo: ${window.location.origin}/auth/callback` in all OAuth calls
+2. Created `/auth/callback` server route that exchanges PKCE code for session
+3. Updated shared `authStore.signInWithOAuth` to accept optional `redirectTo` parameter
+
+## Manual Step Required
+Add these URLs to Supabase dashboard (Authentication > URL Configuration > Redirect URLs):
+- `https://gotravyl.com/auth/callback`
+- `https://dev.gotravyl.com/auth/callback`
+- `http://localhost:3000/auth/callback`
+
+## Files Changed
+- `apps/web/app/auth/callback/route.ts` — new PKCE callback route
+- `apps/web/app/login/page.tsx` — added `redirectTo` to OAuth call
+- `packages/shared/src/stores/authStore.ts` — added optional `redirectTo` param to `signInWithOAuth`
+
+## Linear
+https://linear.app/travyl/issue/TRA-403
+
+## Verification
+- Typecheck passes (web + shared)
+- Playwright confirmed: dev.gotravyl.com currently sends no `redirect_to` (bug)
+- Playwright confirmed: local build with fix sends `redirect_to=http://localhost:3000/auth/callback` (fix working)
+- `/auth/callback` returns 307 redirect to `/login?error=auth_callback_failed` when no code (correct error path)


### PR DESCRIPTION
## Summary
- Add dynamic `redirectTo` to OAuth calls using `window.location.origin` so auth flows return to the correct domain (dev.gotravyl.com vs gotravyl.com)
- Create `/auth/callback` server route for PKCE code exchange after OAuth
- Update shared `authStore.signInWithOAuth` to accept optional `redirectTo` parameter

## Manual Step Required
Add these redirect URLs in Supabase dashboard (Authentication > URL Configuration > Redirect URLs):
- `https://gotravyl.com/auth/callback`
- `https://dev.gotravyl.com/auth/callback`
- `http://localhost:3000/auth/callback`

## Test Plan
- [x] Typecheck passes (web + shared)
- [x] Playwright verified: dev.gotravyl.com currently sends no `redirect_to` param (bug confirmed)
- [x] Playwright verified: local build with fix sends `redirect_to=http://localhost:3000/auth/callback` (fix confirmed)
- [x] `/auth/callback` route returns 307 to `/login?error=auth_callback_failed` when no code present (error path works)
- [ ] After Supabase dashboard config: full Google OAuth flow on dev.gotravyl.com redirects back to dev
- [ ] After Supabase dashboard config: full Google OAuth flow on gotravyl.com redirects back to prod

Closes TRA-403