### PR TITLE
Restyle trip pages: Unified app shell layout (TRA-404)

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/activities/[activityId]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/activities/[activityId]/page.tsx
@@ -44,16 +44,16 @@ export default function ActivityDetailPage({
   if (isLoading) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-6 pb-24 animate-pulse">
-        <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
-        <div className="h-8 w-2/3 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-5 w-20 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
-        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-56 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-36 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-32 bg-gray-200 dark:bg-white/[0.06] rounded mb-4" />
+        <div className="h-8 w-2/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-5 w-20 bg-gray-200 dark:bg-white/[0.06] rounded mb-2" />
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-40 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-56 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-36 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-48 bg-gray-200 dark:bg-white/[0.06] rounded" />
       </div>
     )
   }
@@ -109,8 +109,8 @@ export default function ActivityDetailPage({
       />
 
       {/* Overview */}
-      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100 dark:border-white/[0.06]">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">
           {activity.name}
         </h1>
 

--- a/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
@@ -251,7 +251,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
   return (
     <div className="flex flex-col min-h-[60vh]">
       {/* Sticky header */}
-      <div className="sticky top-0 z-30 bg-white/95 dark:bg-[var(--background)]/95 backdrop-blur-md border-b border-gray-100 dark:border-white/10">
+      <div className="sticky top-0 z-30 bg-white/95 dark:bg-[color-mix(in_srgb,var(--background)_95%,transparent)] backdrop-blur-md border-b border-gray-100 dark:border-white/[0.08]">
         {/* Row 1: Tabs */}
         <div className="px-4 pt-2 pb-0 overflow-x-auto scrollbar-hide">
           <div className="flex gap-0 -mb-px">
@@ -262,7 +262,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
                 className={`flex items-center gap-1.5 px-3 py-2 text-[12px] whitespace-nowrap border-b-2 transition-all shrink-0 ${
                   activeTab === key
                     ? 'font-semibold'
-                    : 'border-transparent text-gray-400 hover:text-gray-600'
+                    : 'border-transparent text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'
                 }`}
                 style={activeTab === key ? { borderColor: 'var(--trip-base)', color: 'var(--trip-base)' } : undefined}
               >
@@ -276,17 +276,17 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
         {/* Row 2: Search + Controls */}
         <div className="px-4 py-2 flex items-center gap-3">
           <div className="relative flex-1 min-w-0 max-w-xs">
-            <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+            <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
             <input
               type="text"
               placeholder={`Search ${destination}...`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-8 pr-8 py-1.5 bg-gray-50 dark:bg-white/10 border border-gray-200 dark:border-white/10 rounded-full text-[12px] text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 transition-all"
+              className="w-full pl-8 pr-8 py-1.5 bg-gray-50 dark:bg-white/[0.06] border border-gray-200 dark:border-white/[0.08] rounded-full text-[12px] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 transition-all"
               style={{ '--tw-ring-color': 'var(--trip-base)' } as any}
             />
             {searchQuery && (
-              <button onClick={() => setSearchQuery('')} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+              <button onClick={() => setSearchQuery('')} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">
                 <X size={12} />
               </button>
             )}
@@ -296,7 +296,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortKey)}
-              className="text-[11px] px-2 py-1.5 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-gray-600 dark:text-gray-300 focus:outline-none cursor-pointer"
+              className="text-[11px] px-2 py-1.5 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] text-gray-600 dark:text-gray-300 focus:outline-none cursor-pointer"
             >
               <option value="default">Default</option>
               <option value="rating">Top Rated</option>
@@ -309,7 +309,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
                   className={`w-7 h-7 rounded-md text-[11px] font-semibold transition-all ${
                     columnCount === n
                       ? 'bg-white dark:bg-white/20 text-gray-900 dark:text-white shadow-sm'
-                      : 'text-gray-400 hover:text-gray-600'
+                      : 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'
                   }`}>
                   {n}
                 </button>
@@ -321,7 +321,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
               className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-all ${
                 flush
                   ? 'bg-gray-900 dark:bg-white/90 text-white dark:text-gray-900'
-                  : 'bg-gray-100 dark:bg-white/10 text-gray-500 hover:bg-gray-200 dark:hover:bg-white/15'
+                  : 'bg-gray-100 dark:bg-white/10 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/15'
               }`}
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -343,7 +343,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
               className={`px-3 py-1 rounded-full text-[11px] font-medium whitespace-nowrap shrink-0 transition-all ${
                 !activeSubcategory
                   ? 'text-white shadow-sm'
-                  : 'bg-gray-100 dark:bg-white/10 text-gray-500 hover:bg-gray-200 dark:hover:bg-white/15'
+                  : 'bg-gray-100 dark:bg-white/10 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/15'
               }`}
               style={!activeSubcategory ? { backgroundColor: 'var(--trip-base)' } : undefined}
             >
@@ -356,7 +356,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
                 className={`px-3 py-1 rounded-full text-[11px] font-medium whitespace-nowrap shrink-0 transition-all ${
                   activeSubcategory === label
                     ? 'text-white shadow-sm'
-                    : 'bg-gray-100 dark:bg-white/10 text-gray-500 hover:bg-gray-200 dark:hover:bg-white/15'
+                    : 'bg-gray-100 dark:bg-white/10 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/15'
                 }`}
                 style={activeSubcategory === label ? { backgroundColor: 'var(--trip-base)' } : undefined}
               >
@@ -373,7 +373,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
           <h2 className="text-lg font-bold text-gray-900 dark:text-white" style={{ color: 'var(--trip-base)' }}>
             Explore {destination}
           </h2>
-          <p className="text-[12px] text-gray-400">{filtered.length} places to discover</p>
+          <p className="text-[12px] text-gray-400 dark:text-gray-500">{filtered.length} places to discover</p>
         </div>
       </div>
 
@@ -388,7 +388,7 @@ export default function ExplorePage({ params }: { params: Promise<{ id: string }
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <Search size={32} className="text-gray-300 dark:text-gray-600 mb-3" />
-            <p className="text-sm text-gray-500">No places found</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">No places found</p>
             <button
               onClick={() => { setSearchQuery(''); setActiveSubcategory(''); setActiveTab('all'); }}
               className="text-xs mt-2 hover:underline"

--- a/apps/web/app/(dashboard)/trip/[id]/budget/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/budget/page.tsx
@@ -329,7 +329,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
 
   /* ---- render ---- */
   return (
-    <div className="bg-white dark:bg-[var(--background)] rounded-xl border border-gray-200 dark:border-white/[0.08] shadow-sm overflow-hidden p-4 space-y-4">
+    <div className="space-y-4">
       {/* ===== Summary Cards (3-column) ===== */}
       <div className="grid grid-cols-3 gap-2">
         {/* Total Budget — editable */}

--- a/apps/web/app/(dashboard)/trip/[id]/budget/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/budget/page.tsx
@@ -58,19 +58,19 @@ const CATEGORY_ICONS: Record<string, LucideIcon> = {
 };
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; bar: string; bgStyle?: React.CSSProperties; textStyle?: React.CSSProperties; barStyle?: React.CSSProperties }> = {
-  Flights:         { bg: 'bg-blue-100',       text: 'text-blue-600',     bar: 'bg-blue-500' },
-  Hotels:          { bg: 'bg-orange-100',      text: 'text-orange-600',   bar: 'bg-orange-500' },
+  Flights:         { bg: 'bg-blue-100 dark:bg-blue-500/15',       text: 'text-blue-600 dark:text-blue-400',     bar: 'bg-blue-500' },
+  Hotels:          { bg: 'bg-orange-100 dark:bg-orange-500/15',   text: 'text-orange-600 dark:text-orange-400',  bar: 'bg-orange-500' },
   'Food & Dining': { bg: '',                   text: '',                  bar: '',
                      bgStyle: { backgroundColor: 'rgb(var(--trip-base-rgb) / 0.1)' },
                      textStyle: { color: 'var(--trip-base)' },
                      barStyle: { backgroundColor: 'var(--trip-base)' } },
-  Activities:      { bg: 'bg-teal-100',        text: 'text-teal-600',     bar: 'bg-teal-500' },
-  Transportation:  { bg: 'bg-purple-100',      text: 'text-purple-600',   bar: 'bg-purple-500' },
-  Shopping:        { bg: 'bg-green-100',        text: 'text-green-600',    bar: 'bg-green-500' },
-  Other:           { bg: 'bg-gray-100',        text: 'text-gray-600',     bar: 'bg-gray-500' },
+  Activities:      { bg: 'bg-teal-100 dark:bg-teal-500/15',      text: 'text-teal-600 dark:text-teal-400',     bar: 'bg-teal-500' },
+  Transportation:  { bg: 'bg-purple-100 dark:bg-purple-500/15',   text: 'text-purple-600 dark:text-purple-400',  bar: 'bg-purple-500' },
+  Shopping:        { bg: 'bg-green-100 dark:bg-green-500/15',     text: 'text-green-600 dark:text-green-400',    bar: 'bg-green-500' },
+  Other:           { bg: 'bg-gray-100 dark:bg-gray-500/15',      text: 'text-gray-600 dark:text-gray-400',     bar: 'bg-gray-500' },
 };
 
-const DEFAULT_COLORS: typeof CATEGORY_COLORS[string] = { bg: 'bg-gray-100', text: 'text-gray-600', bar: 'bg-gray-500' };
+const DEFAULT_COLORS: typeof CATEGORY_COLORS[string] = { bg: 'bg-gray-100 dark:bg-gray-500/15', text: 'text-gray-600 dark:text-gray-400', bar: 'bg-gray-500' };
 
 /* ------------------------------------------------------------------ */
 /*  Skeleton                                                           */
@@ -81,18 +81,18 @@ function BudgetSkeleton() {
     <div>
       <div className="grid grid-cols-3 gap-3 mb-4">
         {['Total Budget', 'Total Spent', 'Remaining'].map((label) => (
-          <div key={label} className="rounded-lg p-3 border border-gray-200 bg-white">
-            <p className="text-[10px] text-gray-600 uppercase tracking-wide">{label}</p>
+          <div key={label} className="rounded-xl p-3 border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03]">
+            <p className="text-[10px] text-gray-600 dark:text-gray-400 uppercase tracking-wide">{label}</p>
             <Skeleton className="h-6 w-16 mt-1.5" />
           </div>
         ))}
       </div>
-      <div className="bg-gray-200 rounded-full h-2.5 mb-6 overflow-hidden">
+      <div className="bg-gray-200 dark:bg-white/[0.08] rounded-full h-2.5 mb-6 overflow-hidden">
         <div className="h-full rounded-full" style={{ width: '65%', backgroundColor: 'var(--trip-base)' }} />
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="rounded-lg p-3.5 border border-gray-200 bg-white">
+          <div key={i} className="rounded-xl p-3.5 border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03]">
             <div className="flex items-center justify-between mb-2.5">
               <div className="flex items-center gap-2.5">
                 <Skeleton className="w-9 h-9 rounded-[10px]" />
@@ -117,23 +117,20 @@ function BudgetSkeleton() {
 
 /** Dynamic background class based on budget health percentage. */
 function healthBg(pct: number) {
-  if (pct >= 100) return 'bg-red-50 border-red-200';
-  if (pct >= 90)  return 'bg-amber-50 border-amber-200';
-  if (pct >= 75)  return 'bg-blue-50 border-blue-200';
-  return 'bg-white border-gray-200';
+  if (pct >= 100) return 'bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20';
+  if (pct >= 90)  return 'bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20';
+  if (pct >= 75)  return 'bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/20';
+  return 'bg-white dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08]';
 }
 
 /** Per-category card background (green when healthy). */
 function categoryHealthBg(pct: number): { className: string; style?: React.CSSProperties } {
-  if (pct >= 100) return { className: 'bg-red-50 border-red-200' };
-  if (pct >= 90)  return { className: 'bg-amber-50 border-amber-200' };
-  if (pct >= 75)  return { className: 'bg-blue-50 border-blue-200' };
+  if (pct >= 100) return { className: 'bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20' };
+  if (pct >= 90)  return { className: 'bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20' };
+  if (pct >= 75)  return { className: 'bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/20' };
   return {
-    className: 'border',
-    style: {
-      backgroundColor: 'rgb(var(--trip-base-rgb) / 0.05)',
-      borderColor: 'rgb(var(--trip-base-rgb) / 0.2)',
-    },
+    className: 'border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03]',
+    style: {},
   };
 }
 
@@ -333,16 +330,16 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
       {/* ===== Summary Cards (3-column) ===== */}
       <div className="grid grid-cols-3 gap-2">
         {/* Total Budget — editable */}
-        <div className={`${overallBg} rounded-lg p-2 transition-colors`}>
+        <div className={`${overallBg} rounded-xl p-2 transition-colors`}>
           <div className="flex items-center justify-between mb-0.5">
-            <span className="text-[10px] sm:text-xs text-gray-600">Total Budget</span>
+            <span className="text-[10px] sm:text-xs text-gray-600 dark:text-gray-400">Total Budget</span>
             {!isEditingTotal ? (
               <button
                 onClick={() => {
                   setIsEditingTotal(true);
                   setTempTotal(totalBudgeted.toString());
                 }}
-                className="text-gray-400 hover:text-gray-600"
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
               >
                 <Edit2 size={12} />
               </button>
@@ -350,13 +347,13 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
               <div className="flex items-center gap-1">
                 <button
                   onClick={handleSaveTotalBudget}
-                  className="text-emerald-600 hover:text-emerald-700"
+                  className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
                 >
                   <Check size={12} />
                 </button>
                 <button
                   onClick={() => setIsEditingTotal(false)}
-                  className="text-gray-400 hover:text-gray-600"
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                 >
                   <X size={12} />
                 </button>
@@ -364,7 +361,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
             )}
           </div>
           {!isEditingTotal ? (
-            <div className="text-base sm:text-xl font-bold text-gray-900">
+            <div className="text-base sm:text-xl font-bold text-gray-900 dark:text-white">
               {formatHome(totalBudgeted, tripCurrency)}
             </div>
           ) : (
@@ -372,23 +369,23 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
               type="number"
               value={tempTotal}
               onChange={(e) => setTempTotal(e.target.value)}
-              className="w-full px-2 py-1 border border-gray-300 rounded text-sm font-bold"
+              className="w-full px-2 py-1 border border-gray-300 dark:border-white/[0.12] rounded text-sm font-bold bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white"
               autoFocus
             />
           )}
         </div>
 
         {/* Total Spent */}
-        <div className={`${overallBg} rounded-lg p-2 transition-colors`}>
-          <span className="text-[10px] sm:text-xs text-gray-600 block mb-0.5">Total Spent</span>
-          <div className="text-base sm:text-xl font-bold text-gray-900">
+        <div className={`${overallBg} rounded-xl p-2 transition-colors`}>
+          <span className="text-[10px] sm:text-xs text-gray-600 dark:text-gray-400 block mb-0.5">Total Spent</span>
+          <div className="text-base sm:text-xl font-bold text-gray-900 dark:text-white">
             {formatHome(totalActual, tripCurrency)}
           </div>
         </div>
 
         {/* Remaining */}
-        <div className={`${overallBg} rounded-lg p-2 transition-colors`}>
-          <span className="text-[10px] sm:text-xs text-gray-600 block mb-0.5">Remaining</span>
+        <div className={`${overallBg} rounded-xl p-2 transition-colors`}>
+          <span className="text-[10px] sm:text-xs text-gray-600 dark:text-gray-400 block mb-0.5">Remaining</span>
           <div
             className={`text-base sm:text-xl font-bold ${
               remaining >= 0 ? 'text-emerald-600' : 'text-red-600'
@@ -400,12 +397,12 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
       </div>
 
       {/* ===== Overall Progress Bar ===== */}
-      <div className={`${overallBg} rounded-lg p-3 transition-colors`}>
+      <div className={`${overallBg} rounded-xl p-3 transition-colors`}>
         <div className="flex items-center justify-between mb-2">
-          <span className="text-sm font-medium text-gray-700">Budget Progress</span>
-          <span className="text-sm font-semibold text-gray-900">{pctUsed.toFixed(1)}%</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Budget Progress</span>
+          <span className="text-sm font-semibold text-gray-900 dark:text-white">{pctUsed.toFixed(1)}%</span>
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">
+        <div className="w-full bg-gray-200 dark:bg-white/[0.08] rounded-full h-2.5 overflow-hidden">
           <div
             className={`h-full transition-all duration-300 ${
               pctUsed > 100
@@ -445,7 +442,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
           return (
             <div
               key={item.id}
-              className={`${healthResult.className} rounded-lg hover:shadow-md transition-shadow ${
+              className={`${healthResult.className} rounded-xl hover:shadow-md dark:hover:shadow-none transition-shadow ${
                 isExpanded ? 'p-4' : 'p-3'
               }`}
               style={healthResult.style}
@@ -460,9 +457,9 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                     <Icon size={18} />
                   </div>
                   <div>
-                    <div className="font-semibold text-gray-900 text-left">{item.category}</div>
+                    <div className="font-semibold text-gray-900 dark:text-white text-left">{item.category}</div>
                     {!isExpanded && (
-                      <div className="text-sm text-gray-600">
+                      <div className="text-sm text-gray-600 dark:text-gray-400">
                         {formatHome(item.budgeted, tripCurrency)}
                       </div>
                     )}
@@ -476,14 +473,14 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                         e.stopPropagation();
                         handleStartEdit(item);
                       }}
-                      className="p-1 text-gray-400 hover:text-gray-600"
+                      className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
                       <Edit2 size={14} />
                     </button>
                   )}
                   {!isEditing && (
                     <ChevronDown
-                      className={`w-5 h-5 text-gray-400 transition-transform ${
+                      className={`w-5 h-5 text-gray-400 dark:text-gray-500 transition-transform ${
                         isExpanded ? 'rotate-180' : ''
                       }`}
                     />
@@ -508,32 +505,32 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                           {/* Budgeted / Actual */}
                           <div className="grid grid-cols-2 gap-3 mb-3">
                             <div>
-                              <div className="text-xs text-gray-600 mb-1">Budgeted</div>
-                              <div className="text-lg font-bold text-gray-900">
+                              <div className="text-xs text-gray-600 dark:text-gray-400 mb-1">Budgeted</div>
+                              <div className="text-lg font-bold text-gray-900 dark:text-white">
                                 {formatHome(item.budgeted, tripCurrency)}
                               </div>
                             </div>
                             <div>
                               <div className="flex items-center justify-between mb-1">
-                                <div className="text-xs text-gray-600">Actual</div>
+                                <div className="text-xs text-gray-600 dark:text-gray-400">Actual</div>
                                 <div className="flex items-center gap-1">
                                   <button
                                     onClick={() => handleStartEdit(item)}
-                                    className="p-1 text-gray-400 hover:text-gray-600"
+                                    className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                                   >
                                     <Edit2 size={14} />
                                   </button>
                                   {!item.fixed && (
                                     <button
                                       onClick={() => handleDeleteCategory(item.id)}
-                                      className="p-1 text-gray-400 hover:text-red-600"
+                                      className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
                                     >
                                       <Trash2 size={14} />
                                     </button>
                                   )}
                                 </div>
                               </div>
-                              <div className="text-lg font-bold text-gray-900">
+                              <div className="text-lg font-bold text-gray-900 dark:text-white">
                                 {formatHome(item.actual, tripCurrency)}
                               </div>
                             </div>
@@ -541,7 +538,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
 
                           {/* Category progress bar */}
                           <div className="mb-2">
-                            <div className="w-full bg-white rounded-full h-2 overflow-hidden">
+                            <div className="w-full bg-gray-200 dark:bg-white/[0.08] rounded-full h-2 overflow-hidden">
                               <div
                                 className={`h-full transition-all ${progressBar}`}
                                 style={{ width: `${Math.min(itemPct, 100)}%`, ...progressBarStyle }}
@@ -551,35 +548,35 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
 
                           {/* Under / over indicator */}
                           <div className="flex items-center justify-between text-xs mb-3">
-                            <span className="text-gray-600">{itemPct.toFixed(0)}% used</span>
+                            <span className="text-gray-600 dark:text-gray-400">{itemPct.toFixed(0)}% used</span>
                             {itemDiff > 0 ? (
-                              <span className="text-emerald-600 font-medium">
+                              <span className="text-emerald-600 dark:text-emerald-400 font-medium">
                                 {formatHome(itemDiff, tripCurrency)} under
                               </span>
                             ) : itemDiff < 0 ? (
-                              <span className="text-red-600 font-medium">
+                              <span className="text-red-600 dark:text-red-400 font-medium">
                                 {formatHome(Math.abs(itemDiff), tripCurrency)} over
                               </span>
                             ) : (
-                              <span className="text-gray-600">On track</span>
+                              <span className="text-gray-600 dark:text-gray-400">On track</span>
                             )}
                           </div>
 
                           {/* Expenses section */}
-                          <div className="mt-3 pt-3 border-t border-gray-200">
+                          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-white/[0.08]">
                             {item.expenses && item.expenses.length > 0 && (
                               <div className="mb-3">
                                 {/* Collapsible expenses header */}
                                 <button
                                   onClick={() => toggleExpenses(item.id)}
-                                  className="w-full flex items-center justify-between mb-2 hover:bg-white/50 rounded px-2 py-1 transition-colors"
+                                  className="w-full flex items-center justify-between mb-2 hover:bg-white/50 dark:hover:bg-white/[0.04] rounded px-2 py-1 transition-colors"
                                 >
-                                  <div className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+                                  <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
                                     {item.expenses.length}{' '}
                                     {item.expenses.length === 1 ? 'Expense' : 'Expenses'}
                                   </div>
                                   <ChevronDown
-                                    className={`w-5 h-5 text-gray-500 transition-transform ${
+                                    className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${
                                       expandedExpenses.has(item.id) ? 'rotate-180' : ''
                                     }`}
                                   />
@@ -600,22 +597,22 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                                         {item.expenses.map((expense) => (
                                           <div
                                             key={expense.id}
-                                            className="group flex items-start justify-between bg-white px-3 py-2 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors"
+                                            className="group flex items-start justify-between bg-white dark:bg-white/[0.04] px-3 py-2 rounded-lg border border-gray-200 dark:border-white/[0.08] hover:border-gray-300 dark:hover:border-white/[0.15] transition-colors"
                                           >
                                             <div className="flex-1 min-w-0 mr-3">
-                                              <p className="text-xs text-gray-800 leading-relaxed">
+                                              <p className="text-xs text-gray-800 dark:text-gray-300 leading-relaxed">
                                                 {expense.description}
                                               </p>
                                             </div>
                                             <div className="flex items-center gap-2 flex-shrink-0">
-                                              <span className="text-sm font-semibold text-gray-900">
+                                              <span className="text-sm font-semibold text-gray-900 dark:text-white">
                                                 {formatHome(expense.amount, tripCurrency)}
                                               </span>
                                               <button
                                                 onClick={() =>
                                                   handleDeleteExpense(item.id, expense.id)
                                                 }
-                                                className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-all"
+                                                className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:text-red-400 dark:hover:bg-red-500/10 rounded transition-all"
                                                 title="Delete expense"
                                               >
                                                 <Trash2 size={12} />
@@ -632,29 +629,29 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
 
                             {/* Add expense form / button */}
                             {addingExpenseFor === item.id ? (
-                              <div className="space-y-2.5 bg-white p-3 rounded-lg border border-gray-200 shadow-sm">
+                              <div className="space-y-2.5 bg-white dark:bg-white/[0.04] p-3 rounded-lg border border-gray-200 dark:border-white/[0.08] shadow-sm">
                                 <div>
-                                  <label className="text-xs font-medium text-gray-700 mb-1.5 block">
+                                  <label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
                                     Description
                                   </label>
                                   <input
                                     type="text"
                                     value={newExpenseDesc}
                                     onChange={(e) => setNewExpenseDesc(e.target.value)}
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-trip-base focus:border-transparent"
+                                    className="w-full px-3 py-2 border border-gray-300 dark:border-white/[0.12] rounded-lg text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-trip-base focus:border-transparent"
                                     placeholder="e.g., Round trip to Paris"
                                     autoFocus
                                   />
                                 </div>
                                 <div>
-                                  <label className="text-xs font-medium text-gray-700 mb-1.5 block">
+                                  <label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
                                     Amount
                                   </label>
                                   <input
                                     type="number"
                                     value={newExpenseAmount}
                                     onChange={(e) => setNewExpenseAmount(e.target.value)}
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-trip-base focus:border-transparent"
+                                    className="w-full px-3 py-2 border border-gray-300 dark:border-white/[0.12] rounded-lg text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-trip-base focus:border-transparent"
                                     placeholder="0.00"
                                   />
                                 </div>
@@ -672,7 +669,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                                       setNewExpenseDesc('');
                                       setNewExpenseAmount('');
                                     }}
-                                    className="flex-1 px-3 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 text-sm font-medium transition-colors"
+                                    className="flex-1 px-3 py-2 bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.10] text-sm font-medium transition-colors"
                                   >
                                     Cancel
                                   </button>
@@ -681,7 +678,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                             ) : (
                               <button
                                 onClick={() => setAddingExpenseFor(item.id)}
-                                className="w-full px-3 py-2 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-gray-400 text-sm font-medium flex items-center justify-center gap-2 transition-colors"
+                                className="w-full px-3 py-2 bg-white dark:bg-white/[0.04] text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-white/[0.12] rounded-lg hover:bg-gray-50 dark:hover:bg-white/[0.08] hover:border-gray-400 dark:hover:border-white/[0.20] text-sm font-medium flex items-center justify-center gap-2 transition-colors"
                               >
                                 <Plus size={14} />
                                 Add Expense
@@ -693,12 +690,12 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                         /* Editing budgeted amount */
                         <div className="space-y-2">
                           <div>
-                            <label className="text-xs text-gray-600 mb-1 block">Budgeted</label>
+                            <label className="text-xs text-gray-600 dark:text-gray-400 mb-1 block">Budgeted</label>
                             <input
                               type="number"
                               value={tempBudgeted}
                               onChange={(e) => setTempBudgeted(e.target.value)}
-                              className="w-full px-3 py-1.5 border border-gray-300 rounded text-sm bg-white"
+                              className="w-full px-3 py-1.5 border border-gray-300 dark:border-white/[0.12] rounded text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
                               placeholder="0.00"
                             />
                           </div>
@@ -712,7 +709,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                             </button>
                             <button
                               onClick={handleCancelEdit}
-                              className="flex-1 px-3 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 text-sm font-medium transition-colors"
+                              className="flex-1 px-3 py-2 bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.10] text-sm font-medium transition-colors"
                             >
                               Cancel
                             </button>
@@ -731,17 +728,17 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
         {!showAddCategory ? (
           <button
             onClick={() => setShowAddCategory(true)}
-            className="border-2 border-dashed border-gray-300 rounded-lg p-4 hover:border-trip-base hover:bg-trip-base/5 transition-colors flex flex-col items-center justify-center gap-2 min-h-[200px]"
+            className="border-2 border-dashed border-gray-300 dark:border-white/[0.12] rounded-xl p-4 hover:border-trip-base dark:hover:border-trip-base hover:bg-trip-base/5 transition-colors flex flex-col items-center justify-center gap-2 min-h-[200px]"
           >
-            <Plus size={24} className="text-gray-400" />
-            <span className="text-sm font-medium text-gray-600">Add Category</span>
+            <Plus size={24} className="text-gray-400 dark:text-gray-500" />
+            <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Add Category</span>
           </button>
         ) : (
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.2 }}
-            className="rounded-lg border-2 p-4"
+            className="rounded-xl border-2 p-4"
             style={{
               backgroundColor: 'rgb(var(--trip-base-rgb) / 0.05)',
               borderColor: 'rgb(var(--trip-base-rgb) / 0.3)',
@@ -749,39 +746,39 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
           >
             <div className="space-y-3">
               <div>
-                <label className="text-xs text-gray-700 mb-1 block font-medium">
+                <label className="text-xs text-gray-700 dark:text-gray-300 mb-1 block font-medium">
                   Category Name
                 </label>
                 <input
                   type="text"
                   value={newCategory}
                   onChange={(e) => setNewCategory(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-white/[0.12] rounded text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
                   placeholder="e.g., Insurance"
                   autoFocus
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-700 mb-1 block font-medium">
+                <label className="text-xs text-gray-700 dark:text-gray-300 mb-1 block font-medium">
                   Budgeted Amount
                 </label>
                 <input
                   type="number"
                   value={newBudgeted}
                   onChange={(e) => setNewBudgeted(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-white/[0.12] rounded text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
                   placeholder="0.00"
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-700 mb-1 block font-medium">
+                <label className="text-xs text-gray-700 dark:text-gray-300 mb-1 block font-medium">
                   Actual Spent
                 </label>
                 <input
                   type="number"
                   value={newActual}
                   onChange={(e) => setNewActual(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-white/[0.12] rounded text-sm bg-white dark:bg-white/[0.06] text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500"
                   placeholder="0.00"
                 />
               </div>
@@ -800,7 +797,7 @@ export default function Budget({ params }: { params: Promise<{ id: string }> }) 
                     setNewBudgeted('');
                     setNewActual('');
                   }}
-                  className="flex-1 px-3 py-2 bg-white text-gray-700 rounded hover:bg-gray-100 text-sm font-medium border border-gray-300"
+                  className="flex-1 px-3 py-2 bg-white dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 rounded hover:bg-gray-100 dark:hover:bg-white/[0.10] text-sm font-medium border border-gray-300 dark:border-white/[0.12]"
                 >
                   Cancel
                 </button>

--- a/apps/web/app/(dashboard)/trip/[id]/cars/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/cars/page.tsx
@@ -5,14 +5,14 @@ import { Car, Plus } from 'lucide-react';
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-16 px-6">
-      <div className="w-14 h-14 rounded-full flex items-center justify-center mb-4" style={{ backgroundColor: '#47556915' }}>
-        <Car size={24} style={{ color: '#475569' }} />
+      <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-white/[0.06] flex items-center justify-center mb-4">
+        <Car size={24} className="text-gray-400 dark:text-gray-500" />
       </div>
-      <h3 className="text-[17px] font-bold text-gray-900 mb-1.5">No car rentals yet</h3>
-      <p className="text-[13px] text-gray-500 text-center leading-5 mb-5">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1.5">No car rentals yet</h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 text-center max-w-xs mb-5">
         Add a car rental to manage your ground transportation for the trip.
       </p>
-      <button className="flex items-center gap-2 text-white px-6 py-3 rounded-xl text-sm font-semibold hover:opacity-90 transition-opacity" style={{ backgroundColor: '#475569' }}>
+      <button className="flex items-center gap-2 bg-gray-900 dark:bg-white dark:text-gray-900 text-white px-5 py-2.5 rounded-xl text-sm font-medium hover:opacity-90 transition-opacity">
         <Plus size={12} />
         Add Car Rental
       </button>

--- a/apps/web/app/(dashboard)/trip/[id]/favorites/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/favorites/page.tsx
@@ -10,15 +10,15 @@ import type { DiscoverItem } from '@travyl/shared';
 import { SplitScreenModal } from '@/components/itinerary';
 
 function Skeleton({ className = '', style }: { className?: string; style?: React.CSSProperties }) {
-  return <div className={`rounded bg-gray-200 ${className}`} style={style} />;
+  return <div className={`rounded bg-gray-200 dark:bg-white/[0.08] ${className}`} style={style} />;
 }
 
 function FavoritesSkeleton() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
       {[1, 2, 3].map((i) => (
-        <div key={i} className="rounded-xl border border-gray-200 bg-white overflow-hidden">
-          <div className="h-[140px] bg-gray-100" />
+        <div key={i} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] overflow-hidden">
+          <div className="h-[140px] bg-gray-100 dark:bg-white/[0.05]" />
           <div className="p-3">
             <Skeleton style={{ width: '70%', height: 14 }} />
             <Skeleton className="mt-2" style={{ width: '55%', height: 10 }} />
@@ -49,12 +49,12 @@ function FavoriteCard({
 
   return (
     <div
-      className="bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-all group cursor-pointer relative border border-gray-100"
+      className="bg-white dark:bg-white/[0.03] rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-all group cursor-pointer relative border border-gray-200 dark:border-white/[0.08]"
       onClick={onClick}
     >
       <button
         onClick={(e) => { e.stopPropagation(); onRemove(item.id); }}
-        className="absolute top-3 right-3 z-10 w-8 h-8 bg-white/95 hover:bg-red-50 rounded-full flex items-center justify-center shadow-md transition-all"
+        className="absolute top-3 right-3 z-10 w-8 h-8 bg-white/95 dark:bg-white/[0.1] hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full flex items-center justify-center shadow-md transition-all"
       >
         <Heart size={14} className="fill-red-500 text-red-500" />
       </button>
@@ -68,16 +68,16 @@ function FavoriteCard({
             onError={() => setImgError(true)}
           />
         ) : (
-          <div className="w-full h-full bg-gray-100 flex items-center justify-center">
-            <ImageIcon size={28} className="text-gray-300" />
+          <div className="w-full h-full bg-gray-100 dark:bg-white/[0.05] flex items-center justify-center">
+            <ImageIcon size={28} className="text-gray-300 dark:text-gray-600" />
           </div>
         )}
         <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent" />
 
         {item.rating && (
-          <div className="absolute bottom-2 left-2 flex items-center gap-1 bg-white/80 backdrop-blur-sm px-2 py-0.5 rounded-md shadow-sm">
+          <div className="absolute bottom-2 left-2 flex items-center gap-1 bg-white/80 dark:bg-black/50 backdrop-blur-sm px-2 py-0.5 rounded-md shadow-sm">
             <Star size={10} className="text-amber-400" fill="#fbbf24" />
-            <span className="text-[11px] text-gray-900" style={{ fontWeight: 600 }}>{item.rating.toFixed(1)}</span>
+            <span className="text-[11px] text-gray-900 dark:text-white" style={{ fontWeight: 600 }}>{item.rating.toFixed(1)}</span>
           </div>
         )}
 
@@ -92,14 +92,14 @@ function FavoriteCard({
       </div>
 
       <div className="p-4">
-        <div className="flex items-center gap-1 text-[11px] text-gray-500 mb-1">
-          <MapPin size={10} className="text-gray-400" />
+        <div className="flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400 mb-1">
+          <MapPin size={10} className="text-gray-400 dark:text-gray-500" />
           <span className="truncate">{item.location}</span>
         </div>
-        <h3 className="text-[16px] text-gray-900 mb-1 line-clamp-1" style={{ fontWeight: 700 }}>
+        <h3 className="text-[16px] text-gray-900 dark:text-white mb-1 line-clamp-1" style={{ fontWeight: 700 }}>
           {item.name}
         </h3>
-        <p className="text-[12px] text-gray-500 line-clamp-2 mb-3">{item.description}</p>
+        <p className="text-[12px] text-gray-500 dark:text-gray-400 line-clamp-2 mb-3">{item.description}</p>
 
         <div className="flex flex-wrap gap-1">
           {item.tags.slice(0, 3).map((tag, i) => (
@@ -124,14 +124,14 @@ function FavoriteCard({
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-16 px-6">
-      <div className="w-14 h-14 rounded-full flex items-center justify-center mb-4" style={{ backgroundColor: '#ef444415' }}>
-        <Heart size={24} style={{ color: '#ef4444' }} />
+      <div className="w-14 h-14 rounded-full flex items-center justify-center mb-4 bg-red-500/10">
+        <Heart size={24} className="text-red-500" />
       </div>
-      <h3 className="text-[17px] font-serif font-normal text-gray-900 tracking-wide mb-1.5">No favorites yet</h3>
-      <p className="text-[13px] text-gray-500 text-center leading-5 mb-5">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1.5">No favorites yet</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 text-center leading-5 mb-5">
         Save your favorite activities, restaurants, and places to quickly find them later.
       </p>
-      <div className="flex flex-wrap justify-center gap-3 text-sm text-gray-500">
+      <div className="flex flex-wrap justify-center gap-3 text-sm text-gray-500 dark:text-gray-400">
         <div className="flex items-center gap-1">
           <Camera size={16} className="text-teal-600" />
           <span>Activities</span>
@@ -199,23 +199,23 @@ export default function TripFavorites({ params }: { params: Promise<{ id: string
     <div className="space-y-8">
       {/* Header */}
       <div className="text-center">
-        <div className="inline-flex items-center justify-center w-14 h-14 bg-gradient-to-r from-[#1e3a5f] to-[#2c4f7f] rounded-full mb-3">
+        <div className="inline-flex items-center justify-center w-14 h-14 bg-gradient-to-r from-[#1e3a5f] to-[#2c4f7f] dark:from-[#2c4f7f] dark:to-[#3d6a9f] rounded-full mb-3">
           <Heart size={24} className="text-white fill-white" />
         </div>
-        <h2 className="text-xl font-serif font-normal text-gray-900 tracking-wide mb-1">Your Favorites</h2>
-        <p className="text-sm text-gray-600">{totalFavorites} saved items across all categories</p>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-1">Your Favorites</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{totalFavorites} saved items across all categories</p>
       </div>
 
       {/* Activities Section */}
       {favoritedActivities.length > 0 && (
-        <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200">
+        <div className="bg-white dark:bg-white/[0.03] rounded-xl p-5 shadow-sm border border-gray-200 dark:border-white/[0.08]">
+          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200 dark:border-white/[0.08]">
             <div className="w-10 h-10 bg-gradient-to-r from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
               <Camera size={20} className="text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-serif font-normal text-gray-900 tracking-wide">Activities & Attractions</h2>
-              <p className="text-sm text-gray-600">{favoritedActivities.length} saved</p>
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white">Activities & Attractions</h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{favoritedActivities.length} saved</p>
             </div>
           </div>
 
@@ -235,14 +235,14 @@ export default function TripFavorites({ params }: { params: Promise<{ id: string
 
       {/* Restaurants Section */}
       {favoritedRestaurants.length > 0 && (
-        <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200">
+        <div className="bg-white dark:bg-white/[0.03] rounded-xl p-5 shadow-sm border border-gray-200 dark:border-white/[0.08]">
+          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200 dark:border-white/[0.08]">
             <div className="w-10 h-10 bg-gradient-to-r from-orange-500 to-orange-600 rounded-lg flex items-center justify-center">
               <UtensilsCrossed size={20} className="text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-serif font-normal text-gray-900 tracking-wide">Restaurants & Dining</h2>
-              <p className="text-sm text-gray-600">{favoritedRestaurants.length} saved</p>
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white">Restaurants & Dining</h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{favoritedRestaurants.length} saved</p>
             </div>
           </div>
 
@@ -262,14 +262,14 @@ export default function TripFavorites({ params }: { params: Promise<{ id: string
 
       {/* Saved Destinations */}
       {favoritedDestinations.length > 0 && (
-        <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200">
+        <div className="bg-white dark:bg-white/[0.03] rounded-xl p-5 shadow-sm border border-gray-200 dark:border-white/[0.08]">
+          <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200 dark:border-white/[0.08]">
             <div className="w-10 h-10 bg-gradient-to-r from-amber-500 to-amber-600 rounded-lg flex items-center justify-center">
               <Compass size={20} className="text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-serif font-normal text-gray-900 tracking-wide">Saved Destinations</h2>
-              <p className="text-sm text-gray-600">{favoritedDestinations.length} saved</p>
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white">Saved Destinations</h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{favoritedDestinations.length} saved</p>
             </div>
           </div>
 
@@ -288,17 +288,17 @@ export default function TripFavorites({ params }: { params: Promise<{ id: string
       )}
 
       {/* Hotels Section Placeholder */}
-      <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-        <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200">
+      <div className="bg-white dark:bg-white/[0.03] rounded-xl p-5 shadow-sm border border-gray-200 dark:border-white/[0.08]">
+        <div className="flex items-center gap-3 mb-5 pb-3 border-b border-gray-200 dark:border-white/[0.08]">
           <div className="w-10 h-10 bg-gradient-to-r from-blue-400 to-blue-500 rounded-lg flex items-center justify-center">
             <Building2 size={20} className="text-white" />
           </div>
           <div>
-            <h2 className="text-lg font-serif font-normal text-gray-900 tracking-wide">Hotels & Accommodations</h2>
-            <p className="text-sm text-gray-600">0 saved</p>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">Hotels & Accommodations</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">0 saved</p>
           </div>
         </div>
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <p className="text-sm">Hotel favorites will appear here when you heart items in the Hotels tab</p>
         </div>
       </div>

--- a/apps/web/app/(dashboard)/trip/[id]/flights/[flightId]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/[flightId]/page.tsx
@@ -25,17 +25,17 @@ export default function FlightDetailPage({
   if (isLoading) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-6 pb-24 animate-pulse">
-        <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
-        <div className="w-full h-[180px] bg-gray-200 dark:bg-gray-700 rounded-xl mb-6" />
-        <div className="h-7 w-2/3 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
-        <div className="h-4 w-1/2 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-56 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-36 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-32 bg-gray-200 dark:bg-white/[0.06] rounded mb-4" />
+        <div className="w-full h-[180px] bg-gray-200 dark:bg-white/[0.06] rounded-xl mb-6" />
+        <div className="h-7 w-2/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-2" />
+        <div className="h-4 w-1/2 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-40 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-56 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-36 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-48 bg-gray-200 dark:bg-white/[0.06] rounded" />
       </div>
     )
   }
@@ -153,7 +153,7 @@ export default function FlightDetailPage({
             </p>
             {departureDate && (
               <>
-                <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                <p className="text-base font-semibold text-gray-900 dark:text-white">
                   {departureDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                 </p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -176,7 +176,7 @@ export default function FlightDetailPage({
             </p>
             {arrivalDate && (
               <>
-                <p className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                <p className="text-base font-semibold text-gray-900 dark:text-white">
                   {arrivalDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                 </p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -195,7 +195,7 @@ export default function FlightDetailPage({
 
         {/* Duration row */}
         {duration && (
-          <div className="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+          <div className="mt-4 pt-3 border-t border-gray-100 dark:border-white/[0.06] flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
             <Clock className="w-4 h-4 text-gray-400 shrink-0" />
             <span>Duration: <span className="font-medium text-gray-800 dark:text-gray-200">{duration}</span></span>
           </div>

--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -23,6 +23,7 @@ import {
   Zap,
   Monitor,
   Info,
+  Plane,
 } from 'lucide-react';
 import { PaperPlane } from '@/components/ui';
 import { useItineraryScreen, useFlights } from '@travyl/shared';
@@ -887,6 +888,12 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
         </div>
       ) : searchedFlights.length > 0 ? (
         <ComparisonAlternatives comparisonFlights={searchedFlights} />
+      ) : !hasBookedFlights ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Plane size={32} className="text-gray-300 mb-3" />
+          <p className="text-sm font-medium text-gray-500">Search for flights to compare options</p>
+          <p className="text-xs text-gray-400 mt-1">Use the search above to find the best deals</p>
+        </div>
       ) : null}
 
       {/* Booking details will show when real booking data is available */}

--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -232,8 +232,8 @@ function AirportInput({ label, value, onChange }: { label: string; value: string
   }, [query]);
 
   return (
-    <div className="flex-1 min-w-0 px-4 py-2.5 hover:bg-blue-50/30 transition-colors relative">
-      <p className="text-[9px] uppercase tracking-widest text-gray-400">{label}</p>
+    <div className="flex-1 min-w-0 px-4 py-2.5 hover:bg-blue-50/30 dark:hover:bg-white/[0.04] transition-colors relative">
+      <p className="text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500">{label}</p>
       <input
         type="text"
         value={query || value}
@@ -241,20 +241,20 @@ function AirportInput({ label, value, onChange }: { label: string; value: string
         onFocus={() => { setQuery(''); }}
         onBlur={() => setTimeout(() => setOpen(false), 200)}
         placeholder={value || 'Search airport...'}
-        className="text-sm font-semibold text-[#2563eb] bg-transparent border-none p-0 w-full focus:outline-none placeholder:text-gray-300"
+        className="text-sm font-semibold text-[#2563eb] bg-transparent border-none p-0 w-full focus:outline-none placeholder:text-gray-300 dark:placeholder:text-gray-600"
       />
-      {cityName && !query && <p className="text-[10px] text-gray-400 truncate">{cityName}</p>}
+      {cityName && !query && <p className="text-[10px] text-gray-400 dark:text-gray-500 truncate">{cityName}</p>}
       {open && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 max-h-48 overflow-auto">
+        <div className="absolute left-0 right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-white/[0.08] rounded-lg shadow-lg z-50 max-h-48 overflow-auto">
           {results.map((r) => (
             <button
               key={r.iata}
               onMouseDown={(e) => { e.preventDefault(); onChange(r.iata); setQuery(''); setOpen(false); }}
-              className="w-full text-left px-3 py-2 hover:bg-blue-50 transition-colors flex items-center gap-2"
+              className="w-full text-left px-3 py-2 hover:bg-blue-50 dark:hover:bg-white/[0.06] transition-colors flex items-center gap-2"
             >
               <span className="text-xs font-bold text-[#2563eb] w-8">{r.iata}</span>
-              <span className="text-xs text-gray-600 truncate">{r.name}</span>
-              <span className="text-[10px] text-gray-400 ml-auto shrink-0">{r.city}</span>
+              <span className="text-xs text-gray-600 dark:text-gray-400 truncate">{r.name}</span>
+              <span className="text-[10px] text-gray-400 dark:text-gray-500 ml-auto shrink-0">{r.city}</span>
             </button>
           ))}
         </div>
@@ -301,23 +301,23 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
   const activeFilterCount = [nonstopOnly, depTimes.length > 0, arrTimes.length > 0, maxPrice < 3000, airlines.length > 0].filter(Boolean).length;
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden mb-4">
+    <div className="bg-white dark:bg-white/[0.03] rounded-xl shadow-sm border border-gray-200 dark:border-white/[0.08] overflow-hidden mb-4">
       {/* Header */}
-      <div role="button" tabIndex={0} onClick={() => setCollapsed(!collapsed)} onKeyDown={(e) => { if (e.key === 'Enter') setCollapsed(!collapsed); }} className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50/50 transition-colors cursor-pointer">
+      <div role="button" tabIndex={0} onClick={() => setCollapsed(!collapsed)} onKeyDown={(e) => { if (e.key === 'Enter') setCollapsed(!collapsed); }} className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50/50 dark:hover:bg-white/[0.04] transition-colors cursor-pointer">
         <div className="flex items-center gap-2.5">
           <div className="w-7 h-7 rounded-lg bg-[#2563eb] flex items-center justify-center">
             <PaperPlane size={14} className="text-white" />
           </div>
           <div className="text-left">
-            <p className="text-sm font-medium text-gray-800">Search Flights</p>
-            <p className="text-[11px] text-gray-400">{from} → {to} · {travelers} traveler{travelers !== 1 ? 's' : ''} · {cabinLabel[cabinClass]}</p>
+            <p className="text-sm font-medium text-gray-800 dark:text-white">Search Flights</p>
+            <p className="text-[11px] text-gray-400 dark:text-gray-500">{from} → {to} · {travelers} traveler{travelers !== 1 ? 's' : ''} · {cabinLabel[cabinClass]}</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
           {!collapsed && (
             <button
               onClick={(e) => { e.stopPropagation(); setShowFilters(!showFilters); }}
-              className={`text-[11px] px-2.5 py-1 rounded-full border flex items-center gap-1 transition-all ${showFilters ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'}`}
+              className={`text-[11px] px-2.5 py-1 rounded-full border flex items-center gap-1 transition-all ${showFilters ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white dark:bg-white/[0.05] text-gray-500 dark:text-gray-400 border-gray-200 dark:border-white/[0.1] hover:border-gray-300 dark:hover:border-white/[0.2]'}`}
             >
               <Settings size={10} />
               Filters
@@ -334,15 +334,15 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
       <AnimatePresence>
         {!collapsed && (
           <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants}>
-            <div className="px-4 pb-4 border-t border-gray-100 pt-3">
+            <div className="px-4 pb-4 border-t border-gray-100 dark:border-white/[0.06] pt-3">
               {/* Search strip */}
-              <div className="flex flex-col sm:flex-row items-stretch border border-gray-200 rounded-xl overflow-visible bg-white divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+              <div className="flex flex-col sm:flex-row items-stretch border border-gray-200 dark:border-white/[0.08] rounded-xl overflow-visible bg-white dark:bg-white/[0.03] divide-y sm:divide-y-0 sm:divide-x divide-gray-200 dark:divide-white/[0.08]">
                 {/* From */}
                 <AirportInput label="From" value={from} onChange={setFrom} />
 
                 {/* Swap */}
                 <div className="hidden sm:flex items-center -mx-3 z-10">
-                  <button onClick={swap} className="w-6 h-6 rounded-full bg-white border border-gray-200 shadow-sm hover:shadow hover:border-[#2563eb]/30 transition-all flex items-center justify-center">
+                  <button onClick={swap} className="w-6 h-6 rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-white/[0.1] shadow-sm hover:shadow hover:border-[#2563eb]/30 transition-all flex items-center justify-center">
                     <ArrowLeftRight size={10} className="text-gray-400" />
                   </button>
                 </div>
@@ -351,21 +351,21 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
                 <AirportInput label="To" value={to} onChange={setTo} />
 
                 {/* Travelers */}
-                <div className="shrink-0 px-4 py-2.5 hover:bg-blue-50/30 transition-colors">
-                  <p className="text-[9px] uppercase tracking-widest text-gray-400">Travelers</p>
+                <div className="shrink-0 px-4 py-2.5 hover:bg-blue-50/30 dark:hover:bg-white/[0.04] transition-colors">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500">Travelers</p>
                   <div className="flex items-center gap-1.5">
                     <span className="text-sm font-semibold text-[#2563eb]">{travelers}</span>
                     <div className="flex items-center gap-0.5">
-                      <button onClick={() => setTravelers(Math.max(1, travelers - 1))} className="w-5 h-5 rounded-full border border-gray-200 text-[10px] text-gray-500 hover:bg-gray-100 flex items-center justify-center">-</button>
-                      <button onClick={() => setTravelers(travelers + 1)} className="w-5 h-5 rounded-full border border-gray-200 text-[10px] text-gray-500 hover:bg-gray-100 flex items-center justify-center">+</button>
+                      <button onClick={() => setTravelers(Math.max(1, travelers - 1))} className="w-5 h-5 rounded-full border border-gray-200 dark:border-white/[0.1] text-[10px] text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/[0.06] flex items-center justify-center">-</button>
+                      <button onClick={() => setTravelers(travelers + 1)} className="w-5 h-5 rounded-full border border-gray-200 dark:border-white/[0.1] text-[10px] text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/[0.06] flex items-center justify-center">+</button>
                     </div>
                   </div>
                 </div>
 
                 {/* Class */}
-                <div className="shrink-0 px-4 py-2.5 hover:bg-blue-50/30 transition-colors">
-                  <p className="text-[9px] uppercase tracking-widest text-gray-400">Class</p>
-                  <select value={cabinClass} onChange={e => setCabinClass(e.target.value)} className="text-sm font-semibold text-[#2563eb] bg-transparent border-none p-0 focus:outline-none cursor-pointer -ml-1">
+                <div className="shrink-0 px-4 py-2.5 hover:bg-blue-50/30 dark:hover:bg-white/[0.04] transition-colors">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500">Class</p>
+                  <select value={cabinClass} onChange={e => setCabinClass(e.target.value)} className="text-sm font-semibold text-[#2563eb] bg-transparent border-none p-0 focus:outline-none cursor-pointer -ml-1 dark:[&>option]:bg-gray-900 dark:[&>option]:text-white">
                     <option value="economy">Economy</option>
                     <option value="premium">Premium Econ</option>
                     <option value="business">Business</option>
@@ -386,36 +386,36 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
               {/* Advanced filters */}
               <AnimatePresence>
                 {showFilters && (
-                  <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants} className="mt-2.5 bg-gray-50/60 rounded-xl border border-gray-200 overflow-hidden">
+                  <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants} className="mt-2.5 bg-gray-50/60 dark:bg-white/[0.02] rounded-xl border border-gray-200 dark:border-white/[0.08] overflow-hidden">
                     <div className="p-3 sm:p-4 space-y-4">
                       {/* Stops & max layover & max price */}
                       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                         <div>
-                          <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-2">Stops</p>
+                          <p className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">Stops</p>
                           <div className="flex gap-1.5">
                             {[{ label: 'Nonstop', val: true }, { label: 'Any', val: false }].map(opt => (
                               <button key={String(opt.val)} onClick={() => setNonstopOnly(opt.val)}
-                                className={`flex-1 text-[11px] px-2 py-1.5 rounded-lg border transition-all ${nonstopOnly === opt.val ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white text-gray-600 border-gray-200 hover:border-gray-300'}`}
+                                className={`flex-1 text-[11px] px-2 py-1.5 rounded-lg border transition-all ${nonstopOnly === opt.val ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white dark:bg-white/[0.05] text-gray-600 dark:text-gray-400 border-gray-200 dark:border-white/[0.1] hover:border-gray-300 dark:hover:border-white/[0.2]'}`}
                               >{opt.label}</button>
                             ))}
                           </div>
                         </div>
                         <div>
-                          <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-2">Max layover</p>
+                          <p className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">Max layover</p>
                           <div className="relative">
                             <input type="number" min={1} max={24} value={nonstopOnly ? 0 : maxLayover} disabled={nonstopOnly}
                               onChange={e => setMaxLayover(Math.min(24, Math.max(1, Number(e.target.value) || 1)))}
-                              className={`w-full text-xs border rounded-lg px-3 py-1.5 focus:outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb]/20 ${nonstopOnly ? 'bg-gray-100 border-gray-200 text-gray-400 cursor-not-allowed' : 'bg-white border-gray-200 text-gray-800'}`} />
-                            <span className={`absolute right-3 top-1/2 -translate-y-1/2 text-[10px] ${nonstopOnly ? 'text-gray-300' : 'text-gray-400'}`}>hours</span>
+                              className={`w-full text-xs border rounded-lg px-3 py-1.5 focus:outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb]/20 ${nonstopOnly ? 'bg-gray-100 dark:bg-white/[0.02] border-gray-200 dark:border-white/[0.06] text-gray-400 dark:text-gray-600 cursor-not-allowed' : 'bg-white dark:bg-white/[0.05] border-gray-200 dark:border-white/[0.1] text-gray-800 dark:text-white'}`} />
+                            <span className={`absolute right-3 top-1/2 -translate-y-1/2 text-[10px] ${nonstopOnly ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}`}>hours</span>
                           </div>
                         </div>
                         <div>
-                          <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-2">Max price</p>
+                          <p className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">Max price</p>
                           <div className="relative">
-                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[11px] text-gray-400">$</span>
+                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[11px] text-gray-400 dark:text-gray-500">$</span>
                             <input type="number" min={0} max={10000} step={50} value={maxPrice}
                               onChange={e => setMaxPrice(Math.max(0, Number(e.target.value) || 0))}
-                              className="w-full text-xs bg-white border border-gray-200 rounded-lg pl-6 pr-3 py-1.5 focus:outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb]/20 text-gray-800" />
+                              className="w-full text-xs bg-white dark:bg-white/[0.05] border border-gray-200 dark:border-white/[0.1] rounded-lg pl-6 pr-3 py-1.5 focus:outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb]/20 text-gray-800 dark:text-white" />
                           </div>
                         </div>
                       </div>
@@ -424,13 +424,13 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         {[{ label: 'Departure time', state: depTimes, setter: setDepTimes }, { label: 'Arrival time', state: arrTimes, setter: setArrTimes }].map(group => (
                           <div key={group.label}>
-                            <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-2">{group.label}</p>
+                            <p className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">{group.label}</p>
                             <div className="grid grid-cols-4 gap-1.5">
                               {[{ label: 'Early', sub: '12a-6a', value: 'night' }, { label: 'Morning', sub: '6a-12p', value: 'morning' }, { label: 'Afternoon', sub: '12p-6p', value: 'afternoon' }, { label: 'Evening', sub: '6p-12a', value: 'evening' }].map(t => {
                                 const active = group.state.includes(t.value);
                                 return (
                                   <button key={t.value} onClick={() => toggleInArray(group.state, t.value, group.setter)}
-                                    className={`py-2 rounded-lg text-center border transition-all ${active ? 'border-[#2563eb] bg-[#2563eb]/5 text-[#2563eb]' : 'border-gray-200 bg-white text-gray-500 hover:border-gray-300'}`}>
+                                    className={`py-2 rounded-lg text-center border transition-all ${active ? 'border-[#2563eb] bg-[#2563eb]/5 dark:bg-[#2563eb]/10 text-[#2563eb]' : 'border-gray-200 dark:border-white/[0.1] bg-white dark:bg-white/[0.05] text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-white/[0.2]'}`}>
                                     <div className="text-[11px] font-medium">{t.label}</div>
                                     <div className="text-[9px] opacity-60">{t.sub}</div>
                                   </button>
@@ -443,13 +443,13 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
 
                       {/* Airline chips */}
                       <div>
-                        <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-2">Airlines</p>
+                        <p className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">Airlines</p>
                         <div className="flex flex-wrap gap-1.5">
                           {[{ code: 'AA', name: 'American', color: '#0078D2' }, { code: 'DL', name: 'Delta', color: '#003366' }, { code: 'UA', name: 'United', color: '#002244' }, { code: 'LH', name: 'Lufthansa', color: '#05164D' }, { code: 'AF', name: 'Air France', color: '#002157' }, { code: 'BA', name: 'British Airways', color: '#075AAA' }].map(a => {
                             const active = airlines.includes(a.name);
                             return (
                               <button key={a.code} onClick={() => toggleInArray(airlines, a.name, setAirlines)}
-                                className={`text-[11px] px-2.5 py-1.5 rounded-lg border flex items-center gap-1.5 transition-all ${active ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white text-gray-600 border-gray-200 hover:border-gray-300'}`}>
+                                className={`text-[11px] px-2.5 py-1.5 rounded-lg border flex items-center gap-1.5 transition-all ${active ? 'bg-[#2563eb] text-white border-[#2563eb]' : 'bg-white dark:bg-white/[0.05] text-gray-600 dark:text-gray-400 border-gray-200 dark:border-white/[0.1] hover:border-gray-300 dark:hover:border-white/[0.2]'}`}>
                                 <span className={`w-1.5 h-1.5 rounded-full ${active ? 'bg-white' : ''}`} style={!active ? { backgroundColor: a.color } : {}} />
                                 {a.name}
                               </button>
@@ -459,7 +459,7 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
                       </div>
 
                       <button onClick={() => { setNonstopOnly(false); setMaxLayover(12); setMaxPrice(3000); setDepTimes([]); setArrTimes([]); setAirlines([]); }}
-                        className="text-[11px] text-gray-400 hover:text-gray-600 transition-colors underline underline-offset-2">Reset all filters</button>
+                        className="text-[11px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors underline underline-offset-2">Reset all filters</button>
                     </div>
                   </motion.div>
                 )}
@@ -485,7 +485,7 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
 
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}
-      className="rounded-2xl border border-gray-200 bg-white overflow-hidden shadow-sm">
+      className="rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] overflow-hidden shadow-sm">
       {/* Header */}
       <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-4 py-3 text-white" style={{ background: gradient }}>
         <div className="flex items-center gap-2">
@@ -503,28 +503,28 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
           <div className="text-center">
-            <p className="text-xl font-bold text-gray-900">{flight.departure.time}</p>
-            <p className="text-xs text-gray-500 font-medium">{flight.departure.code}</p>
-            <p className="text-[10px] text-gray-400">T{flight.departure.terminal} · Gate {flight.departure.gate}</p>
+            <p className="text-xl font-bold text-gray-900 dark:text-white">{flight.departure.time}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">{flight.departure.code}</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-500">T{flight.departure.terminal} · Gate {flight.departure.gate}</p>
           </div>
           <div className="flex-1 flex flex-col items-center px-4">
-            <p className="text-[11px] text-gray-400 mb-1">{flight.duration}</p>
+            <p className="text-[11px] text-gray-400 dark:text-gray-500 mb-1">{flight.duration}</p>
             <div className="flex items-center w-full">
-              <div className="flex-1 border-t border-dashed border-gray-300" />
+              <div className="flex-1 border-t border-dashed border-gray-300 dark:border-white/[0.15]" />
               <div className="w-7 h-7 rounded-full flex items-center justify-center mx-1.5" style={{ backgroundColor: '#2563eb' }}>
                 <PaperPlane size={12} className="text-white" />
               </div>
-              <div className="flex-1 border-t border-dashed border-gray-300" />
+              <div className="flex-1 border-t border-dashed border-gray-300 dark:border-white/[0.15]" />
             </div>
-            <p className="text-[11px] text-emerald-600 font-medium mt-1">{flight.stops}</p>
+            <p className="text-[11px] text-emerald-600 dark:text-emerald-400 font-medium mt-1">{flight.stops}</p>
           </div>
           <div className="text-center">
-            <p className="text-xl font-bold text-gray-900">
+            <p className="text-xl font-bold text-gray-900 dark:text-white">
               {flight.arrival.time}
               {flight.arrival.nextDay && <sup className="text-[10px] text-amber-500 ml-0.5">+1</sup>}
             </p>
-            <p className="text-xs text-gray-500 font-medium">{flight.arrival.code}</p>
-            <p className="text-[10px] text-gray-400">T{flight.arrival.terminal} · Gate {flight.arrival.gate}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">{flight.arrival.code}</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-500">T{flight.arrival.terminal} · Gate {flight.arrival.gate}</p>
           </div>
         </div>
 
@@ -534,12 +534,12 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
             <span className="text-white text-[10px] font-bold">{flight.airlineLogo}</span>
           </div>
           <div>
-            <p className="text-xs font-medium text-gray-800">{flight.airline}</p>
-            <p className="text-[10px] text-gray-400">{flight.cabinClass}</p>
+            <p className="text-xs font-medium text-gray-800 dark:text-white">{flight.airline}</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-500">{flight.cabinClass}</p>
           </div>
           <div className="ml-auto text-right">
             <p className="text-sm font-bold text-[#2563eb]">${flight.price.total}</p>
-            <p className="text-[10px] text-gray-400">per person</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-500">per person</p>
           </div>
         </div>
       </div>
@@ -548,7 +548,7 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
       <AnimatePresence>
         {expanded && (
           <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants}>
-            <div className="border-t border-gray-100 bg-gradient-to-b from-gray-50/80 to-white px-4 pb-4 pt-3">
+            <div className="border-t border-gray-100 dark:border-white/[0.06] bg-gradient-to-b from-gray-50/80 dark:from-white/[0.02] to-white dark:to-transparent px-4 pb-4 pt-3">
               <div className="grid grid-cols-2 gap-2">
                 {[
                   { label: 'Aircraft', value: flight.aircraft },
@@ -558,23 +558,23 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
                   { label: 'Meal', value: flight.meal },
                   { label: 'Wi-Fi', value: flight.wifi },
                 ].map(item => (
-                  <div key={item.label} className="bg-white rounded-lg p-2.5 border border-gray-100 shadow-sm">
-                    <p className="text-[9px] text-gray-400 uppercase tracking-wider mb-0.5">{item.label}</p>
-                    <p className="text-[11px] text-gray-700 font-medium">{item.value}</p>
+                  <div key={item.label} className="bg-white dark:bg-white/[0.03] rounded-lg p-2.5 border border-gray-100 dark:border-white/[0.06] shadow-sm">
+                    <p className="text-[9px] text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-0.5">{item.label}</p>
+                    <p className="text-[11px] text-gray-700 dark:text-gray-300 font-medium">{item.value}</p>
                   </div>
                 ))}
               </div>
               {/* Price breakdown */}
-              <div className="mt-2 bg-white rounded-lg p-2.5 border border-gray-100 shadow-sm">
-                <p className="text-[9px] text-gray-400 uppercase tracking-wider mb-1.5">Price Breakdown</p>
+              <div className="mt-2 bg-white dark:bg-white/[0.03] rounded-lg p-2.5 border border-gray-100 dark:border-white/[0.06] shadow-sm">
+                <p className="text-[9px] text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1.5">Price Breakdown</p>
                 <div className="space-y-1">
-                  <div className="flex justify-between text-[11px]"><span className="text-gray-500">Base fare</span><span className="text-gray-700">${flight.price.base}</span></div>
-                  <div className="flex justify-between text-[11px]"><span className="text-gray-500">Taxes & fees</span><span className="text-gray-700">${flight.price.taxes}</span></div>
-                  <div className="flex justify-between text-[11px] font-semibold border-t border-gray-100 pt-1 mt-1"><span className="text-gray-800">Total</span><span className="text-[#2563eb]">${flight.price.total}</span></div>
+                  <div className="flex justify-between text-[11px]"><span className="text-gray-500 dark:text-gray-400">Base fare</span><span className="text-gray-700 dark:text-gray-300">${flight.price.base}</span></div>
+                  <div className="flex justify-between text-[11px]"><span className="text-gray-500 dark:text-gray-400">Taxes & fees</span><span className="text-gray-700 dark:text-gray-300">${flight.price.taxes}</span></div>
+                  <div className="flex justify-between text-[11px] font-semibold border-t border-gray-100 dark:border-white/[0.06] pt-1 mt-1"><span className="text-gray-800 dark:text-white">Total</span><span className="text-[#2563eb]">${flight.price.total}</span></div>
                 </div>
               </div>
               <div className="mt-2 flex items-center gap-2 text-[11px]">
-                <span className="text-gray-500">Confirmation:</span>
+                <span className="text-gray-500 dark:text-gray-400">Confirmation:</span>
                 <span className="font-mono font-bold text-[#2563eb]">{flight.confirmation}</span>
               </div>
             </div>
@@ -605,12 +605,12 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
   });
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden mb-4">
-      <button onClick={() => setOpen(!open)} className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50/50 transition-colors">
+    <div className="bg-white dark:bg-white/[0.03] rounded-xl shadow-sm border border-gray-200 dark:border-white/[0.08] overflow-hidden mb-4">
+      <button onClick={() => setOpen(!open)} className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50/50 dark:hover:bg-white/[0.04] transition-colors">
         <div className="flex items-center gap-2">
-          <TrendingUp size={16} className="text-emerald-600" />
-          <span className="text-sm font-medium text-gray-900">Compare Alternatives</span>
-          <span className="text-[10px] text-gray-400">{comparisonFlights.length} options</span>
+          <TrendingUp size={16} className="text-emerald-600 dark:text-emerald-400" />
+          <span className="text-sm font-medium text-gray-900 dark:text-white">Compare Alternatives</span>
+          <span className="text-[10px] text-gray-400 dark:text-gray-500">{comparisonFlights.length} options</span>
         </div>
         <ChevronDown size={16} className={`text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
@@ -618,19 +618,19 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
       <AnimatePresence>
         {open && (
           <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants}>
-            <div className="px-4 pb-4 border-t border-gray-100 pt-3 space-y-3">
+            <div className="px-4 pb-4 border-t border-gray-100 dark:border-white/[0.06] pt-3 space-y-3">
               {/* Sort + alt airports */}
               <div className="flex items-center justify-between gap-2">
                 <div className="flex gap-1">
                   {(['price', 'duration', 'value'] as const).map(s => (
                     <button key={s} onClick={() => setSort(s)}
-                      className={`px-2.5 py-1 rounded-lg text-xs transition-all ${sort === s ? 'bg-[#2563eb] text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                      className={`px-2.5 py-1 rounded-lg text-xs transition-all ${sort === s ? 'bg-[#2563eb] text-white' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/[0.1]'}`}>
                       {s === 'price' ? 'Price' : s === 'duration' ? 'Fastest' : 'Best Value'}
                     </button>
                   ))}
                 </div>
                 <button onClick={() => setAltAirports(!altAirports)}
-                  className={`text-xs px-2.5 py-1 rounded-lg transition-all ${altAirports ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                  className={`text-xs px-2.5 py-1 rounded-lg transition-all ${altAirports ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/[0.1]'}`}>
                   Alt Airports
                 </button>
               </div>
@@ -641,9 +641,9 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
                   <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden">
                     <div className="grid grid-cols-3 gap-2">
                       {[{ code: 'EWR', savings: 50 }, { code: 'LGA', savings: 35 }, { code: 'ORY', savings: 75 }].map(ap => (
-                        <button key={ap.code} className="text-left p-2 border border-gray-200 rounded-lg hover:border-[#2563eb] hover:bg-blue-50/50 transition-colors">
-                          <p className="text-xs font-semibold text-gray-900">{ap.code}</p>
-                          <p className="text-xs text-emerald-600 font-medium">-${ap.savings}</p>
+                        <button key={ap.code} className="text-left p-2 border border-gray-200 dark:border-white/[0.08] rounded-lg hover:border-[#2563eb] hover:bg-blue-50/50 dark:hover:bg-white/[0.04] transition-colors">
+                          <p className="text-xs font-semibold text-gray-900 dark:text-white">{ap.code}</p>
+                          <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">-${ap.savings}</p>
                         </button>
                       ))}
                     </div>
@@ -654,16 +654,16 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
               {/* Price range info */}
               <div className="flex items-center gap-2 px-1">
                 <Info size={11} className="text-gray-400 shrink-0" />
-                <p className="text-[10px] text-gray-500">
-                  Prices from <span className="font-semibold text-gray-700">${Math.min(...comparisonFlights.map(f => f.price))}</span> to{' '}
-                  <span className="font-semibold text-gray-700">${Math.max(...comparisonFlights.map(f => f.price))}</span> per person incl. taxes
+                <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                  Prices from <span className="font-semibold text-gray-700 dark:text-gray-300">${Math.min(...comparisonFlights.map(f => f.price))}</span> to{' '}
+                  <span className="font-semibold text-gray-700 dark:text-gray-300">${Math.max(...comparisonFlights.map(f => f.price))}</span> per person incl. taxes
                 </p>
               </div>
 
               {/* Flight option cards */}
               <div className="space-y-2">
                 {sorted.map(flight => (
-                  <div key={flight.id} className={`rounded-xl overflow-hidden transition-all ${expandedId === flight.id ? 'shadow-md ring-1 ring-[#2563eb]/20' : 'shadow-sm ring-1 ring-gray-200 hover:ring-gray-300 hover:shadow'}`}>
+                  <div key={flight.id} className={`rounded-xl overflow-hidden transition-all ${expandedId === flight.id ? 'shadow-md ring-1 ring-[#2563eb]/20' : 'shadow-sm ring-1 ring-gray-200 dark:ring-white/[0.08] hover:ring-gray-300 dark:hover:ring-white/[0.15] hover:shadow'}`}>
                     {/* Badge */}
                     {flight.badge && (
                       <div className="bg-gradient-to-r from-[#2563eb] to-[#3b82f6] px-3 py-0.5">
@@ -672,50 +672,50 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
                     )}
 
                     {/* Summary row */}
-                    <button onClick={() => setExpandedId(expandedId === flight.id ? null : flight.id)} className="w-full text-left bg-white p-3 hover:bg-gray-50/50 transition-colors">
+                    <button onClick={() => setExpandedId(expandedId === flight.id ? null : flight.id)} className="w-full text-left bg-white dark:bg-white/[0.03] p-3 hover:bg-gray-50/50 dark:hover:bg-white/[0.05] transition-colors">
                       <div className="flex items-center gap-3">
                         <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-[#1e3a5f] to-[#2d4a6f] flex items-center justify-center shrink-0 shadow-sm">
                           <span className="text-white text-[11px] font-bold">{flight.airlineLogo}</span>
                         </div>
                         <div className="flex items-baseline gap-1.5 min-w-0 shrink-0">
                           <div>
-                            <p className="text-sm font-semibold text-gray-900">{flight.departure.time}</p>
-                            <p className="text-[11px] text-gray-400">{flight.departure.airport}</p>
+                            <p className="text-sm font-semibold text-gray-900 dark:text-white">{flight.departure.time}</p>
+                            <p className="text-[11px] text-gray-400 dark:text-gray-500">{flight.departure.airport}</p>
                           </div>
-                          <span className="text-gray-300 text-sm px-0.5">→</span>
+                          <span className="text-gray-300 dark:text-gray-600 text-sm px-0.5">→</span>
                           <div>
-                            <p className="text-sm font-semibold text-gray-900">
+                            <p className="text-sm font-semibold text-gray-900 dark:text-white">
                               {flight.arrival.time}
                               {flight.arrival.nextDay && <sup className="text-[9px] text-amber-500 ml-0.5">+1</sup>}
                             </p>
-                            <p className="text-[11px] text-gray-400">{flight.arrival.airport}</p>
+                            <p className="text-[11px] text-gray-400 dark:text-gray-500">{flight.arrival.airport}</p>
                           </div>
                         </div>
                         <div className="flex-1" />
                         <div className="shrink-0 text-right mr-1">
-                          <p className="text-[13px] text-gray-700">{flight.duration}</p>
+                          <p className="text-[13px] text-gray-700 dark:text-gray-300">{flight.duration}</p>
                           {flight.stops === 0
-                            ? <p className="text-[11px] text-emerald-600 font-medium">Direct</p>
-                            : <p className="text-[11px] text-amber-600 font-medium">{flight.stops} stop</p>}
+                            ? <p className="text-[11px] text-emerald-600 dark:text-emerald-400 font-medium">Direct</p>
+                            : <p className="text-[11px] text-amber-600 dark:text-amber-400 font-medium">{flight.stops} stop</p>}
                         </div>
-                        <div className="h-8 w-px bg-gray-200 shrink-0" />
+                        <div className="h-8 w-px bg-gray-200 dark:bg-white/[0.08] shrink-0" />
                         <div className="text-right shrink-0 min-w-[56px]">
                           <p className="text-[15px] font-bold text-[#2563eb]">${flight.price}</p>
-                          <p className="text-[11px] text-gray-400">{flight.fareClass}</p>
+                          <p className="text-[11px] text-gray-400 dark:text-gray-500">{flight.fareClass}</p>
                         </div>
-                        <ChevronDown size={16} className={`text-gray-300 shrink-0 transition-transform ${expandedId === flight.id ? 'rotate-180' : ''}`} />
+                        <ChevronDown size={16} className={`text-gray-300 dark:text-gray-600 shrink-0 transition-transform ${expandedId === flight.id ? 'rotate-180' : ''}`} />
                       </div>
                       {/* Amenity row */}
                       <div className="flex items-center gap-2 mt-2 ml-[52px]">
-                        <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 rounded-md">
-                          <Wifi size={11} className={flight.amenities.wifi ? 'text-gray-600' : 'text-gray-300'} />
-                          <Zap size={11} className={flight.amenities.power ? 'text-gray-600' : 'text-gray-300'} />
-                          <Utensils size={11} className={flight.amenities.meals ? 'text-gray-600' : 'text-gray-300'} />
-                          <Monitor size={11} className={flight.amenities.entertainment ? 'text-gray-600' : 'text-gray-300'} />
+                        <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 dark:bg-white/[0.04] rounded-md">
+                          <Wifi size={11} className={flight.amenities.wifi ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'} />
+                          <Zap size={11} className={flight.amenities.power ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'} />
+                          <Utensils size={11} className={flight.amenities.meals ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'} />
+                          <Monitor size={11} className={flight.amenities.entertainment ? 'text-gray-600 dark:text-gray-400' : 'text-gray-300 dark:text-gray-600'} />
                         </div>
-                        <span className="text-[11px] text-gray-400">{flight.airline}</span>
+                        <span className="text-[11px] text-gray-400 dark:text-gray-500">{flight.airline}</span>
                         {'businessAvailable' in flight && flight.businessAvailable && (
-                          <span className="text-[10px] bg-amber-50 text-amber-700 border border-amber-200 px-1.5 py-0.5 rounded-full">Business avail.</span>
+                          <span className="text-[10px] bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-700/30 px-1.5 py-0.5 rounded-full">Business avail.</span>
                         )}
                       </div>
                     </button>
@@ -724,22 +724,22 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
                     <AnimatePresence>
                       {expandedId === flight.id && (
                         <motion.div initial="hidden" animate="visible" exit="exit" variants={collapseVariants}>
-                          <div className="border-t border-gray-100 bg-gradient-to-b from-gray-50/80 to-white px-3 pb-3 pt-2">
-                            <div className="flex items-center flex-wrap gap-x-1.5 gap-y-0.5 mb-2 text-[10px] text-gray-400">
-                              <span className="text-gray-600 font-medium">{flight.airline}</span>
+                          <div className="border-t border-gray-100 dark:border-white/[0.06] bg-gradient-to-b from-gray-50/80 dark:from-white/[0.02] to-white dark:to-transparent px-3 pb-3 pt-2">
+                            <div className="flex items-center flex-wrap gap-x-1.5 gap-y-0.5 mb-2 text-[10px] text-gray-400 dark:text-gray-500">
+                              <span className="text-gray-600 dark:text-gray-300 font-medium">{flight.airline}</span>
                               <span>·</span><span>{flight.flightNumber}</span>
-                              {flight.layover && (<><span>·</span><span className="text-amber-600">Stop: {flight.layover}</span></>)}
+                              {flight.layover && (<><span>·</span><span className="text-amber-600 dark:text-amber-400">Stop: {flight.layover}</span></>)}
                             </div>
                             {/* Stats bar */}
-                            <div className="flex items-center justify-between bg-white rounded-lg p-2.5 border border-gray-100 shadow-sm mb-2">
+                            <div className="flex items-center justify-between bg-white dark:bg-white/[0.03] rounded-lg p-2.5 border border-gray-100 dark:border-white/[0.06] shadow-sm mb-2">
                               <div className="flex items-center gap-1 text-[10px]">
                                 <div className={`w-1.5 h-1.5 rounded-full ${flight.onTime >= 85 ? 'bg-green-500' : flight.onTime >= 78 ? 'bg-amber-400' : 'bg-red-400'}`} />
-                                <span className="text-gray-600">{flight.onTime}% on-time</span>
+                                <span className="text-gray-600 dark:text-gray-400">{flight.onTime}% on-time</span>
                               </div>
-                              <div className="h-3 w-px bg-gray-200" />
+                              <div className="h-3 w-px bg-gray-200 dark:bg-white/[0.08]" />
                               <div className="flex items-center gap-0.5 text-[10px]">
-                                <Leaf size={10} className={flight.co2 <= 280 ? 'text-green-600' : 'text-gray-400'} />
-                                <span className="text-gray-600">{flight.co2}kg CO2</span>
+                                <Leaf size={10} className={flight.co2 <= 280 ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-500'} />
+                                <span className="text-gray-600 dark:text-gray-400">{flight.co2}kg CO2</span>
                               </div>
                             </div>
                             <button className="w-full py-2 bg-gradient-to-r from-[#2563eb] to-[#3b82f6] text-white text-xs font-medium rounded-lg hover:from-[#1d4ed8] hover:to-[#2563eb] transition-all shadow-sm">
@@ -840,17 +840,17 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
     return (
       <div className="space-y-3 animate-pulse">
         {[0, 1].map(i => (
-          <div key={i} className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+          <div key={i} className="rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] overflow-hidden">
             <div className="h-11 rounded-t-2xl" style={{ background: i === 0 ? 'linear-gradient(135deg, #2563eb, #3b82f6)' : 'linear-gradient(135deg, #1e3a5f, #2d4a6f)' }} />
             <div className="p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <div className="h-12 w-16 rounded bg-gray-200" />
-                <div className="flex-1 mx-4 h-px bg-gray-200" />
-                <div className="h-12 w-16 rounded bg-gray-200" />
+                <div className="h-12 w-16 rounded bg-gray-200 dark:bg-white/[0.06]" />
+                <div className="flex-1 mx-4 h-px bg-gray-200 dark:bg-white/[0.06]" />
+                <div className="h-12 w-16 rounded bg-gray-200 dark:bg-white/[0.06]" />
               </div>
               <div className="flex gap-2">
-                <div className="h-6 w-20 rounded-full bg-gray-200" />
-                <div className="h-6 w-24 rounded-full bg-gray-200" />
+                <div className="h-6 w-20 rounded-full bg-gray-200 dark:bg-white/[0.06]" />
+                <div className="h-6 w-24 rounded-full bg-gray-200 dark:bg-white/[0.06]" />
               </div>
             </div>
           </div>
@@ -882,17 +882,19 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
 
       {/* 3. Comparison Alternatives */}
       {searchingFlights ? (
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 text-center">
-          <div className="w-6 h-6 border-2 border-gray-300 border-t-[#2563eb] rounded-full animate-spin mx-auto mb-2" />
-          <p className="text-sm text-gray-400">Searching flights...</p>
+        <div className="bg-white dark:bg-white/[0.03] rounded-xl shadow-sm border border-gray-200 dark:border-white/[0.08] p-6 text-center">
+          <div className="w-6 h-6 border-2 border-gray-300 dark:border-white/[0.15] border-t-[#2563eb] rounded-full animate-spin mx-auto mb-2" />
+          <p className="text-sm text-gray-400 dark:text-gray-500">Searching flights...</p>
         </div>
       ) : searchedFlights.length > 0 ? (
         <ComparisonAlternatives comparisonFlights={searchedFlights} />
       ) : !hasBookedFlights ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <Plane size={32} className="text-gray-300 mb-3" />
-          <p className="text-sm font-medium text-gray-500">Search for flights to compare options</p>
-          <p className="text-xs text-gray-400 mt-1">Use the search above to find the best deals</p>
+          <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-white/[0.06] flex items-center justify-center mb-3">
+            <Plane size={24} className="text-gray-400 dark:text-gray-500" />
+          </div>
+          <p className="text-sm font-semibold text-gray-900 dark:text-white">Search for flights to compare options</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Use the search above to find the best deals</p>
         </div>
       ) : null}
 

--- a/apps/web/app/(dashboard)/trip/[id]/hotels/[hotelId]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/hotels/[hotelId]/page.tsx
@@ -20,17 +20,17 @@ export default function HotelDetailPage({
   if (isLoading) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-6 pb-24 animate-pulse">
-        <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
-        <div className="w-full h-[280px] bg-gray-200 dark:bg-gray-700 rounded-xl mb-6" />
-        <div className="h-7 w-2/3 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
-        <div className="h-4 w-1/2 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-56 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-36 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-32 bg-gray-200 dark:bg-white/[0.06] rounded mb-4" />
+        <div className="w-full h-[280px] bg-gray-200 dark:bg-white/[0.06] rounded-xl mb-6" />
+        <div className="h-7 w-2/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-2" />
+        <div className="h-4 w-1/2 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-40 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-56 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-36 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-48 bg-gray-200 dark:bg-white/[0.06] rounded" />
       </div>
     )
   }
@@ -83,7 +83,7 @@ export default function HotelDetailPage({
       />
 
       {/* Overview */}
-      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100 dark:border-white/[0.06]">
         {data.star_rating !== null && (
           <div className="flex items-center gap-0.5 mb-2">
             {Array.from({ length: 5 }).map((_, i) => (

--- a/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
@@ -392,10 +392,10 @@ function ImageCarousel({
       />
       {images.length > 1 && (
         <>
-          <button onClick={prev} className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all shadow-md">
+          <button onClick={prev} className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white dark:bg-black/60 dark:hover:bg-black/80 rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all shadow-md dark:text-white">
             <ChevronLeft size={16} />
           </button>
-          <button onClick={next} className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all shadow-md">
+          <button onClick={next} className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white dark:bg-black/60 dark:hover:bg-black/80 rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all shadow-md dark:text-white">
             <ChevronRight size={16} />
           </button>
           <span className="absolute bottom-2 right-2 bg-black/60 text-white text-[10px] px-2 py-0.5 rounded-full">
@@ -478,17 +478,17 @@ function HotelSearchFilter({
   }, [checkIn, checkOut]);
 
   return (
-    <div className="rounded-xl overflow-hidden bg-white dark:bg-[var(--background)] border border-gray-200 dark:border-white/[0.08] shadow-sm">
+    <div className="rounded-xl overflow-hidden bg-white dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] shadow-sm">
       {/* Header */}
       <button onClick={onToggle}
-        className="w-full flex items-center justify-between px-4 py-3 transition-colors hover:bg-gray-50">
+        className="w-full flex items-center justify-between px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.02]">
         <div className="flex items-center gap-2.5">
           <div className="w-8 h-8 rounded-lg flex items-center justify-center"
             style={{ backgroundColor: 'rgba(200,169,106,0.15)', border: '1px solid rgba(200,169,106,0.25)' }}>
             <Hotel size={16} style={{ color: 'var(--magazine-accent, #c8a96a)' }} />
           </div>
           <div className="text-left">
-            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Update Hotel</p>
+            <p className="text-sm font-semibold text-gray-900 dark:text-white">Update Hotel</p>
             <p className="text-[11px] text-gray-500 dark:text-gray-400">{destination || 'Search hotels'} &middot; {nights} nights &middot; {guests} guests</p>
           </div>
         </div>
@@ -515,30 +515,30 @@ function HotelSearchFilter({
                     onChange={(e) => onSearchQueryChange(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter') onSearch(); }}
                     placeholder="Hotel name or area..."
-                    className="w-full mt-0.5 text-xs border border-gray-200 rounded-lg px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
+                    className="w-full mt-0.5 text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2.5 py-1.5 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
                   />
                 </div>
                 <div className="flex-1 min-w-[120px]">
                   <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Check-in</label>
-                  <input type="date" value={checkIn} onChange={(e) => setCheckIn(e.target.value)} className="w-full mt-0.5 text-xs border border-gray-200 rounded-lg px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]" />
+                  <input type="date" value={checkIn} onChange={(e) => setCheckIn(e.target.value)} className="w-full mt-0.5 text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2.5 py-1.5 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]" />
                 </div>
                 <div className="flex-1 min-w-[120px]">
                   <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Check-out</label>
-                  <input type="date" value={checkOut} onChange={(e) => setCheckOut(e.target.value)} className="w-full mt-0.5 text-xs border border-gray-200 rounded-lg px-2.5 py-1.5 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]" />
+                  <input type="date" value={checkOut} onChange={(e) => setCheckOut(e.target.value)} className="w-full mt-0.5 text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2.5 py-1.5 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]" />
                 </div>
                 <div className="flex items-center gap-1.5">
                   <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Guests</label>
-                  <div className="flex items-center gap-1 border border-gray-200 rounded-lg px-1.5 py-1">
+                  <div className="flex items-center gap-1 border border-gray-200 dark:border-white/[0.08] rounded-lg px-1.5 py-1">
                     <button onClick={() => setGuests(Math.max(1, guests - 1))} className="text-gray-400 hover:text-gray-600 dark:text-gray-300"><Minus size={12} /></button>
-                    <span className="text-xs font-medium w-5 text-center">{guests}</span>
+                    <span className="text-xs font-medium w-5 text-center text-gray-900 dark:text-white">{guests}</span>
                     <button onClick={() => setGuests(guests + 1)} className="text-gray-400 hover:text-gray-600 dark:text-gray-300"><Plus size={12} /></button>
                   </div>
                 </div>
                 <div className="flex items-center gap-1.5">
                   <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">Rooms</label>
-                  <div className="flex items-center gap-1 border border-gray-200 rounded-lg px-1.5 py-1">
+                  <div className="flex items-center gap-1 border border-gray-200 dark:border-white/[0.08] rounded-lg px-1.5 py-1">
                     <button onClick={() => setRooms(Math.max(1, rooms - 1))} className="text-gray-400 hover:text-gray-600 dark:text-gray-300"><Minus size={12} /></button>
-                    <span className="text-xs font-medium w-5 text-center">{rooms}</span>
+                    <span className="text-xs font-medium w-5 text-center text-gray-900 dark:text-white">{rooms}</span>
                     <button onClick={() => setRooms(rooms + 1)} className="text-gray-400 hover:text-gray-600 dark:text-gray-300"><Plus size={12} /></button>
                   </div>
                 </div>
@@ -560,7 +560,7 @@ function HotelSearchFilter({
                 {/* Sort */}
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-gray-600 dark:text-gray-300">Sort By</span>
-                  <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} className="text-xs border border-gray-200 rounded-lg px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]">
+                  <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} className="text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2 py-1 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]">
                     <option value="recommended">Recommended</option>
                     <option value="price_low">Price: Low to High</option>
                     <option value="price_high">Price: High to Low</option>
@@ -580,7 +580,7 @@ function HotelSearchFilter({
                         min={0}
                         value={priceRange[0]}
                         onChange={(e) => setPriceRange([Number(e.target.value), priceRange[1]])}
-                        className="w-16 text-xs border border-gray-200 rounded-lg px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
+                        className="w-16 text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2 py-1 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
                         placeholder="Min"
                       />
                     </div>
@@ -592,7 +592,7 @@ function HotelSearchFilter({
                         min={0}
                         value={priceRange[1]}
                         onChange={(e) => setPriceRange([priceRange[0], Number(e.target.value)])}
-                        className="w-16 text-xs border border-gray-200 rounded-lg px-2 py-1 focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
+                        className="w-16 text-xs border border-gray-200 dark:border-white/[0.08] rounded-lg px-2 py-1 bg-white dark:bg-white/[0.03] text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#60a5fa]"
                         placeholder="Max"
                       />
                     </div>
@@ -610,7 +610,7 @@ function HotelSearchFilter({
                         className={`text-xs px-3 py-1 rounded-full border transition-colors ${
                           starFilter.includes(s)
                             ? 'bg-amber-400 border-amber-400 text-white'
-                            : 'border-gray-200 text-gray-600 dark:text-gray-300 hover:border-amber-300'
+                            : 'border-gray-200 dark:border-white/[0.08] text-gray-600 dark:text-gray-300 hover:border-amber-300 dark:hover:border-amber-300/50'
                         }`}
                       >
                         {s} <Star size={9} className="inline -mt-0.5 fill-current" />
@@ -630,7 +630,7 @@ function HotelSearchFilter({
                         className={`flex items-center gap-1 text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
                           amenityFilter.includes(a)
                             ? 'bg-[#60a5fa] border-[#60a5fa] text-white'
-                            : 'border-gray-200 text-gray-600 dark:text-gray-300 hover:border-[#60a5fa]/50'
+                            : 'border-gray-200 dark:border-white/[0.08] text-gray-600 dark:text-gray-300 hover:border-[#60a5fa]/50'
                         }`}
                       >
                         {AMENITY_ICONS[a]} {a}
@@ -650,7 +650,7 @@ function HotelSearchFilter({
                         className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
                           brandFilter.includes(b)
                             ? 'bg-[#60a5fa] border-[#60a5fa] text-white'
-                            : 'border-gray-200 text-gray-600 dark:text-gray-300 hover:border-[#60a5fa]/50'
+                            : 'border-gray-200 dark:border-white/[0.08] text-gray-600 dark:text-gray-300 hover:border-[#60a5fa]/50'
                         }`}
                       >
                         {b}
@@ -694,18 +694,18 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
             <div>
               <div className="flex items-center gap-2 mb-2 flex-wrap">
                 <span className="text-white text-xs px-2.5 py-1 rounded-full font-medium bg-[#60a5fa]">Selected</span>
-                <span className="flex items-center gap-0.5 bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded text-[10px]">
+                <span className="flex items-center gap-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 px-1.5 py-0.5 rounded text-[10px]">
                   <Star size={9} className="fill-blue-600 text-blue-600" />
                   <span className="font-medium">{hotel.rating}/10</span>
-                  <span className="text-blue-600">({hotel.reviews})</span>
+                  <span className="text-blue-600 dark:text-blue-400">({hotel.reviews})</span>
                 </span>
               </div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{hotel.name}</h3>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{hotel.name}</h3>
               <div className="flex items-center gap-2 mt-1 flex-wrap">
                 <span className="text-[10px] text-gray-600 dark:text-gray-300">
                   Check-in: {hotel.checkIn} &bull; Check-out: {hotel.checkOut}
                 </span>
-                <span className="bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded font-medium text-[10px] inline-flex items-center gap-0.5">
+                <span className="bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 px-2 py-0.5 rounded font-medium text-[10px] inline-flex items-center gap-0.5">
                   <Shield size={9} /> {hotel.cancellation}
                 </span>
               </div>
@@ -745,7 +745,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                         <div className="flex justify-between text-xs"><span className="text-gray-600 dark:text-gray-300">VAT (10%)</span><span>&euro;{vat.toFixed(2)}</span></div>
                       </div>
                       <div className="pt-1.5 border-t flex justify-between" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
-                        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">Total</span>
+                        <span className="text-sm font-semibold text-gray-900 dark:text-white">Total</span>
                         <span className="font-bold" style={{ color: 'var(--trip-base)' }}>&euro;{totalCost.toFixed(2)}</span>
                       </div>
                     </div>
@@ -762,7 +762,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
               >
                 <div className="flex items-center gap-2">
                   <Hotel size={14} style={{ color: 'var(--trip-base)' }} />
-                  <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">Room Options</span>
+                  <span className="text-xs font-semibold text-gray-900 dark:text-white">Room Options</span>
                   <span className="text-[10px] px-1.5 py-0.5 rounded-full border" style={{ color: 'var(--trip-base)', backgroundColor: 'rgb(var(--trip-base-rgb) / 0.05)', borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
                     {hotel.roomTypes[selectedRoom].type}
                   </span>
@@ -802,9 +802,9 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                                   <div className="flex items-start justify-between gap-2">
                                     <div>
                                       <div className="flex items-center gap-2 mb-0.5">
-                                        <span className={`text-xs font-semibold ${isSelected ? '' : 'text-gray-900 dark:text-gray-100'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>{room.type}</span>
+                                        <span className={`text-xs font-semibold ${isSelected ? '' : 'text-gray-900 dark:text-white'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>{room.type}</span>
                                         {isSelected && <span className="text-white text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: 'var(--trip-base)' }}>Selected</span>}
-                                        {priceDiff > 0 && !isSelected && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-200">+&euro;{priceDiff}/nt</span>}
+                                        {priceDiff > 0 && !isSelected && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400 border border-amber-200 dark:border-amber-700/30">+&euro;{priceDiff}/nt</span>}
                                       </div>
                                       <p className="text-[10px] text-gray-600 dark:text-gray-300">{room.beds}</p>
                                       <div className="flex items-center gap-2.5 text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
@@ -813,7 +813,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                                       </div>
                                     </div>
                                     <div className="text-right shrink-0">
-                                      <p className={`text-sm font-bold ${isSelected ? '' : 'text-gray-900 dark:text-gray-100'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>&euro;{room.price}</p>
+                                      <p className={`text-sm font-bold ${isSelected ? '' : 'text-gray-900 dark:text-white'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>&euro;{room.price}</p>
                                       <p className="text-[9px] text-gray-500 dark:text-gray-400">per night</p>
                                     </div>
                                   </div>
@@ -825,7 +825,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                             <AnimatePresence>
                               {expandedRoom === roomKey && (
                                 <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden">
-                                  <div className="mt-1.5 bg-white dark:bg-[var(--background)] rounded-lg border-2 overflow-hidden" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
+                                  <div className="mt-1.5 bg-white dark:bg-white/[0.03] rounded-lg border-2 overflow-hidden" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
                                     <div className="relative w-full h-48">
                                       {/* eslint-disable-next-line @next/next/no-img-element */}
                                       <img src={room.image} alt={room.type} referrerPolicy="no-referrer" className="absolute inset-0 w-full h-full object-cover" />
@@ -834,7 +834,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                                     <div className="p-3 space-y-2">
                                       <div className="flex justify-between">
                                         <div>
-                                          <h6 className="text-xs font-semibold text-gray-900 dark:text-gray-100">{room.type}</h6>
+                                          <h6 className="text-xs font-semibold text-gray-900 dark:text-white">{room.type}</h6>
                                           <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">{room.beds} &middot; {room.size} &middot; {room.guests} guests</p>
                                         </div>
                                         <div className="text-right">
@@ -866,15 +866,15 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
               <div className="grid grid-cols-3 gap-2">
                 <a href={`tel:${hotel.phone}`} onClick={(e) => e.stopPropagation()} className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                   <Phone size={14} style={{ color: 'var(--trip-base)' }} />
-                  <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Call</span>
+                  <span className="text-xs text-gray-900 dark:text-white font-medium">Call</span>
                 </a>
                 <a href={`mailto:${hotel.email}`} onClick={(e) => e.stopPropagation()} className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                   <Mail size={14} style={{ color: 'var(--trip-base)' }} />
-                  <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Email</span>
+                  <span className="text-xs text-gray-900 dark:text-white font-medium">Email</span>
                 </a>
                 <button onClick={(e) => e.stopPropagation()} className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                   <MapPin size={14} className="text-[#8b6f47]" />
-                  <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Map</span>
+                  <span className="text-xs text-gray-900 dark:text-white font-medium">Map</span>
                 </button>
               </div>
 
@@ -883,7 +883,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                 <div className="flex items-start gap-2">
                   <MapPin size={14} className="text-[#8b6f47] mt-0.5 flex-shrink-0" />
                   <div>
-                    <p className="text-xs text-gray-900 dark:text-gray-100 leading-snug">{hotel.address}</p>
+                    <p className="text-xs text-gray-900 dark:text-white leading-snug">{hotel.address}</p>
                     <p className="text-[10px] mt-0.5" style={{ color: 'var(--trip-base)' }}>{hotel.neighborhood}</p>
                   </div>
                 </div>
@@ -902,7 +902,7 @@ function HotelDetailPanel({ hotel, onSelect }: { hotel: HotelData; onSelect: (h:
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-baseline gap-1.5">
-                      <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">{hotel.guestRatings.label}</span>
+                      <span className="text-xs font-semibold text-gray-900 dark:text-white">{hotel.guestRatings.label}</span>
                       <span className="text-[10px] text-gray-400">&middot; {hotel.reviews} reviews</span>
                     </div>
                     <div className="flex flex-wrap gap-x-2 mt-1">
@@ -966,15 +966,15 @@ function BrowsingHotelGridCard({
   return (
     <div
       className={`rounded-xl border overflow-hidden transition-all flex flex-col cursor-pointer ${
-        isActive ? 'border-[var(--trip-base)] shadow-md ring-2 ring-[var(--trip-base)]/20' : 'border-gray-200 bg-white dark:bg-[var(--background)] hover:shadow-md'
+        isActive ? 'border-[var(--trip-base)] shadow-md ring-2 ring-[var(--trip-base)]/20' : 'border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:shadow-md dark:hover:border-white/15'
       }`}
       onClick={onViewDetails}
     >
       <ImageCarousel images={hotel.images} alt={hotel.name} height="h-44" />
-      <div className="p-3.5 flex flex-col flex-1 bg-white dark:bg-[var(--background)]">
+      <div className="p-3.5 flex flex-col flex-1 bg-white dark:bg-white/[0.03]">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <h4 className="text-sm font-bold text-gray-900 dark:text-gray-100 truncate">{hotel.name}</h4>
+            <h4 className="text-sm font-bold text-gray-900 dark:text-white truncate">{hotel.name}</h4>
             <StarRating count={hotel.stars} />
           </div>
           <div className="text-right shrink-0">
@@ -1020,18 +1020,18 @@ function BrowsingHotelListCard({
   return (
     <div
       className={`flex flex-col sm:flex-row rounded-xl border overflow-hidden transition-all cursor-pointer ${
-        isActive ? 'border-[var(--trip-base)] shadow-md ring-2 ring-[var(--trip-base)]/20' : 'border-gray-200 bg-white dark:bg-[var(--background)] hover:shadow-md'
+        isActive ? 'border-[var(--trip-base)] shadow-md ring-2 ring-[var(--trip-base)]/20' : 'border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:shadow-md dark:hover:border-white/15'
       }`}
       onClick={onViewDetails}
     >
       <div className="sm:w-60 flex-shrink-0">
         <ImageCarousel images={hotel.images} alt={hotel.name} height="h-48 sm:h-full" />
       </div>
-      <div className="flex-1 p-4 flex flex-col justify-between bg-white dark:bg-[var(--background)]">
+      <div className="flex-1 p-4 flex flex-col justify-between bg-white dark:bg-white/[0.03]">
         <div>
           <div className="flex items-start justify-between gap-2">
             <div>
-              <h4 className="text-sm font-bold text-gray-900 dark:text-gray-100">{hotel.name}</h4>
+              <h4 className="text-sm font-bold text-gray-900 dark:text-white">{hotel.name}</h4>
               <StarRating count={hotel.stars} />
             </div>
             <div className="text-right shrink-0">
@@ -1111,13 +1111,13 @@ function BrowsingHotelBookView({
             transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
             style={{ transformOrigin: direction > 0 ? 'left center' : 'right center' }}
           >
-            <div className="bg-white dark:bg-[var(--background)] rounded-xl border border-gray-200 dark:border-white/[0.08] overflow-hidden shadow-md">
+            <div className="bg-white dark:bg-white/[0.03] rounded-xl border border-gray-200 dark:border-white/[0.08] overflow-hidden shadow-md">
               <div className="grid grid-cols-1 md:grid-cols-2">
                 {/* Left page — large image */}
                 <div className="relative">
                   <ImageCarousel images={hotel.images} alt={hotel.name} height="h-72 md:h-96" />
                   {/* Page number badge */}
-                  <div className="absolute top-3 left-3 bg-white/90 backdrop-blur-sm text-[10px] font-semibold text-gray-600 dark:text-gray-300 px-2.5 py-1 rounded-full shadow-sm">
+                  <div className="absolute top-3 left-3 bg-white/90 dark:bg-black/60 backdrop-blur-sm text-[10px] font-semibold text-gray-600 dark:text-gray-300 px-2.5 py-1 rounded-full shadow-sm">
                     {page + 1} / {hotels.length}
                   </div>
                 </div>
@@ -1133,7 +1133,7 @@ function BrowsingHotelBookView({
                       {hotel.rating}
                     </span>
                   </div>
-                  <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100">{hotel.name}</h3>
+                  <h3 className="text-xl font-bold text-gray-900 dark:text-white">{hotel.name}</h3>
                   <div className="flex items-center gap-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
                     <MapPin size={12} />
                     <span>{hotel.neighborhood} &middot; {hotel.address}</span>
@@ -1151,7 +1151,7 @@ function BrowsingHotelBookView({
                         {hotel.guestRatings.overall}
                       </div>
                       <div>
-                        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{hotel.guestRatings.label}</p>
+                        <p className="text-sm font-semibold text-gray-900 dark:text-white">{hotel.guestRatings.label}</p>
                         <p className="text-[10px] text-gray-400">{hotel.reviews.toLocaleString()} reviews</p>
                       </div>
                     </div>
@@ -1170,9 +1170,9 @@ function BrowsingHotelBookView({
                       <p className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Room Types</p>
                       <div className="space-y-1">
                         {hotel.roomTypes.map((room, i) => (
-                          <div key={i} className="flex items-center justify-between text-xs bg-gray-50 dark:bg-white/5 rounded-lg px-3 py-2 border border-gray-100">
+                          <div key={i} className="flex items-center justify-between text-xs bg-gray-50 dark:bg-white/[0.02] rounded-lg px-3 py-2 border border-gray-100 dark:border-white/[0.06]">
                             <div>
-                              <span className="font-medium text-gray-900 dark:text-gray-100">{room.type}</span>
+                              <span className="font-medium text-gray-900 dark:text-white">{room.type}</span>
                               <span className="text-gray-400 ml-1.5">{room.beds}</span>
                             </div>
                             <span className="font-semibold" style={{ color: 'var(--trip-base)' }}>&euro;{room.price}</span>
@@ -1193,7 +1193,7 @@ function BrowsingHotelBookView({
                     {/* Check-in/out */}
                     <div className="flex gap-2 text-[10px]">
                       <span className="text-gray-500 dark:text-gray-400">Check-in: <span className="font-medium text-gray-700 dark:text-gray-200">{hotel.checkIn}</span></span>
-                      <span className="text-gray-300">|</span>
+                      <span className="text-gray-300 dark:text-white/20">|</span>
                       <span className="text-gray-500 dark:text-gray-400">Check-out: <span className="font-medium text-gray-700 dark:text-gray-200">{hotel.checkOut}</span></span>
                     </div>
                   </div>
@@ -1216,7 +1216,7 @@ function BrowsingHotelBookView({
         <button
           onClick={() => goTo(Math.max(0, page - 1))}
           disabled={page === 0}
-          className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-gray-200 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.08] text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           <ChevronLeft size={14} />
           Previous
@@ -1227,7 +1227,7 @@ function BrowsingHotelBookView({
               key={i}
               onClick={() => goTo(i)}
               className={`w-2 h-2 rounded-full transition-all ${
-                i === page ? 'bg-[#60a5fa] w-5' : 'bg-gray-300 hover:bg-gray-400'
+                i === page ? 'bg-[#60a5fa] w-5' : 'bg-gray-300 dark:bg-white/20 hover:bg-gray-400 dark:hover:bg-white/30'
               }`}
             />
           ))}
@@ -1235,7 +1235,7 @@ function BrowsingHotelBookView({
         <button
           onClick={() => goTo(Math.min(hotels.length - 1, page + 1))}
           disabled={page === hotels.length - 1}
-          className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-gray-200 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.08] text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           Next
           <ChevronRight size={14} />
@@ -1293,12 +1293,12 @@ function BrowsingHotelsSection({
   };
 
   return (
-    <div className="rounded-xl overflow-hidden bg-white dark:bg-[var(--background)] border border-gray-200 dark:border-white/[0.08] shadow-sm">
+    <div className="rounded-xl overflow-hidden bg-white dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] shadow-sm">
       <button onClick={onToggle}
-        className="w-full flex items-center justify-between px-4 py-3 transition-colors hover:bg-gray-50">
+        className="w-full flex items-center justify-between px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.02]">
         <div className="flex items-center gap-2.5">
           <Search size={16} className="text-gray-400" />
-          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">Browsing Hotels</span>
+          <span className="text-sm font-semibold text-gray-900 dark:text-white">Browsing Hotels</span>
           <span className="text-[10px] px-2 py-0.5 rounded-full font-medium"
             style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent, #c8a96a)', border: '1px solid rgba(200,169,106,0.25)' }}>{hotels.length} results</span>
         </div>
@@ -1339,7 +1339,7 @@ function BrowsingHotelsSection({
                         <X size={14} />
                       </button>
                     </div>
-                    <div className="bg-white dark:bg-[var(--background)]">
+                    <div className="bg-white dark:bg-white/[0.03]">
                       <HotelDetailPanel hotel={detailHotel} onSelect={onSelect} />
                     </div>
                   </motion.div>
@@ -1363,7 +1363,7 @@ function BrowsingHotelsSection({
                       className={`p-1.5 rounded-md transition-colors ${
                         viewMode === mode
                           ? 'bg-[#60a5fa] text-white'
-                          : 'bg-gray-100 text-gray-500 dark:text-gray-400 hover:bg-gray-200'
+                          : 'bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/10'
                       }`}
                       title={label}
                     >
@@ -1444,7 +1444,7 @@ function BookedHotelCard({
   const totalCost = baseTotal + cityTax + serviceFee + vat;
 
   return (
-    <div className="rounded-xl overflow-hidden border border-gray-200 dark:border-white/[0.08] shadow-sm bg-white dark:bg-[var(--background)]">
+    <div className="rounded-xl overflow-hidden border border-gray-200 dark:border-white/[0.08] shadow-sm bg-white dark:bg-white/[0.03]">
       {/* Gradient banner header */}
       <div className="px-4 py-3" style={{ background: 'linear-gradient(135deg, var(--trip-base), var(--trip-base-light))' }}>
         <div className="flex items-center justify-between text-white">
@@ -1468,29 +1468,29 @@ function BookedHotelCard({
             {/* Status badges */}
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-white text-[10px] px-2.5 py-1 rounded-full font-medium" style={{ backgroundColor: 'var(--trip-base)' }}>Confirmed</span>
-              <span className="flex items-center gap-0.5 bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded text-[10px]">
+              <span className="flex items-center gap-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 px-1.5 py-0.5 rounded text-[10px]">
                 <Star size={9} className="fill-blue-600 text-blue-600" />
                 <span className="font-medium">{hotel.rating}/10</span>
-                <span className="text-blue-600">({hotel.reviews})</span>
+                <span className="text-blue-600 dark:text-blue-400">({hotel.reviews})</span>
               </span>
             </div>
 
-            <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">{hotel.name}</h3>
+            <h3 className="text-lg font-bold text-gray-900 dark:text-white">{hotel.name}</h3>
 
             {/* Check-in / check-out */}
             <div className="flex gap-2">
               <div className="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/30 px-3 py-2">
-                <span className="text-[10px] text-blue-800 block font-medium">Check-in</span>
-                <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">Mar 22 &middot; {hotel.checkIn}</span>
+                <span className="text-[10px] text-blue-800 dark:text-blue-300 block font-medium">Check-in</span>
+                <span className="text-xs font-semibold text-gray-900 dark:text-white">Mar 22 &middot; {hotel.checkIn}</span>
               </div>
               <div className="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/30 px-3 py-2">
-                <span className="text-[10px] text-blue-800 block font-medium">Check-out</span>
-                <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">Mar 27 &middot; {hotel.checkOut}</span>
+                <span className="text-[10px] text-blue-800 dark:text-blue-300 block font-medium">Check-out</span>
+                <span className="text-xs font-semibold text-gray-900 dark:text-white">Mar 27 &middot; {hotel.checkOut}</span>
               </div>
             </div>
 
             {/* Cancellation badge */}
-            <span className="inline-flex items-center gap-1 bg-emerald-100 text-emerald-800 px-2.5 py-1 rounded-full text-[10px] font-medium">
+            <span className="inline-flex items-center gap-1 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 px-2.5 py-1 rounded-full text-[10px] font-medium">
               <Shield size={10} /> {hotel.cancellation}
             </span>
 
@@ -1515,13 +1515,13 @@ function BookedHotelCard({
                       </div>
                     </div>
                   </div>
-                  <div className="p-3 space-y-2.5 bg-white dark:bg-[var(--background)]">
+                  <div className="p-3 space-y-2.5 bg-white dark:bg-white/[0.03]">
                     {/* Room specs */}
                     <div className="flex items-center gap-4 text-xs text-gray-600 dark:text-gray-300">
                       <span className="flex items-center gap-1"><Users size={12} style={{ color: 'var(--trip-base)' }} /> {room.guests} {room.guests === 1 ? 'Guest' : 'Guests'}</span>
-                      <span className="text-gray-300">|</span>
+                      <span className="text-gray-300 dark:text-white/20">|</span>
                       <span>{room.beds}</span>
-                      <span className="text-gray-300">|</span>
+                      <span className="text-gray-300 dark:text-white/20">|</span>
                       <span>{room.size}</span>
                     </div>
 
@@ -1530,7 +1530,7 @@ function BookedHotelCard({
                       <p className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Room Amenities</p>
                       <div className="flex flex-wrap gap-1.5">
                         {room.amenities.map((a, idx) => (
-                          <span key={idx} className="text-[10px] bg-gray-50 text-gray-600 dark:text-gray-300 px-2 py-1 rounded-md border border-gray-200 flex items-center gap-1">
+                          <span key={idx} className="text-[10px] bg-gray-50 dark:bg-white/[0.02] text-gray-600 dark:text-gray-300 px-2 py-1 rounded-md border border-gray-200 dark:border-white/[0.08] flex items-center gap-1">
                             {AMENITY_ICONS[a] || null} {a}
                           </span>
                         ))}
@@ -1544,9 +1544,9 @@ function BookedHotelCard({
                         <p className="text-sm font-bold" style={{ color: 'var(--trip-base)' }}>&euro;{(room.price * nights).toFixed(0)}</p>
                         <p className="text-[9px] text-gray-400">{nights} nights</p>
                       </div>
-                      <div className="rounded-md bg-gray-50 p-2 text-center">
+                      <div className="rounded-md bg-gray-50 dark:bg-white/[0.02] p-2 text-center">
                         <p className="text-[9px] text-gray-500 dark:text-gray-400 uppercase tracking-wide">Check-in</p>
-                        <p className="text-sm font-bold text-gray-900 dark:text-gray-100">{hotel.checkIn}</p>
+                        <p className="text-sm font-bold text-gray-900 dark:text-white">{hotel.checkIn}</p>
                         <p className="text-[9px] text-gray-400">Mar 22</p>
                       </div>
                     </div>
@@ -1581,7 +1581,7 @@ function BookedHotelCard({
                         <div className="flex justify-between text-xs"><span className="text-gray-600 dark:text-gray-300">VAT (10%)</span><span>&euro;{vat.toFixed(2)}</span></div>
                       </div>
                       <div className="pt-1.5 border-t flex justify-between" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
-                        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">Total</span>
+                        <span className="text-sm font-semibold text-gray-900 dark:text-white">Total</span>
                         <span className="font-bold" style={{ color: 'var(--trip-base)' }}>&euro;{totalCost.toFixed(2)}</span>
                       </div>
                     </div>
@@ -1595,7 +1595,7 @@ function BookedHotelCard({
               <button onClick={() => setRoomsOpen(!roomsOpen)} className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
                 <div className="flex items-center gap-2">
                   <Hotel size={14} style={{ color: 'var(--trip-base)' }} />
-                  <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">Room Options</span>
+                  <span className="text-xs font-semibold text-gray-900 dark:text-white">Room Options</span>
                   <span className="text-[10px] px-1.5 py-0.5 rounded-full border" style={{ color: 'var(--trip-base)', backgroundColor: 'rgb(var(--trip-base-rgb) / 0.05)', borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
                     {hotel.roomTypes[selectedRoom].type}
                   </span>
@@ -1633,9 +1633,9 @@ function BookedHotelCard({
                                 <div className="flex items-start justify-between gap-2">
                                   <div>
                                     <div className="flex items-center gap-2 mb-0.5">
-                                      <span className={`text-xs font-semibold ${isSelected ? '' : 'text-gray-900 dark:text-gray-100'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>{room.type}</span>
+                                      <span className={`text-xs font-semibold ${isSelected ? '' : 'text-gray-900 dark:text-white'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>{room.type}</span>
                                       {isSelected && <span className="text-white text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: 'var(--trip-base)' }}>Current</span>}
-                                      {priceDiff > 0 && !isSelected && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-200">+&euro;{priceDiff}/nt</span>}
+                                      {priceDiff > 0 && !isSelected && <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400 border border-amber-200 dark:border-amber-700/30">+&euro;{priceDiff}/nt</span>}
                                     </div>
                                     <p className="text-[10px] text-gray-600 dark:text-gray-300">{room.beds}</p>
                                     <div className="flex items-center gap-2.5 text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
@@ -1644,7 +1644,7 @@ function BookedHotelCard({
                                     </div>
                                   </div>
                                   <div className="text-right shrink-0">
-                                    <p className={`text-sm font-bold ${isSelected ? '' : 'text-gray-900 dark:text-gray-100'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>&euro;{room.price}</p>
+                                    <p className={`text-sm font-bold ${isSelected ? '' : 'text-gray-900 dark:text-white'}`} style={isSelected ? { color: 'var(--trip-base)' } : undefined}>&euro;{room.price}</p>
                                     <p className="text-[9px] text-gray-500 dark:text-gray-400">per night</p>
                                   </div>
                                 </div>
@@ -1655,7 +1655,7 @@ function BookedHotelCard({
                             <AnimatePresence>
                               {expandedRoom === roomKey && (
                                 <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden">
-                                  <div className="mt-1.5 bg-white dark:bg-[var(--background)] rounded-lg border-2 overflow-hidden" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
+                                  <div className="mt-1.5 bg-white dark:bg-white/[0.03] rounded-lg border-2 overflow-hidden" style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.2)' }}>
                                     <div className="relative w-full h-48">
                                       {/* eslint-disable-next-line @next/next/no-img-element */}
                                       <img src={room.image} alt={room.type} referrerPolicy="no-referrer" className="absolute inset-0 w-full h-full object-cover" />
@@ -1664,7 +1664,7 @@ function BookedHotelCard({
                                     <div className="p-3 space-y-2">
                                       <div className="flex justify-between">
                                         <div>
-                                          <h6 className="text-xs font-semibold text-gray-900 dark:text-gray-100">{room.type}</h6>
+                                          <h6 className="text-xs font-semibold text-gray-900 dark:text-white">{room.type}</h6>
                                           <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">{room.beds} &middot; {room.size} &middot; {room.guests} guests</p>
                                         </div>
                                         <div className="text-right">
@@ -1696,20 +1696,20 @@ function BookedHotelCard({
               <p className="text-[10px] font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wide">Booking Details</p>
               <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
                 <span className="text-gray-500 dark:text-gray-400">Confirmation #</span>
-                <span className="font-medium text-gray-900 dark:text-gray-100">HTL-2026-{hotel.id.toUpperCase()}</span>
+                <span className="font-medium text-gray-900 dark:text-white">HTL-2026-{hotel.id.toUpperCase()}</span>
                 <span className="text-gray-500 dark:text-gray-400">Property ID</span>
-                <span className="font-medium text-gray-900 dark:text-gray-100">{hotel.id.toUpperCase()}-PAR</span>
+                <span className="font-medium text-gray-900 dark:text-white">{hotel.id.toUpperCase()}-PAR</span>
                 <span className="text-gray-500 dark:text-gray-400">Guest</span>
-                <span className="font-medium text-gray-900 dark:text-gray-100">2 Adults</span>
+                <span className="font-medium text-gray-900 dark:text-white">2 Adults</span>
                 <span className="text-gray-500 dark:text-gray-400">Payment</span>
-                <span className="font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1"><CreditCard size={10} /> **** 4242</span>
+                <span className="font-medium text-gray-900 dark:text-white flex items-center gap-1"><CreditCard size={10} /> **** 4242</span>
               </div>
             </div>
 
             {/* Hotel policies (collapsible) */}
             <div className="bg-white dark:bg-white/5 rounded-lg border border-gray-200 dark:border-white/[0.08] overflow-hidden">
               <button onClick={() => setPoliciesOpen(!policiesOpen)} className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
-                <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">Hotel Policies</span>
+                <span className="text-xs font-semibold text-gray-900 dark:text-white">Hotel Policies</span>
                 <ChevronDown size={14} className={`text-gray-400 transition-transform ${policiesOpen ? 'rotate-180' : ''}`} />
               </button>
               <AnimatePresence>
@@ -1755,15 +1755,15 @@ function BookedHotelCard({
             <div className="grid grid-cols-3 gap-2">
               <a href={`tel:${hotel.phone}`} className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                 <Phone size={14} style={{ color: 'var(--trip-base)' }} />
-                <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Call</span>
+                <span className="text-xs text-gray-900 dark:text-white font-medium">Call</span>
               </a>
               <a href={`mailto:${hotel.email}`} className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                 <Mail size={14} style={{ color: 'var(--trip-base)' }} />
-                <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Email</span>
+                <span className="text-xs text-gray-900 dark:text-white font-medium">Email</span>
               </a>
               <button className="flex flex-col items-center justify-center gap-1.5 bg-white dark:bg-white/5 rounded-md p-2.5 border border-gray-200 dark:border-white/[0.08] hover:border-trip-base hover:shadow-sm transition-all">
                 <Map size={14} className="text-[#8b6f47]" />
-                <span className="text-xs text-gray-900 dark:text-gray-100 font-medium">Map</span>
+                <span className="text-xs text-gray-900 dark:text-white font-medium">Map</span>
               </button>
             </div>
 
@@ -1772,7 +1772,7 @@ function BookedHotelCard({
               <div className="flex items-start gap-2">
                 <MapPin size={14} className="text-[#8b6f47] mt-0.5 flex-shrink-0" />
                 <div>
-                  <p className="text-xs text-gray-900 dark:text-gray-100 leading-snug">{hotel.address}</p>
+                  <p className="text-xs text-gray-900 dark:text-white leading-snug">{hotel.address}</p>
                   <p className="text-[10px] mt-0.5" style={{ color: 'var(--trip-base)' }}>{hotel.neighborhood}</p>
                 </div>
               </div>
@@ -1791,7 +1791,7 @@ function BookedHotelCard({
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-baseline gap-1.5">
-                    <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">{hotel.guestRatings.label}</span>
+                    <span className="text-xs font-semibold text-gray-900 dark:text-white">{hotel.guestRatings.label}</span>
                     <span className="text-[10px] text-gray-400">&middot; {hotel.reviews} reviews</span>
                   </div>
                   <div className="flex flex-wrap gap-x-2.5 mt-1">

--- a/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
@@ -19,7 +19,7 @@ function CollapsibleSection({
   icon,
   badge,
   badgeColor,
-  bgClass = 'bg-white',
+  bgClass = 'bg-white dark:bg-white/[0.03]',
   children,
   defaultOpen = false,
 }: {
@@ -34,14 +34,14 @@ function CollapsibleSection({
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <div className={`${bgClass} rounded-xl shadow-md`}>
+    <div className={`${bgClass} rounded-xl border border-gray-200 dark:border-white/[0.08] shadow-sm`}>
       <button
         onClick={() => setOpen(!open)}
-        className="w-full p-3 flex items-center justify-between hover:bg-gray-50/50 transition-colors rounded-xl"
+        className="w-full p-3 flex items-center justify-between hover:bg-gray-50/50 dark:hover:bg-white/[0.04] transition-colors rounded-xl"
       >
         <div className="flex items-center gap-2">
           {icon}
-          <h5 className="text-sm font-semibold text-gray-900">{title}</h5>
+          <h5 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h5>
           {badge && (
             <span className={`text-xs px-2 py-0.5 rounded-full ${badgeColor}`}>
               {badge}
@@ -100,9 +100,9 @@ function DetailCard({
     >
       <div className="flex items-center gap-2">
         {icon}
-        <p className={`text-sm text-gray-900 group-hover:${themeAccent}`}>{title}</p>
+        <p className={`text-sm text-gray-900 dark:text-white group-hover:${themeAccent}`}>{title}</p>
       </div>
-      <p className="text-xs text-gray-600 mt-1">{subtitle}</p>
+      <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">{subtitle}</p>
       <AnimatePresence>
         {expanded ? (
           <motion.div
@@ -112,7 +112,7 @@ function DetailCard({
             transition={{ duration: 0.15 }}
             className="overflow-hidden"
           >
-            <p className="text-xs text-gray-700 mt-2 bg-white/80 p-2.5 rounded-lg border border-gray-200 leading-relaxed">
+            <p className="text-xs text-gray-700 dark:text-gray-300 mt-2 bg-white/80 dark:bg-white/[0.05] p-2.5 rounded-lg border border-gray-200 dark:border-white/[0.08] leading-relaxed">
               {detail}
             </p>
           </motion.div>
@@ -222,9 +222,9 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
   if (isLoading || !trip) {
     return (
       <div className="space-y-4">
-        <div className="h-32 rounded-xl bg-gray-200 animate-pulse" />
-        <div className="h-16 rounded-xl bg-gray-200 animate-pulse" />
-        <div className="h-16 rounded-xl bg-gray-200 animate-pulse" />
+        <div className="h-32 rounded-xl bg-gray-200 dark:bg-white/[0.08] animate-pulse" />
+        <div className="h-16 rounded-xl bg-gray-200 dark:bg-white/[0.08] animate-pulse" />
+        <div className="h-16 rounded-xl bg-gray-200 dark:bg-white/[0.08] animate-pulse" />
       </div>
     );
   }
@@ -268,7 +268,7 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             title="Getting Around"
             icon={<Train size={18} className="text-purple-600" />}
             badge="4 options"
-            badgeColor="bg-purple-100 text-purple-700"
+            badgeColor="bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-300"
             defaultOpen
           >
             {transportOptions.map((t) => (
@@ -278,8 +278,8 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
                 title={t.name}
                 subtitle={t.subtitle}
                 detail={t.detail}
-                themeBg="bg-purple-50"
-                themeHover="hover:bg-purple-100"
+                themeBg="bg-purple-50 dark:bg-purple-500/10"
+                themeHover="hover:bg-purple-100 dark:hover:bg-purple-500/20"
                 themeAccent="text-purple-600"
               />
             ))}
@@ -290,7 +290,7 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             title="Must-Try Restaurants"
             icon={<Utensils size={18} className="text-red-600" />}
             badge="3 spots"
-            badgeColor="bg-red-100 text-red-700"
+            badgeColor="bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-300"
           >
             {restaurantData.map((r: { name: string; subtitle: string; detail: string }) => (
               <DetailCard
@@ -299,8 +299,8 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
                 title={r.name}
                 subtitle={r.subtitle}
                 detail={r.detail}
-                themeBg="bg-red-50"
-                themeHover="hover:bg-red-100"
+                themeBg="bg-red-50 dark:bg-red-500/10"
+                themeHover="hover:bg-red-100 dark:hover:bg-red-500/20"
                 themeAccent="text-red-600"
               />
             ))}
@@ -314,7 +314,7 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             title="Transportation Passes"
             icon={<CreditCard size={18} className="text-blue-600" />}
             badge={`${transportOptions.length} options`}
-            badgeColor="bg-blue-100 text-blue-700"
+            badgeColor="bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-300"
           >
             {transportOptions.map((p) => (
               <DetailCard
@@ -323,8 +323,8 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
                 title={p.name}
                 subtitle={p.subtitle}
                 detail={p.detail}
-                themeBg="bg-blue-50"
-                themeHover="hover:bg-blue-100"
+                themeBg="bg-blue-50 dark:bg-blue-500/10"
+                themeHover="hover:bg-blue-100 dark:hover:bg-blue-500/20"
                 themeAccent="text-blue-600"
               />
             ))}
@@ -335,7 +335,7 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             title="Must-Do Experiences"
             icon={<Camera size={18} className="text-green-600" />}
             badge={`${experiences.length} experiences`}
-            badgeColor="bg-green-100 text-green-700"
+            badgeColor="bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-300"
             defaultOpen
           >
             {experiences.map((e: { name: string; subtitle: string; detail: string }) => (
@@ -345,8 +345,8 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
                 title={e.name}
                 subtitle={e.subtitle}
                 detail={e.detail}
-                themeBg="bg-green-50"
-                themeHover="hover:bg-green-100"
+                themeBg="bg-green-50 dark:bg-green-500/10"
+                themeHover="hover:bg-green-100 dark:hover:bg-green-500/20"
                 themeAccent="text-green-600"
               />
             ))}
@@ -357,27 +357,27 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             title="Emergency Information"
             icon={<ShieldAlert size={18} className="text-red-700" />}
             badge="112 &bull; 15"
-            badgeColor="bg-red-200 text-red-800"
-            bgClass="bg-gradient-to-r from-red-50 to-rose-50"
+            badgeColor="bg-red-200 dark:bg-red-500/20 text-red-800 dark:text-red-300"
+            bgClass="bg-gradient-to-r from-red-50 to-rose-50 dark:from-red-500/10 dark:to-rose-500/10"
           >
             {/* Emergency Numbers */}
             <button
               onClick={() => {}}
-              className="w-full bg-white p-3 rounded-lg hover:bg-red-50 transition-all cursor-default text-left border border-red-200"
+              className="w-full bg-white dark:bg-white/[0.03] p-3 rounded-lg hover:bg-red-50 dark:hover:bg-red-500/10 transition-all cursor-default text-left border border-red-200 dark:border-red-500/20"
             >
               <div className="flex items-center gap-2 mb-2">
-                <Phone size={16} className="text-red-600" />
-                <p className="text-sm font-semibold text-gray-900">Emergency Numbers</p>
+                <Phone size={16} className="text-red-600 dark:text-red-400" />
+                <p className="text-sm font-semibold text-gray-900 dark:text-white">Emergency Numbers</p>
               </div>
               <div className="grid grid-cols-2 gap-2">
                 {emergencyNumbers.map((e) => (
                   <a
                     key={e.number}
                     href={`tel:${e.number}`}
-                    className="p-2 bg-red-50 rounded-lg hover:bg-red-100 transition-colors text-center"
+                    className="p-2 bg-red-50 dark:bg-red-500/10 rounded-lg hover:bg-red-100 dark:hover:bg-red-500/20 transition-colors text-center"
                   >
-                    <p className="text-lg font-bold text-red-600">{e.number}</p>
-                    <p className="text-[11px] text-gray-600">{e.label}</p>
+                    <p className="text-lg font-bold text-red-600 dark:text-red-400">{e.number}</p>
+                    <p className="text-[11px] text-gray-600 dark:text-gray-400">{e.label}</p>
                   </a>
                 ))}
               </div>
@@ -386,30 +386,30 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
             {/* Hospitals */}
             <button
               onClick={() => {}}
-              className="w-full bg-white p-3 rounded-lg hover:bg-red-50 transition-all cursor-default text-left border border-red-200"
+              className="w-full bg-white dark:bg-white/[0.03] p-3 rounded-lg hover:bg-red-50 dark:hover:bg-red-500/10 transition-all cursor-default text-left border border-red-200 dark:border-red-500/20"
             >
               <div className="flex items-center gap-2 mb-2">
-                <Ambulance size={16} className="text-red-600" />
-                <p className="text-sm font-semibold text-gray-900">Hospitals & Medical</p>
+                <Ambulance size={16} className="text-red-600 dark:text-red-400" />
+                <p className="text-sm font-semibold text-gray-900 dark:text-white">Hospitals & Medical</p>
               </div>
               <div className="space-y-1.5">
-                <div className="text-xs text-gray-700">
+                <div className="text-xs text-gray-700 dark:text-gray-300">
                   <p className="font-medium">Hotel-Dieu Hospital</p>
-                  <p className="text-gray-500">1 Place du Parvis Notre-Dame, 75004</p>
-                  <a href="tel:+33142348234" className="text-blue-600 hover:underline">+33 1 42 34 82 34</a>
+                  <p className="text-gray-500 dark:text-gray-400">1 Place du Parvis Notre-Dame, 75004</p>
+                  <a href="tel:+33142348234" className="text-blue-600 dark:text-blue-400 hover:underline">+33 1 42 34 82 34</a>
                 </div>
-                <div className="text-xs text-gray-700">
+                <div className="text-xs text-gray-700 dark:text-gray-300">
                   <p className="font-medium">American Hospital of Paris</p>
-                  <p className="text-gray-500">63 Blvd Victor Hugo, 92200 Neuilly</p>
-                  <a href="tel:+33146412525" className="text-blue-600 hover:underline">+33 1 46 41 25 25</a>
+                  <p className="text-gray-500 dark:text-gray-400">63 Blvd Victor Hugo, 92200 Neuilly</p>
+                  <a href="tel:+33146412525" className="text-blue-600 dark:text-blue-400 hover:underline">+33 1 46 41 25 25</a>
                 </div>
               </div>
             </button>
 
             {/* Safety Tips */}
-            <div className="bg-white p-3 rounded-lg border border-amber-300">
-              <p className="text-xs font-semibold text-gray-900 mb-2">Important Safety Tips</p>
-              <ul className="text-xs text-gray-700 space-y-1">
+            <div className="bg-white dark:bg-white/[0.03] p-3 rounded-lg border border-amber-300 dark:border-amber-500/30">
+              <p className="text-xs font-semibold text-gray-900 dark:text-white mb-2">Important Safety Tips</p>
+              <ul className="text-xs text-gray-700 dark:text-gray-300 space-y-1">
                 {safetyTips.map((tip, i) => (
                   <li key={i} className="flex items-start gap-1.5">
                     <span className="text-amber-500 shrink-0 mt-px">&#x2022;</span>

--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -1211,7 +1211,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
 
   return (
     <div className="relative overflow-hidden">
-      <div className="relative z-10 px-6 sm:px-10 pb-8">
+      <div className="relative z-10 pb-8">
 
         {/* ── Day selector — draggable to reorder ── */}
         <div className="flex items-center gap-1 overflow-x-auto scrollbar-hide py-2 mb-4">

--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -263,7 +263,7 @@ function GlanceView({
                     {day.dateLabel}
                   </p>
                   <div className="flex items-end justify-between">
-                    <h3 className="text-base font-bold font-serif text-white">{day.dayLabel}</h3>
+                    <h3 className="text-base font-bold text-white">{day.dayLabel}</h3>
                     <span className="text-[9px] text-white/40">
                       {day.activityCount} {day.activityCount === 1 ? 'activity' : 'activities'}
                     </span>
@@ -540,7 +540,7 @@ function GlanceView({
                 <div className="absolute inset-0" style={{ background: 'linear-gradient(to right, #0f0f1e 0%, transparent 20%)' }} />
                 {/* Day label — bottom right */}
                 <div className="absolute bottom-3 right-3">
-                  <p className="text-sm font-bold text-white/60 font-serif" style={{ textShadow: '0 1px 6px rgba(0,0,0,0.5)' }}>
+                  <p className="text-sm font-bold text-white/60" style={{ textShadow: '0 1px 6px rgba(0,0,0,0.5)' }}>
                     {day.dayLabel}
                   </p>
                 </div>
@@ -1232,16 +1232,18 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
               }}
               onDragEnd={() => { dragDayRef.current = null; setDragOverIdx(null); }}
               onClick={() => setSelectedDayIndex(i)}
-              className={`shrink-0 px-3 py-1.5 rounded-lg text-center transition-all cursor-grab active:cursor-grabbing ${
-                dragOverIdx === i ? 'ring-2 ring-white/40 scale-105' : ''
+              className={`shrink-0 px-3 py-1.5 rounded-lg text-center transition-all cursor-grab active:cursor-grabbing border ${
+                dragOverIdx === i ? 'ring-2 ring-gray-400 dark:ring-white/40 scale-105' : ''
+              } ${
+                i === selectedDayIndex
+                  ? 'bg-gray-100 dark:bg-white/[0.15] border-gray-300 dark:border-white/[0.25]'
+                  : dragOverIdx === i
+                    ? 'bg-gray-50 dark:bg-white/[0.08] border-transparent'
+                    : 'bg-transparent border-transparent'
               }`}
-              style={{
-                backgroundColor: i === selectedDayIndex ? 'rgba(255,255,255,0.15)' : dragOverIdx === i ? 'rgba(255,255,255,0.08)' : 'transparent',
-                border: i === selectedDayIndex ? '1px solid rgba(255,255,255,0.25)' : '1px solid transparent',
-              }}
             >
-              <span className="block text-[10px] font-bold text-white/50">{d.dayLabel.replace('Day ', 'D')}</span>
-              <span className="block text-[11px] font-medium text-white/80">{d.dateLabel.replace(/,.*/, '')}</span>
+              <span className="block text-[10px] font-bold text-gray-500 dark:text-white/50">{d.dayLabel.replace('Day ', 'D')}</span>
+              <span className="block text-[11px] font-medium text-gray-800 dark:text-white/80">{d.dateLabel.replace(/,.*/, '')}</span>
             </button>
           ))}
         </div>
@@ -1250,17 +1252,15 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
         <section>
           <div className="mb-4 flex items-end justify-between">
             <div>
-              <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-white/70"
-                style={{ textShadow: '0 1px 6px rgba(0,0,0,0.4)' }}>Your Itinerary</p>
-              <h2 className="text-2xl sm:text-3xl font-normal font-serif text-white tracking-wide"
+              <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-white/70">Your Itinerary</p>
+              <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white tracking-wide"
                 style={{ textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}>At a Glance</h2>
             </div>
             <div className="relative shrink-0 mr-2" ref={regenMenuRef}>
               <button
                 onClick={() => !regenerating && setRegenMenuOpen(v => !v)}
                 disabled={regenerating}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-semibold text-white/70 hover:text-white hover:bg-white/10 transition-all disabled:opacity-50"
-                style={{ border: '1px solid rgba(255,255,255,0.2)' }}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-semibold text-gray-600 dark:text-white/70 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/10 border border-gray-200 dark:border-white/[0.2] transition-all disabled:opacity-50"
               >
                 <RefreshCw size={12} className={regenerating ? 'animate-spin' : ''} />
                 {regenerating ? 'Working...' : 'Regenerate'}
@@ -1268,48 +1268,48 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
               </button>
               {regenMenuOpen && !regenerating && (
                 <div className="absolute right-0 top-full mt-1.5 z-50 animate-[fadeSlideIn_0.15s_ease-out]">
-                  <div className="bg-[#0f1f33] border border-white/15 rounded-xl p-1.5 shadow-2xl min-w-[200px] backdrop-blur-xl">
-                    <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-white/30 font-semibold">Regenerate</p>
+                  <div className="bg-white dark:bg-[#0f1f33] border border-gray-200 dark:border-white/15 rounded-xl p-1.5 shadow-2xl min-w-[200px] backdrop-blur-xl">
+                    <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-gray-400 dark:text-white/30 font-semibold">Regenerate</p>
                     <button onClick={() => { setRegenMenuOpen(false); handleRegenerate(); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <RefreshCw size={11} /> Entire trip
                     </button>
                     <button onClick={() => { setRegenMenuOpen(false); handleRegenerateDay(selectedDayIndex); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <Calendar size={11} /> Day {selectedDayIndex + 1} only
                     </button>
                     <button onClick={() => { setRegenMenuOpen(false); handleFillEmpty(selectedDayIndex); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <Compass size={11} /> Fill empty slots
                     </button>
-                    <div className="mx-2 my-1 h-px bg-white/10" />
-                    <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-white/30 font-semibold">Suggest for Day {selectedDayIndex + 1}</p>
+                    <div className="mx-2 my-1 h-px bg-gray-100 dark:bg-white/10" />
+                    <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-gray-400 dark:text-white/30 font-semibold">Suggest for Day {selectedDayIndex + 1}</p>
                     <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('restaurant', selectedDayIndex, 'evening'); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <UtensilsCrossed size={11} /> Restaurant
                     </button>
                     <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('attraction', selectedDayIndex, 'morning'); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <Landmark size={11} /> Attraction
                     </button>
                     <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('nightlife bar', selectedDayIndex, 'latenight'); }}
-                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                      className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                       <Moon size={11} /> Nightlife
                     </button>
                     {trip?.trip_context?.lat && (
                       <>
-                        <div className="mx-2 my-1 h-px bg-white/10" />
-                        <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-white/30 font-semibold">Nearby</p>
+                        <div className="mx-2 my-1 h-px bg-gray-100 dark:bg-white/10" />
+                        <p className="px-3 py-1 text-[9px] uppercase tracking-wider text-gray-400 dark:text-white/30 font-semibold">Nearby</p>
                         <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('restaurant', selectedDayIndex, 'evening', true); }}
-                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                           <UtensilsCrossed size={11} /> Restaurant nearby
                         </button>
                         <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('cafe coffee', selectedDayIndex, 'morning', true); }}
-                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                           <MapPin size={11} /> Cafe nearby
                         </button>
                         <button onClick={() => { setRegenMenuOpen(false); handleSuggestActivity('things to do', selectedDayIndex, 'afternoon', true); }}
-                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-white/80 hover:bg-white/10 transition-colors flex items-center gap-2">
+                          className="w-full text-left px-3 py-2 rounded-lg text-[11px] text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors flex items-center gap-2">
                           <Compass size={11} /> Activity nearby
                         </button>
                       </>
@@ -1318,50 +1318,40 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-full backdrop-blur-md"
-              style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}>
-              <span className="text-[11px] tabular-nums mr-1 text-white/70">
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-full backdrop-blur-md bg-gray-100/80 dark:bg-black/30">
+              <span className="text-[11px] tabular-nums mr-1 text-gray-600 dark:text-white/70">
                 {selectedDayIndex + 1} / {days.length}
               </span>
               <button onClick={() => selectedDayIndex > 0 && setSelectedDayIndex(selectedDayIndex - 1)} disabled={selectedDayIndex === 0}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-                style={{ border: '1px solid rgba(255,255,255,0.25)' }}>
-                <ChevronDown size={14} className="rotate-90 text-white/70" />
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/[0.25]">
+                <ChevronDown size={14} className="rotate-90 text-gray-600 dark:text-white/70" />
               </button>
               <button onClick={() => selectedDayIndex < days.length - 1 && setSelectedDayIndex(selectedDayIndex + 1)} disabled={selectedDayIndex === days.length - 1}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-                style={{ border: '1px solid rgba(255,255,255,0.25)' }}>
-                <ChevronDown size={14} className="-rotate-90 text-white/70" />
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/[0.25]">
+                <ChevronDown size={14} className="-rotate-90 text-gray-600 dark:text-white/70" />
               </button>
               <a
                 href={`/trip/${id}/calendar`}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
-                style={{ border: '1px solid rgba(255,255,255,0.25)' }}
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/[0.25]"
                 title="Calendar view"
               >
-                <Calendar size={13} className="text-white/70" />
+                <Calendar size={13} className="text-gray-600 dark:text-white/70" />
               </a>
               <button
                 onClick={() => setCompactOpen((v) => !v)}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
-                style={{
-                  border: '1px solid rgba(255,255,255,0.25)',
-                  backgroundColor: compactOpen ? 'rgba(255,255,255,0.2)' : 'transparent',
-                  color: compactOpen ? 'white' : 'rgba(255,255,255,0.7)',
-                }}
+                className={`w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/[0.25] ${
+                  compactOpen ? 'bg-gray-200 dark:bg-white/[0.2] text-gray-900 dark:text-white' : 'text-gray-600 dark:text-white/70'
+                }`}
                 title={compactOpen ? 'Hide day details' : 'Show day details'}
               >
                 <LayoutList size={13} />
               </button>
-              <div className="w-px h-4 mx-1 bg-white/20" />
+              <div className="w-px h-4 mx-1 bg-gray-300 dark:bg-white/20" />
               <button
                 onClick={() => setRequestMapOpen((v: boolean) => !v)}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
-                style={{
-                  border: '1px solid rgba(255,255,255,0.25)',
-                  backgroundColor: requestMapOpen ? 'rgba(255,255,255,0.2)' : 'transparent',
-                  color: requestMapOpen ? 'white' : 'rgba(255,255,255,0.7)',
-                }}
+                className={`w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/[0.25] ${
+                  requestMapOpen ? 'bg-gray-200 dark:bg-white/[0.2] text-gray-900 dark:text-white' : 'text-gray-600 dark:text-white/70'
+                }`}
                 title="Toggle map"
               >
                 <Map size={13} />
@@ -1394,12 +1384,10 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
       {compactOpen && selectedDay && (
         <section className="mt-8">
           <div className="mb-4">
-            <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1"
-              style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
+            <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-gray-400">
               {selectedDay.dateLabel}
             </p>
-            <h2 className="text-xl sm:text-2xl font-bold font-serif"
-              style={{ color: 'var(--magazine-heading, #1a1a2e)' }}>
+            <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">
               {selectedDay.dayLabel} — {selectedDay.theme || 'Your Day'}
             </h2>
           </div>
@@ -1410,17 +1398,17 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
           {/* Flight placeholder on first day — links to Flights tab */}
           {isFirstDay && !arrivalFlight && tripFlight && (
             <section className="mb-3.5">
-              <a href={`/trip/${id}/flights`} className="block rounded-lg p-3 shadow-sm border border-blue-200/60 bg-gradient-to-r from-blue-50 to-indigo-50 hover:shadow-md transition-shadow group">
+              <a href={`/trip/${id}/flights`} className="block rounded-xl p-3 shadow-sm border border-blue-200/60 dark:border-blue-500/20 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/20 hover:shadow-md transition-shadow group">
                 <div className="flex items-center gap-2.5">
                   <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ backgroundColor: 'var(--trip-base)' }}>
                     <PaperPlane size={14} className="text-white" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-[11px] font-semibold text-blue-700 uppercase tracking-wider">Arrival Flight</p>
-                    <p className="text-sm font-medium text-gray-900">Flight to {tripFlight.city} ({tripFlight.destAirport})</p>
-                    <p className="text-[11px] text-gray-500">Tap to search and select your flight</p>
+                    <p className="text-[11px] font-semibold text-blue-700 dark:text-blue-400 uppercase tracking-wider">Arrival Flight</p>
+                    <p className="text-sm font-medium text-gray-900 dark:text-white">Flight to {tripFlight.city} ({tripFlight.destAirport})</p>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400">Tap to search and select your flight</p>
                   </div>
-                  <span className="text-[11px] font-medium text-blue-600 group-hover:text-blue-800 shrink-0">Search →</span>
+                  <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-800 dark:group-hover:text-blue-300 shrink-0">Search →</span>
                 </div>
               </a>
             </section>
@@ -1428,15 +1416,15 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
           {/* Hotel check-in on first day */}
           {isFirstDay && firstHotel && (
             <section className="mb-3.5">
-              <a href={`/trip/${id}/hotels`} className="block rounded-lg p-3 shadow-sm border border-amber-200/60 bg-gradient-to-r from-amber-50 to-orange-50 hover:shadow-md transition-shadow group">
+              <a href={`/trip/${id}/hotels`} className="block rounded-xl p-3 shadow-sm border border-amber-200/60 dark:border-amber-500/20 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/30 dark:to-orange-950/20 hover:shadow-md transition-shadow group">
                 <div className="flex items-center gap-2.5">
                   <div className="w-8 h-8 rounded-lg bg-amber-500 flex items-center justify-center shrink-0">
                     <MapPin size={14} className="text-white" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-[11px] font-semibold text-amber-700 uppercase tracking-wider">Hotel Check-in</p>
-                    <p className="text-sm font-medium text-gray-900 truncate">{firstHotel.name}</p>
-                    <p className="text-[11px] text-gray-500">
+                    <p className="text-[11px] font-semibold text-amber-700 dark:text-amber-400 uppercase tracking-wider">Hotel Check-in</p>
+                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{firstHotel.name}</p>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400">
                       {firstHotel.price ? `$${firstHotel.price}/night · ` : firstHotel.price_per_night ? `$${firstHotel.price_per_night}/night · ` : ''}
                       {firstHotel.stars ? `${'★'.repeat(firstHotel.stars)} · ` : ''}
                       Check-in 3:00 PM
@@ -1446,7 +1434,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={firstHotel.image} alt={firstHotel.name} referrerPolicy="no-referrer" className="w-12 h-12 rounded-lg object-cover shrink-0" />
                   )}
-                  <span className="text-[11px] font-medium text-amber-600 group-hover:text-amber-800 shrink-0">Change →</span>
+                  <span className="text-[11px] font-medium text-amber-600 dark:text-amber-400 group-hover:text-amber-800 dark:group-hover:text-amber-300 shrink-0">Change →</span>
                 </div>
               </a>
             </section>
@@ -1539,7 +1527,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
                       </div>
                     ) : (
                       <div className="text-center py-8">
-                        <Search size={24} className="mx-auto text-gray-300 mb-2" />
+                        <Search size={24} className="mx-auto text-gray-300 dark:text-gray-600 mb-2" />
                         <p className="text-xs text-gray-500 dark:text-gray-400">No results match your search</p>
                         <button onClick={() => { setAddSearch(''); setAddCategory('All'); }} className="text-[11px] mt-1 hover:underline" style={{ color: 'var(--trip-base)' }}>Clear filters</button>
                       </div>
@@ -1555,15 +1543,15 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
             <>
               {firstHotel && (
                 <section className="mb-3.5">
-                  <div className="rounded-lg p-3 shadow-sm border border-blue-200/60 bg-gradient-to-r from-blue-50 to-indigo-50">
+                  <div className="rounded-xl p-3 shadow-sm border border-blue-200/60 dark:border-blue-500/20 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/20">
                     <div className="flex items-center gap-2.5">
                       <div className="w-8 h-8 rounded-lg bg-blue-500 flex items-center justify-center shrink-0">
                         <MapPin size={14} className="text-white" />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-[11px] font-semibold text-blue-700 uppercase tracking-wider">Hotel Check-out</p>
-                        <p className="text-sm font-medium text-gray-900 truncate">{firstHotel.name}</p>
-                        <p className="text-[11px] text-gray-500">Check-out 11:00 AM</p>
+                        <p className="text-[11px] font-semibold text-blue-700 dark:text-blue-400 uppercase tracking-wider">Hotel Check-out</p>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{firstHotel.name}</p>
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400">Check-out 11:00 AM</p>
                       </div>
                     </div>
                   </div>
@@ -1572,17 +1560,17 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
               {returnFlight && <FlightSection flight={returnFlight} collapsed={allCollapsedOverride ?? undefined} />}
               {!returnFlight && tripFlight && (
                 <section className="mb-3.5">
-                  <a href={`/trip/${id}/flights`} className="block rounded-lg p-3 shadow-sm border border-blue-200/60 bg-gradient-to-r from-blue-50 to-indigo-50 hover:shadow-md transition-shadow group">
+                  <a href={`/trip/${id}/flights`} className="block rounded-xl p-3 shadow-sm border border-blue-200/60 dark:border-blue-500/20 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/20 hover:shadow-md transition-shadow group">
                     <div className="flex items-center gap-2.5">
                       <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ backgroundColor: 'var(--trip-base)' }}>
                         <PaperPlane size={14} className="text-white rotate-180" />
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="text-[11px] font-semibold text-blue-700 uppercase tracking-wider">Return Flight</p>
-                        <p className="text-sm font-medium text-gray-900">Flight home from {tripFlight.city} ({tripFlight.destAirport})</p>
-                        <p className="text-[11px] text-gray-500">Tap to search and select your flight</p>
+                        <p className="text-[11px] font-semibold text-blue-700 dark:text-blue-400 uppercase tracking-wider">Return Flight</p>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">Flight home from {tripFlight.city} ({tripFlight.destAirport})</p>
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400">Tap to search and select your flight</p>
                       </div>
-                      <span className="text-[11px] font-medium text-blue-600 group-hover:text-blue-800 shrink-0">Search →</span>
+                      <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-800 dark:group-hover:text-blue-300 shrink-0">Search →</span>
                     </div>
                   </a>
                 </section>

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -699,7 +699,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
         <div ref={revealRef}>
 
           {/* ── Row 1: Things to Do (left) + Cuisine (right) ── */}
-          <div className="px-6 sm:px-10 md:pl-16 mt-6">
+          <div className="px-0 mt-6">
             <div className="flex flex-col lg:flex-row gap-6">
               {/* Things to Do — fills left column */}
               <div className="flex-1 min-w-0">
@@ -741,7 +741,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 2: News (left) + What's Going On (right) ── */}
           {(hasNewsArticles || events.length > 0) && (
-            <div className="relative z-10 px-6 sm:px-10 md:pl-16 mt-8">
+            <div className="relative z-10 px-0 mt-8">
               <div className="flex flex-col lg:flex-row gap-6">
                 {hasNewsArticles && (
                   <div className="flex-1 min-w-0">
@@ -759,7 +759,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 3: Phrases + Cost of Living ── */}
           {(trip?.trip_context?.phrases || trip?.trip_context?.cost_of_living) && (
-            <div className="relative z-10 px-6 sm:px-10 md:pl-16 mt-8">
+            <div className="relative z-10 px-0 mt-8">
               <div className="flex flex-col lg:flex-row gap-6 items-start">
                 {trip?.trip_context?.phrases && Object.keys(trip.trip_context.phrases).length > 0 && (
                   <div className="flex-1 min-w-0">
@@ -777,7 +777,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 4: Nearby Cities ── */}
           {trip?.trip_context?.nearby_cities && trip.trip_context.nearby_cities.length > 0 && (
-            <div className="px-6 sm:px-10 md:pl-16 mt-8">
+            <div className="px-0 mt-8">
               <NearbyCitiesSection cities={trip.trip_context.nearby_cities} />
             </div>
           )}

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -85,39 +85,36 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
         <div>
           <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full backdrop-blur-md"
             style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Explore</span>
-          <h2 className="text-2xl sm:text-3xl font-bold font-serif text-white"
-            style={{ textShadow: '0 2px 10px rgba(0,0,0,0.5)' }}>Things to Do</h2>
+          <h2 className="text-2xl sm:text-3xl font-bold font-serif text-gray-900 dark:text-white">Things to Do</h2>
         </div>
-        <div className="flex items-center gap-2 px-3 py-1 rounded-full backdrop-blur-md"
-          style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}>
+        <div className="flex items-center gap-2 px-3 py-1 rounded-full"
+          style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}>
           {!gridView && (
             <>
-              <span className="text-[11px] tabular-nums mr-1 text-white/80">
+              <span className="text-[11px] tabular-nums mr-1 text-gray-500 dark:text-white/80">
                 {activeIdx + 1} / {items.length}
               </span>
               <button onClick={() => { const i = Math.max(0, activeIdx - 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === 0}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-                style={{ border: '1px solid rgba(255,255,255,0.3)' }}>
-                <ChevronLeft size={14} className="text-white" />
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/30">
+                <ChevronLeft size={14} className="text-gray-600 dark:text-white" />
               </button>
               <button onClick={() => { const i = Math.min(items.length - 1, activeIdx + 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === items.length - 1}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-                style={{ border: '1px solid rgba(255,255,255,0.3)' }}>
-                <ChevronRight size={14} className="text-white" />
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/30">
+                <ChevronRight size={14} className="text-gray-600 dark:text-white" />
               </button>
             </>
           )}
           {gridView && (
             <button onClick={() => setFlush(f => !f)} title="Flush grid"
-              className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
-              style={{ border: '1px solid rgba(255,255,255,0.3)', backgroundColor: flush ? 'rgba(255,255,255,0.2)' : 'transparent' }}>
-              <LayoutGrid size={12} className="text-white/70" />
+              className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/30"
+              style={{ backgroundColor: flush ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
+              <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />
             </button>
           )}
           <button onClick={() => setGridView(v => !v)} title={gridView ? 'Carousel view' : 'Grid view'}
-            className="w-7 h-7 rounded-full flex items-center justify-center transition-all"
-            style={{ border: '1px solid rgba(255,255,255,0.3)', backgroundColor: gridView ? 'rgba(255,255,255,0.2)' : 'transparent' }}>
-            {gridView ? <LayoutList size={12} className="text-white/70" /> : <LayoutGrid size={12} className="text-white/70" />}
+            className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/30"
+            style={{ backgroundColor: gridView ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
+            {gridView ? <LayoutList size={12} className="text-gray-500 dark:text-white/70" /> : <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />}
           </button>
         </div>
       </div>
@@ -702,7 +699,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
         <div ref={revealRef}>
 
           {/* ── Row 1: Things to Do (left) + Cuisine (right) ── */}
-          <div className="px-6 sm:px-10 mt-6">
+          <div className="px-6 sm:px-10 md:pl-16 mt-6">
             <div className="flex flex-col lg:flex-row gap-6">
               {/* Things to Do — fills left column */}
               <div className="flex-1 min-w-0">
@@ -723,7 +720,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
                   <div className="mb-4">
                     <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full"
                       style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Local Cuisine</span>
-                    <h3 className="text-2xl sm:text-3xl font-bold font-serif text-white" style={{ textShadow: '0 2px 10px rgba(0,0,0,0.5)' }}>Must-Try Dishes</h3>
+                    <h3 className="text-2xl sm:text-3xl font-bold font-serif text-gray-900 dark:text-white">Must-Try Dishes</h3>
                   </div>
                   <div className="flex gap-2 overflow-x-auto scrollbar-hide snap-x snap-mandatory">
                     {trip!.trip_context!.cuisine!.map((dish: { id: string; name: string; image: string }) => (
@@ -744,7 +741,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 2: News (left) + What's Going On (right) ── */}
           {(hasNewsArticles || events.length > 0) && (
-            <div className="relative z-10 px-6 sm:px-10 mt-8">
+            <div className="relative z-10 px-6 sm:px-10 md:pl-16 mt-8">
               <div className="flex flex-col lg:flex-row gap-6">
                 {hasNewsArticles && (
                   <div className="flex-1 min-w-0">
@@ -762,7 +759,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 3: Phrases + Cost of Living ── */}
           {(trip?.trip_context?.phrases || trip?.trip_context?.cost_of_living) && (
-            <div className="relative z-10 px-6 sm:px-10 mt-8">
+            <div className="relative z-10 px-6 sm:px-10 md:pl-16 mt-8">
               <div className="flex flex-col lg:flex-row gap-6 items-start">
                 {trip?.trip_context?.phrases && Object.keys(trip.trip_context.phrases).length > 0 && (
                   <div className="flex-1 min-w-0">
@@ -780,15 +777,12 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 4: Nearby Cities ── */}
           {trip?.trip_context?.nearby_cities && trip.trip_context.nearby_cities.length > 0 && (
-            <div className="px-6 sm:px-10 mt-8">
+            <div className="px-6 sm:px-10 md:pl-16 mt-8">
               <NearbyCitiesSection cities={trip.trip_context.nearby_cities} />
             </div>
           )}
 
-          {/* ── Rotating photo mosaic — bleeds up behind the cards ── */}
-          {trip?.trip_context?.hero_images && trip.trip_context.hero_images.length > 0 && (
-            <TripMosaic photos={trip.trip_context.hero_images} destination={trip.destination} />
-          )}
+          {/* TripMosaic removed — was designed for magazine layout, not app shell */}
 
         </div>
       </div>

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -41,12 +41,16 @@ function useRevealOnScroll(ready: boolean) {
 function AddToTripButton({ isAdded, onToggle }: { isAdded: boolean; onToggle: () => void }) {
   return (
     <button onClick={onToggle}
-      className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-[12px] font-semibold transition-all duration-300 backdrop-blur-sm w-fit"
-      style={{
-        color: isAdded ? 'var(--magazine-success)' : 'var(--magazine-accent)',
-        border: `1px solid ${isAdded ? 'rgba(52,211,153,0.25)' : 'rgba(200,169,106,0.25)'}`,
-        backgroundColor: isAdded ? 'rgba(52,211,153,0.1)' : 'rgba(200,169,106,0.1)',
-      }}>
+      className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-[12px] font-semibold transition-all duration-300 w-fit border ${
+        isAdded
+          ? 'text-emerald-600 dark:text-emerald-400 border-emerald-500/25 bg-emerald-500/10'
+          : ''
+      }`}
+      style={!isAdded ? {
+        color: 'var(--trip-base)',
+        borderColor: 'color-mix(in srgb, var(--trip-base) 25%, transparent)',
+        backgroundColor: 'color-mix(in srgb, var(--trip-base) 10%, transparent)',
+      } : undefined}>
       {isAdded ? <span>✓ Added to trip</span> : <><Plus size={13} /><span>Add to trip</span></>}
     </button>
   );
@@ -83,36 +87,33 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
     <section>
       <div className="mb-4 flex items-end justify-between">
         <div>
-          <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full backdrop-blur-md"
-            style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Explore</span>
-          <h2 className="text-2xl sm:text-3xl font-bold font-serif text-gray-900 dark:text-white">Things to Do</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Things to Do</h2>
         </div>
-        <div className="flex items-center gap-2 px-3 py-1 rounded-full"
-          style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}>
+        <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-gray-100 dark:bg-white/[0.06]">
           {!gridView && (
             <>
               <span className="text-[11px] tabular-nums mr-1 text-gray-500 dark:text-white/80">
                 {activeIdx + 1} / {items.length}
               </span>
               <button onClick={() => { const i = Math.max(0, activeIdx - 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === 0}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/30">
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-200 dark:border-white/[0.12]">
                 <ChevronLeft size={14} className="text-gray-600 dark:text-white" />
               </button>
               <button onClick={() => { const i = Math.min(items.length - 1, activeIdx + 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === items.length - 1}
-                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-300 dark:border-white/30">
+                className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-200 dark:border-white/[0.12]">
                 <ChevronRight size={14} className="text-gray-600 dark:text-white" />
               </button>
             </>
           )}
           {gridView && (
             <button onClick={() => setFlush(f => !f)} title="Flush grid"
-              className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/30"
+              className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-200 dark:border-white/[0.12]"
               style={{ backgroundColor: flush ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
               <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />
             </button>
           )}
           <button onClick={() => setGridView(v => !v)} title={gridView ? 'Carousel view' : 'Grid view'}
-            className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-300 dark:border-white/30"
+            className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-200 dark:border-white/[0.12]"
             style={{ backgroundColor: gridView ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
             {gridView ? <LayoutList size={12} className="text-gray-500 dark:text-white/70" /> : <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />}
           </button>
@@ -135,13 +136,12 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
                 <img src={item.image} alt={item.title} referrerPolicy="no-referrer" className="absolute inset-0 w-full h-full object-cover" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                 <div className="absolute top-3 left-3">
-                  <span className="text-[9px] uppercase tracking-wider font-semibold px-2.5 py-1 rounded-full backdrop-blur-md"
-                    style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.2)' }}>
+                  <span className="text-[9px] uppercase tracking-wider font-semibold px-2.5 py-1 rounded-full backdrop-blur-md bg-black/30 text-white border border-white/20">
                     {item.category}
                   </span>
                 </div>
                 <div className="absolute bottom-0 left-0 right-0 p-5">
-                  <h3 className="text-lg font-bold text-white leading-tight mb-1 font-serif">{item.title}</h3>
+                  <h3 className="text-lg font-bold text-white leading-tight mb-1">{item.title}</h3>
                   <p className="text-[12px] text-white/60 mb-3 line-clamp-2">{item.description}</p>
                   <AddToTripButton isAdded={addedItems.has(item.id)} onToggle={() => onToggleAdd(item.id)} />
                 </div>
@@ -155,7 +155,7 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
                 className="rounded-full transition-all duration-300"
                 style={{
                   width: i === activeIdx ? 16 : 5, height: 5,
-                  backgroundColor: i === activeIdx ? 'var(--magazine-accent)' : 'var(--magazine-border)',
+                  backgroundColor: i === activeIdx ? 'var(--trip-base)' : 'rgba(0,0,0,0.15)',
                 }} />
             ))}
           </div>
@@ -174,13 +174,12 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
                 style={!flush ? { minHeight: 200 } : undefined} />
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
               <div className="absolute top-2 left-2">
-                <span className="text-[8px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded-full backdrop-blur-md"
-                  style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.2)' }}>
+                <span className="text-[8px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded-full backdrop-blur-md bg-black/30 text-white border border-white/20">
                   {item.category}
                 </span>
               </div>
               <div className="absolute bottom-0 left-0 right-0 p-3">
-                <h3 className="text-sm font-bold text-white leading-tight font-serif">{item.title}</h3>
+                <h3 className="text-sm font-bold text-white leading-tight">{item.title}</h3>
               </div>
             </div>
           ))}
@@ -196,29 +195,22 @@ function NewsSection({ news }: { news: NonNullable<TripContextData['news']> }) {
 
   return (
     <section>
-      <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full backdrop-blur-md"
-        style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Latest</span>
-      <h2 className="text-2xl sm:text-3xl font-bold font-serif mb-4"
-        style={{ color: 'var(--magazine-heading)' }}>News</h2>
+      <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">News</h2>
 
       {/* Scrollable news list capped to match What's Going On card height */}
       <div className="max-h-[360px] overflow-y-auto scrollbar-hide pr-1">
-        <div className="divide-y" style={{ borderColor: 'var(--magazine-border, rgba(0,0,0,0.08))' }}>
+        <div className="divide-y divide-gray-200 dark:divide-white/[0.08]">
           {newsItems.map((item) => (
             <a key={item.id} href={item.url || '#'} target="_blank" rel="noopener noreferrer"
               className="block py-3.5 first:pt-0 hover:opacity-80 transition-opacity">
               <div className="flex items-center gap-2 mb-1">
-                <span className="text-[10px] uppercase tracking-wider font-bold"
-                  style={{ color: 'var(--magazine-accent)' }}>{item.category}</span>
+                <span className="text-[10px] uppercase tracking-wider font-bold text-[color:var(--trip-base)]">{item.category}</span>
                 {item.source && (
-                  <span className="text-[10px] uppercase tracking-wider font-bold"
-                    style={{ color: 'var(--magazine-accent)', opacity: 0.5 }}>· {item.source}</span>
+                  <span className="text-[10px] uppercase tracking-wider font-bold text-[color:var(--trip-base)] opacity-50">· {item.source}</span>
                 )}
               </div>
-              <h3 className="text-[14px] font-bold leading-snug mb-0.5 line-clamp-2"
-                style={{ color: 'var(--magazine-heading)' }}>{item.title}</h3>
-              <p className="text-[12px] leading-relaxed line-clamp-1"
-                style={{ color: 'var(--magazine-text)', opacity: 0.6 }}>{item.snippet}</p>
+              <h3 className="text-[14px] font-bold leading-snug mb-0.5 line-clamp-2 text-gray-900 dark:text-white">{item.title}</h3>
+              <p className="text-[12px] leading-relaxed line-clamp-1 text-gray-600 dark:text-gray-400 opacity-60">{item.snippet}</p>
             </a>
           ))}
         </div>
@@ -251,25 +243,19 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
     <section>
       <div className="mb-4 flex items-end justify-between">
         <div>
-          <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full backdrop-blur-md"
-            style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>What&apos;s Happening</span>
-          <h2 className="text-2xl sm:text-3xl font-bold font-serif"
-            style={{ color: 'var(--magazine-heading)' }}>What&apos;s Going On</h2>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">What&apos;s Going On</h2>
         </div>
-        <div className="flex items-center gap-2 px-3 py-1 rounded-full backdrop-blur-md"
-          style={{ backgroundColor: 'var(--magazine-bg, rgba(245,240,235,0.85))' }}>
-          <span className="text-[11px] tabular-nums mr-1" style={{ color: 'var(--magazine-heading)' }}>
+        <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-gray-100 dark:bg-white/[0.06]">
+          <span className="text-[11px] tabular-nums mr-1 text-gray-500 dark:text-white/80">
             {activeIdx + 1} / {events.length}
           </span>
           <button onClick={() => { const i = Math.max(0, activeIdx - 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === 0}
-            className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-            style={{ border: '1px solid var(--magazine-border)' }}>
-            <ChevronLeft size={14} style={{ color: 'var(--magazine-heading)' }} />
+            className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-200 dark:border-white/[0.12]">
+            <ChevronLeft size={14} className="text-gray-600 dark:text-white" />
           </button>
           <button onClick={() => { const i = Math.min(events.length - 1, activeIdx + 1); setActiveIdx(i); scrollTo(i); }} disabled={activeIdx === events.length - 1}
-            className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20"
-            style={{ border: '1px solid var(--magazine-border)' }}>
-            <ChevronRight size={14} style={{ color: 'var(--magazine-heading)' }} />
+            className="w-7 h-7 rounded-full flex items-center justify-center transition-all disabled:opacity-20 border border-gray-200 dark:border-white/[0.12]">
+            <ChevronRight size={14} className="text-gray-600 dark:text-white" />
           </button>
         </div>
       </div>
@@ -299,14 +285,13 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
               )}
               {/* Category badge */}
               <div className="absolute top-3 left-3">
-                <span className="text-[9px] uppercase tracking-wider font-semibold px-2.5 py-1 rounded-full backdrop-blur-md"
-                  style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.2)' }}>
+                <span className="text-[9px] uppercase tracking-wider font-semibold px-2.5 py-1 rounded-full backdrop-blur-md bg-black/30 text-white border border-white/20">
                   {item.category}
                 </span>
               </div>
               {/* Content overlay on image */}
               <div className="absolute bottom-0 left-0 right-0 p-4">
-                <h3 className="text-[15px] font-bold text-white leading-tight mb-0.5 font-serif line-clamp-2">
+                <h3 className="text-[15px] font-bold text-white leading-tight mb-0.5 line-clamp-2">
                   {item.title}
                 </h3>
                 <p className="text-[11px] text-white/60 leading-snug line-clamp-1 mb-2">{item.description}</p>
@@ -324,7 +309,7 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
             className="rounded-full transition-all duration-300"
             style={{
               width: i === activeIdx ? 16 : 5, height: 5,
-              backgroundColor: i === activeIdx ? 'var(--magazine-accent)' : 'var(--magazine-border)',
+              backgroundColor: i === activeIdx ? 'var(--trip-base)' : 'rgba(0,0,0,0.15)',
             }} />
         ))}
       </div>
@@ -337,19 +322,16 @@ function NearbyCitiesSection({ cities }: { cities: NonNullable<TripContextData['
   if (!cities.length) return null;
   return (
     <section>
-      <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full"
-        style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Day Trips</span>
-      <h3 className="text-2xl font-bold font-serif mb-4" style={{ color: 'var(--magazine-heading)' }}>Also Consider Visiting</h3>
+      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Also Consider Visiting</h3>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {cities.map((city) => (
-          <div key={city.id} className="rounded-xl p-4 backdrop-blur-md transition-all hover:scale-[1.02]"
-            style={{ backgroundColor: 'var(--magazine-card-bg, rgba(255,255,255,0.08))', border: '1px solid var(--magazine-border, rgba(255,255,255,0.1))' }}>
+          <div key={city.id} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-4 transition-all hover:scale-[1.02]">
             <div className="flex items-center gap-2 mb-1">
-              <MapPin size={12} style={{ color: 'var(--magazine-accent)' }} />
-              <span className="text-[14px] font-bold" style={{ color: 'var(--magazine-heading)' }}>{city.name}</span>
+              <MapPin size={12} className="text-[color:var(--trip-base)]" />
+              <span className="text-[14px] font-bold text-gray-900 dark:text-white">{city.name}</span>
             </div>
-            <p className="text-[11px] opacity-60" style={{ color: 'var(--magazine-heading)' }}>{city.country}</p>
-            <p className="text-[11px] font-semibold mt-1" style={{ color: 'var(--magazine-accent)' }}>{Math.round(city.distance)} km away</p>
+            <p className="text-[11px] text-gray-600 dark:text-gray-400 opacity-60">{city.country}</p>
+            <p className="text-[11px] font-semibold mt-1 text-[color:var(--trip-base)]">{Math.round(city.distance)} km away</p>
           </div>
         ))}
       </div>
@@ -371,28 +353,25 @@ function CostOfLivingSection({ cost, currency }: { cost: NonNullable<TripContext
   ];
   return (
     <section>
-      <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full"
-        style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Budget</span>
-      <h3 className="text-2xl font-bold font-serif mb-4" style={{ color: 'var(--magazine-heading)' }}>Cost of Living</h3>
+      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Cost of Living</h3>
       <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
         {items.map(({ icon: Icon, label, value }) => (
-          <div key={label} className="rounded-xl p-3 text-center backdrop-blur-md"
-            style={{ backgroundColor: 'var(--magazine-card-bg, rgba(255,255,255,0.08))', border: '1px solid var(--magazine-border, rgba(255,255,255,0.1))' }}>
-            <Icon size={16} className="mx-auto mb-1.5" style={{ color: 'var(--magazine-accent)' }} />
-            <p className="text-[15px] font-bold" style={{ color: 'var(--magazine-heading)' }}>{value}</p>
-            <p className="text-[10px] opacity-50" style={{ color: 'var(--magazine-heading)' }}>{label}</p>
+          <div key={label} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-3 text-center">
+            <Icon size={16} className="mx-auto mb-1.5 text-[color:var(--trip-base)]" />
+            <p className="text-[15px] font-bold text-gray-900 dark:text-white">{value}</p>
+            <p className="text-[10px] text-gray-600 dark:text-gray-400 opacity-50">{label}</p>
           </div>
         ))}
       </div>
-      <div className="flex gap-2 mt-3 rounded-xl overflow-hidden" style={{ backgroundColor: 'var(--magazine-card-bg, rgba(255,255,255,0.08))', border: '1px solid var(--magazine-border, rgba(255,255,255,0.1))' }}>
+      <div className="flex gap-2 mt-3 rounded-xl overflow-hidden border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm">
         {[
           { label: 'Budget', range: fmt(cost.daily_budget_low) },
           { label: 'Mid-range', range: fmt(cost.daily_budget_mid) },
           { label: 'Luxury', range: fmt(cost.daily_budget_high) },
         ].map(({ label, range }, i) => (
-          <div key={label} className="flex-1 py-3 text-center" style={i < 2 ? { borderRight: '1px solid var(--magazine-border, rgba(255,255,255,0.1))' } : undefined}>
-            <p className="text-[10px] uppercase tracking-wider font-semibold mb-1" style={{ color: 'var(--magazine-heading)', opacity: 0.4 }}>{label}</p>
-            <p className="text-[16px] font-bold" style={{ color: 'var(--magazine-accent)' }}>{range}<span className="text-[11px] font-normal opacity-60">/day</span></p>
+          <div key={label} className="flex-1 py-3 text-center" style={i < 2 ? { borderRight: '1px solid rgba(0,0,0,0.08)' } : undefined}>
+            <p className="text-[10px] uppercase tracking-wider font-semibold mb-1 text-gray-900 dark:text-white opacity-40">{label}</p>
+            <p className="text-[16px] font-bold text-[color:var(--trip-base)]">{range}<span className="text-[11px] font-normal opacity-60">/day</span></p>
           </div>
         ))}
       </div>
@@ -446,29 +425,27 @@ function PhrasesSection({ phrases, language }: { phrases: Record<string, string>
 
   return (
     <section>
-      <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full"
-        style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>
-        <Languages size={10} className="inline mr-1" />{language || 'Local Language'}
-      </span>
-      <h3 className="text-2xl font-bold font-serif mb-4" style={{ color: 'var(--magazine-heading)' }}>Essential Phrases</h3>
+      <div className="flex items-center gap-2 mb-4">
+        <Languages size={14} className="text-[color:var(--trip-base)]" />
+        <h3 className="text-xl font-bold text-gray-900 dark:text-white">Essential Phrases</h3>
+        {language && <span className="text-xs font-medium text-gray-500 dark:text-gray-400">({language})</span>}
+      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {entries.map(([english, translated]) => (
           <button key={english}
             onClick={() => speak(translated)}
-            className="flex items-center gap-3 rounded-xl px-4 py-3 backdrop-blur-md text-left transition-all hover:scale-[1.01] active:scale-[0.99] cursor-pointer group"
-            style={{ backgroundColor: 'var(--magazine-card-bg, rgba(255,255,255,0.08))', border: '1px solid var(--magazine-border, rgba(255,255,255,0.1))' }}>
-            <span className="text-[12px] font-medium opacity-60 flex-1" style={{ color: 'var(--magazine-heading)' }}>{english}</span>
-            <span className="text-[13px] font-bold" style={{ color: 'var(--magazine-accent)' }}>{translated}</span>
+            className="flex items-center gap-3 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm px-4 py-3 text-left transition-all hover:scale-[1.01] active:scale-[0.99] cursor-pointer group">
+            <span className="text-[12px] font-medium text-gray-600 dark:text-gray-400 opacity-60 flex-1">{english}</span>
+            <span className="text-[13px] font-bold text-[color:var(--trip-base)]">{translated}</span>
             <Volume2
               size={14}
-              className={`shrink-0 transition-all ${speaking === translated ? 'animate-pulse' : 'opacity-30 group-hover:opacity-70'}`}
-              style={{ color: speaking === translated ? 'var(--magazine-accent)' : 'var(--magazine-heading)' }}
+              className={`shrink-0 transition-all ${speaking === translated ? 'animate-pulse text-[color:var(--trip-base)]' : 'text-gray-900 dark:text-white opacity-30 group-hover:opacity-70'}`}
             />
           </button>
         ))}
       </div>
       {allEntries.length > 6 && (
-        <button onClick={() => setShowAll(v => !v)} className="mt-2 text-[11px] font-medium hover:underline" style={{ color: 'var(--magazine-accent)' }}>
+        <button onClick={() => setShowAll(v => !v)} className="mt-2 text-[11px] font-medium hover:underline text-[color:var(--trip-base)]">
           {showAll ? 'Show less' : `Show ${allEntries.length - 6} more phrases`}
         </button>
       )}
@@ -511,14 +488,14 @@ function TripMosaic({ photos, destination }: { photos: string[]; destination?: s
       {/* Top fade — stronger gradient for clean transition */}
       <div className="absolute top-0 left-0 right-0 pointer-events-none" style={{
         height: '55%',
-        background: 'linear-gradient(to bottom, var(--magazine-bg, #f5f0eb) 50%, transparent 100%)',
+        background: 'linear-gradient(to bottom, var(--background, #fff) 50%, transparent 100%)',
       }} />
       {/* Side fades */}
       <div className="absolute top-0 bottom-0 left-0 w-6 pointer-events-none" style={{
-        background: 'linear-gradient(to right, var(--magazine-bg, #f5f0eb), transparent)',
+        background: 'linear-gradient(to right, var(--background, #fff), transparent)',
       }} />
       <div className="absolute top-0 bottom-0 right-0 w-6 pointer-events-none" style={{
-        background: 'linear-gradient(to left, var(--magazine-bg, #f5f0eb), transparent)',
+        background: 'linear-gradient(to left, var(--background, #fff), transparent)',
       }} />
     </div>
   );
@@ -718,9 +695,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
               {hasCuisine && (
                 <div className="shrink-0 w-full lg:w-[380px]">
                   <div className="mb-4">
-                    <span className="inline-block text-[10px] tracking-[0.3em] uppercase font-semibold mb-2 px-2.5 py-1 rounded-full"
-                      style={{ backgroundColor: 'rgba(200,169,106,0.15)', color: 'var(--magazine-accent)', border: '1px solid rgba(200,169,106,0.25)' }}>Local Cuisine</span>
-                    <h3 className="text-2xl sm:text-3xl font-bold font-serif text-gray-900 dark:text-white">Must-Try Dishes</h3>
+                    <h3 className="text-xl font-bold text-gray-900 dark:text-white">Must-Try Dishes</h3>
                   </div>
                   <div className="flex gap-2 overflow-x-auto scrollbar-hide snap-x snap-mandatory">
                     {trip!.trip_context!.cuisine!.map((dish: { id: string; name: string; image: string }) => (
@@ -729,7 +704,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
                         <img src={dish.image} alt={dish.name} className="absolute inset-0 w-full h-full object-cover" />
                         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />
                         <div className="absolute bottom-0 left-0 right-0 p-5">
-                          <h3 className="text-lg font-bold text-white leading-tight font-serif">{dish.name}</h3>
+                          <h3 className="text-lg font-bold text-white leading-tight">{dish.name}</h3>
                         </div>
                       </div>
                     ))}

--- a/apps/web/app/(dashboard)/trip/[id]/restaurants/[restaurantId]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/restaurants/[restaurantId]/page.tsx
@@ -32,16 +32,16 @@ export default function RestaurantDetailPage({
   if (isLoading) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-6 pb-24 animate-pulse">
-        <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
-        <div className="h-8 w-2/3 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-5 w-20 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
-        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-56 bg-gray-200 dark:bg-gray-700 rounded mb-6" />
-        <div className="h-px bg-gray-100 dark:bg-gray-800 mb-4" />
-        <div className="h-4 w-36 bg-gray-200 dark:bg-gray-700 rounded mb-3" />
-        <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-32 bg-gray-200 dark:bg-white/[0.06] rounded mb-4" />
+        <div className="h-8 w-2/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-5 w-20 bg-gray-200 dark:bg-white/[0.06] rounded mb-2" />
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-40 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-56 bg-gray-200 dark:bg-white/[0.06] rounded mb-6" />
+        <div className="h-px bg-gray-100 dark:bg-white/[0.06] mb-4" />
+        <div className="h-4 w-36 bg-gray-200 dark:bg-white/[0.06] rounded mb-3" />
+        <div className="h-4 w-48 bg-gray-200 dark:bg-white/[0.06] rounded" />
       </div>
     )
   }
@@ -90,16 +90,15 @@ export default function RestaurantDetailPage({
       />
 
       {/* Overview */}
-      <div className="px-6 md:px-10 py-6 border-b border-gray-100">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+      <div className="px-6 md:px-10 py-6 border-b border-gray-100 dark:border-white/[0.06]">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">
           {activity.name}
         </h1>
 
         <div className="flex flex-wrap items-center gap-3">
           {/* Category badge */}
           <span
-            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold text-white"
-            style={{ backgroundColor: '#8b5cf6' }}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold text-white bg-violet-500"
           >
             <UtensilsCrossed className="w-3.5 h-3.5" />
             {categoryLabel}

--- a/apps/web/app/(dashboard)/trip/[id]/settings/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/settings/page.tsx
@@ -56,11 +56,11 @@ const FALLBACK_BRAND = '#1e3a5f';
 // ─── Reusable small components ────────────────────────────────
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
-  return <h2 className="text-xl font-serif font-normal text-gray-900 mb-4 tracking-wide">{children}</h2>;
+  return <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">{children}</h2>;
 }
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
-  return <label className="block text-sm font-medium text-gray-700 mb-1">{children}</label>;
+  return <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{children}</label>;
 }
 
 function Input({
@@ -83,7 +83,7 @@ function Input({
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
       disabled={disabled}
-      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-50 disabled:text-gray-400"
+      className="w-full rounded-lg border border-gray-300 dark:border-white/[0.12] bg-white dark:bg-white/[0.05] px-3 py-2 text-sm text-gray-900 dark:text-white dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:bg-white/[0.02] dark:disabled:text-gray-500"
       style={{ '--tw-ring-color': FALLBACK_BRAND } as React.CSSProperties}
     />
   );
@@ -105,11 +105,11 @@ function Select({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
-      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 bg-white focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-50 disabled:text-gray-400"
+      className="w-full rounded-lg border border-gray-300 dark:border-white/[0.12] px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-white/[0.05] focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-50 disabled:text-gray-400 dark:disabled:bg-white/[0.02] dark:disabled:text-gray-500"
       style={{ '--tw-ring-color': FALLBACK_BRAND } as React.CSSProperties}
     >
       {options.map((o) => (
-        <option key={o.value} value={o.value}>
+        <option key={o.value} value={o.value} className="dark:bg-gray-900 dark:text-white">
           {o.label}
         </option>
       ))}
@@ -130,8 +130,8 @@ function Toggle({
     <button
       type="button"
       onClick={onToggle}
-      className="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-      style={{ backgroundColor: enabled ? (color ?? FALLBACK_BRAND) : '#d1d5db' }}
+      className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${!enabled ? 'bg-gray-300 dark:bg-white/[0.15]' : ''}`}
+      style={enabled ? { backgroundColor: color ?? FALLBACK_BRAND } : undefined}
     >
       <span
         className="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out"
@@ -239,40 +239,40 @@ function TripSharingSection({
     <div>
       <SectionHeading>Trip Sharing</SectionHeading>
       <div className="space-y-4">
-        <div className="flex items-center justify-between rounded-xl border border-gray-200 p-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-blue-50">
-              <Globe size={16} className="text-blue-600" />
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-blue-50 dark:bg-blue-500/10">
+              <Globe size={16} className="text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">Make Public</p>
-              <p className="text-xs text-gray-500 mt-0.5">Allow anyone to discover and fork this trip</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">Make Public</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Allow anyone to discover and fork this trip</p>
             </div>
           </div>
           <Toggle enabled={isPublic} onToggle={onTogglePublic} />
         </div>
 
-        <div className="flex items-center justify-between rounded-xl border border-gray-200 p-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-purple-50">
-              <Share2 size={16} className="text-purple-600" />
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-purple-50 dark:bg-purple-500/10">
+              <Share2 size={16} className="text-purple-600 dark:text-purple-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">Share Link</p>
-              <p className="text-xs text-gray-500 mt-0.5">Generate a link to share with specific people</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">Share Link</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Generate a link to share with specific people</p>
             </div>
           </div>
           <Toggle enabled={isShared} onToggle={onToggleShared} />
         </div>
 
         {isShared && shareToken && (
-          <div className="rounded-xl border border-gray-200 p-4 bg-gray-50">
+          <div className="rounded-xl border border-gray-200 dark:border-white/[0.08] p-4 bg-gray-50 dark:bg-white/[0.03]">
             <div className="flex items-center gap-2 mb-2">
-              <Copy size={14} className="text-gray-500" />
-              <p className="text-sm font-medium text-gray-700">Share URL</p>
+              <Copy size={14} className="text-gray-500 dark:text-gray-400" />
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Share URL</p>
             </div>
             <div className="flex items-center gap-2">
-              <div className="flex-1 rounded-lg bg-white border border-gray-200 px-3 py-2 text-xs text-gray-600 font-mono truncate">
+              <div className="flex-1 rounded-lg bg-white dark:bg-white/[0.05] border border-gray-200 dark:border-white/[0.08] px-3 py-2 text-xs text-gray-600 dark:text-gray-300 font-mono truncate">
                 {shareUrl}
               </div>
               <button
@@ -287,13 +287,13 @@ function TripSharingSection({
         )}
 
         {forkCount > 0 && (
-          <div className="flex items-center gap-3 rounded-xl border border-gray-200 p-4">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-green-50">
-              <GitFork size={16} className="text-green-600" />
+          <div className="flex items-center gap-3 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-green-50 dark:bg-green-500/10">
+              <GitFork size={16} className="text-green-600 dark:text-green-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">{forkCount} Fork{forkCount === 1 ? '' : 's'}</p>
-              <p className="text-xs text-gray-500 mt-0.5">This trip has been forked by other users</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">{forkCount} Fork{forkCount === 1 ? '' : 's'}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">This trip has been forked by other users</p>
             </div>
           </div>
         )}
@@ -323,15 +323,15 @@ function DangerZoneSection({
   return (
     <div>
       <SectionHeading>Danger Zone</SectionHeading>
-      <div className="rounded-xl border-2 border-red-200 bg-red-50/50 p-5 space-y-4">
+      <div className="rounded-xl border-2 border-red-200 dark:border-red-500/30 bg-red-50/50 dark:bg-red-500/5 p-5 space-y-4">
         {isOwner ? (
           <>
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <AlertTriangle size={16} className="text-red-600" />
-                <p className="text-sm font-bold text-red-700">Delete Trip</p>
+                <AlertTriangle size={16} className="text-red-600 dark:text-red-400" />
+                <p className="text-sm font-bold text-red-700 dark:text-red-400">Delete Trip</p>
               </div>
-              <p className="text-xs text-red-600">
+              <p className="text-xs text-red-600 dark:text-red-400/80">
                 Permanently delete this trip and all associated data. This action cannot be undone.
               </p>
             </div>
@@ -339,7 +339,7 @@ function DangerZoneSection({
             {!showConfirm ? (
               <button
                 onClick={() => setShowConfirm(true)}
-                className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition"
+                className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 transition"
               >
                 <Trash2 size={14} />
                 Delete Trip
@@ -347,28 +347,28 @@ function DangerZoneSection({
             ) : (
               <div className="space-y-3">
                 <div>
-                  <p className="text-xs text-red-700 mb-1.5">
+                  <p className="text-xs text-red-700 dark:text-red-400 mb-1.5">
                     Type <strong>{tripTitle}</strong> to confirm:
                   </p>
                   <input
                     value={confirmText}
                     onChange={(e) => setConfirmText(e.target.value)}
                     placeholder={tripTitle}
-                    className="w-full rounded-lg border border-red-300 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-red-400 focus:border-transparent"
+                    className="w-full rounded-lg border border-red-300 dark:border-red-500/30 bg-white dark:bg-white/[0.05] px-3 py-2 text-sm text-gray-900 dark:text-white dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-400 focus:border-transparent"
                   />
                 </div>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={onDeleteTrip}
                     disabled={!canDelete}
-                    className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 transition disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     <Trash2 size={14} />
                     Confirm Delete
                   </button>
                   <button
                     onClick={() => { setShowConfirm(false); setConfirmText(''); }}
-                    className="text-sm font-medium px-4 py-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50 transition"
+                    className="text-sm font-medium px-4 py-2 rounded-lg border border-gray-300 dark:border-white/[0.12] text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.05] transition"
                   >
                     Cancel
                   </button>
@@ -380,16 +380,16 @@ function DangerZoneSection({
           <>
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <LogOut size={16} className="text-red-600" />
-                <p className="text-sm font-bold text-red-700">Leave Trip</p>
+                <LogOut size={16} className="text-red-600 dark:text-red-400" />
+                <p className="text-sm font-bold text-red-700 dark:text-red-400">Leave Trip</p>
               </div>
-              <p className="text-xs text-red-600">
+              <p className="text-xs text-red-600 dark:text-red-400/80">
                 Remove yourself from this trip. You will lose access to all trip data.
               </p>
             </div>
             <button
               onClick={onLeaveTrip}
-              className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition"
+              className="flex items-center gap-2 text-sm font-semibold px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500 transition"
             >
               <LogOut size={14} />
               Leave Trip
@@ -427,16 +427,16 @@ function Stepper({
         type="button"
         onClick={() => onChange(Math.max(min, value - 1))}
         disabled={disabled || value <= min}
-        className="w-8 h-8 rounded-lg border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50 transition disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-8 h-8 rounded-lg border border-gray-300 dark:border-white/[0.12] flex items-center justify-center text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.05] transition disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <Minus size={14} />
       </button>
-      <span className="w-6 text-center text-sm font-semibold text-gray-900 tabular-nums">{value}</span>
+      <span className="w-6 text-center text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{value}</span>
       <button
         type="button"
         onClick={() => onChange(value + 1)}
         disabled={disabled}
-        className="w-8 h-8 rounded-lg border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50 transition disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-8 h-8 rounded-lg border border-gray-300 dark:border-white/[0.12] flex items-center justify-center text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.05] transition disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <Plus size={14} />
       </button>
@@ -532,33 +532,33 @@ function TravelersSection({
     <div>
       <div className="flex items-center gap-2 mb-4">
         <SectionHeading>Travelers</SectionHeading>
-        {saving && <span className="text-xs text-gray-400 mb-3.5">Saving…</span>}
+        {saving && <span className="text-xs text-gray-400 dark:text-gray-500 mb-3.5">Saving…</span>}
       </div>
 
       <div className="space-y-3">
         {/* Adults */}
-        <div className="flex items-center justify-between rounded-xl border border-gray-200 p-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-blue-50">
-              <Users size={16} className="text-blue-600" />
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-blue-50 dark:bg-blue-500/10">
+              <Users size={16} className="text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">Adults</p>
-              <p className="text-xs text-gray-500 mt-0.5">Age 18+</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">Adults</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Age 18+</p>
             </div>
           </div>
           <Stepper value={travelers.adults} min={1} onChange={(v) => handleChange({ adults: v })} disabled={disabled} />
         </div>
 
         {/* Children */}
-        <div className="flex items-center justify-between rounded-xl border border-gray-200 p-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-purple-50">
-              <Users size={16} className="text-purple-600" />
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-purple-50 dark:bg-purple-500/10">
+              <Users size={16} className="text-purple-600 dark:text-purple-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">Children</p>
-              <p className="text-xs text-gray-500 mt-0.5">Ages 2–17</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">Children</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Ages 2-17</p>
             </div>
           </div>
           <Stepper value={travelers.children} min={0} onChange={(v) => handleChange({ children: v })} disabled={disabled} />
@@ -566,12 +566,12 @@ function TravelersSection({
 
         {/* Child ages — shown only when children > 0 */}
         {travelers.children > 0 && (
-          <div className="rounded-xl border border-gray-200 p-4 bg-gray-50 space-y-3">
-            <p className="text-xs font-medium text-gray-600">Child ages (optional)</p>
+          <div className="rounded-xl border border-gray-200 dark:border-white/[0.08] p-4 bg-gray-50 dark:bg-white/[0.03] space-y-3">
+            <p className="text-xs font-medium text-gray-600 dark:text-gray-400">Child ages (optional)</p>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
               {Array.from({ length: travelers.children }).map((_, i) => (
                 <div key={i} className="flex items-center gap-2">
-                  <label className="text-xs text-gray-500 shrink-0">Child {i + 1}</label>
+                  <label className="text-xs text-gray-500 dark:text-gray-400 shrink-0">Child {i + 1}</label>
                   <input
                     type="number"
                     min={2}
@@ -580,7 +580,7 @@ function TravelersSection({
                     value={travelers.child_ages[i] !== undefined && travelers.child_ages[i] > 0 ? travelers.child_ages[i] : ''}
                     onChange={(e) => handleChildAge(i, e.target.value ? Number(e.target.value) : 0)}
                     disabled={disabled}
-                    className="w-full rounded-lg border border-gray-300 px-2 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-100 disabled:text-gray-400"
+                    className="w-full rounded-lg border border-gray-300 dark:border-white/[0.12] bg-white dark:bg-white/[0.05] px-2 py-1.5 text-sm text-gray-900 dark:text-white dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:border-transparent transition disabled:bg-gray-100 disabled:text-gray-400 dark:disabled:bg-white/[0.02] dark:disabled:text-gray-500"
                     style={{ '--tw-ring-color': FALLBACK_BRAND } as React.CSSProperties}
                   />
                 </div>
@@ -590,21 +590,21 @@ function TravelersSection({
         )}
 
         {/* Infants */}
-        <div className="flex items-center justify-between rounded-xl border border-gray-200 p-4">
+        <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-pink-50">
-              <Users size={16} className="text-pink-500" />
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center bg-pink-50 dark:bg-pink-500/10">
+              <Users size={16} className="text-pink-500 dark:text-pink-400" />
             </div>
             <div>
-              <p className="text-sm font-semibold text-gray-900">Infants</p>
-              <p className="text-xs text-gray-500 mt-0.5">Under 2</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-white">Infants</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Under 2</p>
             </div>
           </div>
           <Stepper value={travelers.infants} min={0} onChange={(v) => handleChange({ infants: v })} disabled={disabled} />
         </div>
       </div>
 
-      <p className="mt-3 text-xs text-gray-400">
+      <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
         Total: {travelers.adults + travelers.children + travelers.infants} traveler{travelers.adults + travelers.children + travelers.infants === 1 ? '' : 's'}
       </p>
     </div>
@@ -780,7 +780,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
 
   if (tripLoading && !trip) {
     return (
-      <div className="max-w-2xl mx-auto py-16 text-center text-gray-400 text-sm">
+      <div className="max-w-2xl mx-auto py-16 text-center text-gray-400 dark:text-gray-500 text-sm">
         Loading settings...
       </div>
     );
@@ -789,8 +789,8 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   if (!trip) {
     return (
       <div className="max-w-2xl mx-auto py-16 text-center">
-        <p className="text-gray-500 mb-4">Trip not found or you don't have access.</p>
-        <button onClick={() => router.push('/trips')} className="text-sm text-blue-600 hover:underline">
+        <p className="text-gray-500 dark:text-gray-400 mb-4">Trip not found or you don&apos;t have access.</p>
+        <button onClick={() => router.push('/trips')} className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
           Back to trips
         </button>
       </div>
@@ -798,7 +798,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   }
 
   return (
-    <div className="max-w-2xl mx-auto pb-24 divide-y divide-gray-200">
+    <div className="max-w-2xl mx-auto pb-24 divide-y divide-gray-200 dark:divide-white/[0.08]">
       {/* Theme & Colors */}
       <section className="py-8 first:pt-0">
         <SectionHeading>Theme & Colors</SectionHeading>
@@ -820,25 +820,25 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
       {/* Manage Tabs */}
       <section className="py-8">
         <SectionHeading>Manage Tabs</SectionHeading>
-        <p className="text-sm text-gray-500 mb-4">Choose which tabs appear in your trip navigation.</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">Choose which tabs appear in your trip navigation.</p>
         <div className="space-y-1">
           {CONFIGURABLE_TABS.map(({ segment, label, icon: Icon, alwaysOn }) => {
             const isEnabled = !hiddenTabs[segment];
             const tabColor = tabColorOverrides[segment] ?? theme.tabColors[segment] ?? theme.base;
             return (
-              <div key={segment} className="flex items-center justify-between rounded-xl p-3.5 hover:bg-gray-50 transition">
+              <div key={segment} className="flex items-center justify-between rounded-xl p-3.5 hover:bg-gray-50 dark:hover:bg-white/[0.03] transition">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg flex items-center justify-center"
-                    style={{ backgroundColor: isEnabled ? tabColor : '#d1d5db' }}>
-                    <Icon size={14} style={{ color: theme.textOnBase }} />
+                  <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${!isEnabled ? 'bg-gray-300 dark:bg-white/[0.12]' : ''}`}
+                    style={isEnabled ? { backgroundColor: tabColor } : undefined}>
+                    <Icon size={14} style={isEnabled ? { color: theme.textOnBase } : undefined} className={!isEnabled ? 'text-gray-400 dark:text-gray-500' : ''} />
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-gray-900">{label}</p>
-                    {alwaysOn && <p className="text-[11px] text-gray-400">Always visible</p>}
+                    <p className="text-sm font-semibold text-gray-900 dark:text-white">{label}</p>
+                    {alwaysOn && <p className="text-[11px] text-gray-400 dark:text-gray-500">Always visible</p>}
                   </div>
                 </div>
                 {alwaysOn ? (
-                  <div className="text-xs font-medium text-gray-400 px-2 py-1 rounded-full bg-gray-100">Required</div>
+                  <div className="text-xs font-medium text-gray-400 dark:text-gray-500 px-2 py-1 rounded-full bg-gray-100 dark:bg-white/[0.06]">Required</div>
                 ) : (
                   <Toggle enabled={isEnabled} onToggle={() => { setTabHidden(segment, isEnabled); markDirty(); }} color={theme.base} />
                 )}
@@ -891,14 +891,14 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
 
       {/* Floating save bar */}
       {dirty && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-2xl border border-gray-200 bg-white px-5 py-3 shadow-xl">
-          <div className="flex items-center gap-2 text-sm font-medium text-gray-700">
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900 px-5 py-3 shadow-xl">
+          <div className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
             <AlertTriangle size={14} className="text-amber-500" />
             Unsaved changes
           </div>
           <button
             onClick={handleDiscard}
-            className="flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50 transition"
+            className="flex items-center gap-1.5 text-sm font-medium px-4 py-2 rounded-lg border border-gray-300 dark:border-white/[0.12] text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.05] transition"
           >
             <X size={14} />
             Discard

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -34,7 +34,7 @@ function ContentHeader({ tripId, mapOpen, onToggleMap }: {
   const Icon = tab.icon;
 
   return (
-    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-6 pt-4 pb-3 sticky top-0 z-20">
+    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-16 pt-4 pb-3 sticky top-0 z-20">
       <div className="flex items-center gap-3">
         <div className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm shrink-0" style={{ backgroundColor: tab.color }}>
           <Icon size={15} className="text-white" />
@@ -341,7 +341,7 @@ function TripLayoutContent({
 
           <div className="flex">
             {/* Main content */}
-            <div className="flex-1 min-w-0 relative overflow-hidden px-5 md:pl-6 pt-4 pb-5">
+            <div className="flex-1 min-w-0 relative overflow-hidden px-5 md:pl-16 pt-4 pb-5">
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.div
                   key={`tab-${currentSegment}`}

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -139,7 +139,7 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 md:pl-16 py-8">
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+      <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-6">
         Explore {city}
       </h2>
 
@@ -147,10 +147,10 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
         {categories.map(({ key, label, items }) => (
           <div key={key}>
             <div className="flex items-center justify-between mb-2">
-              <h3 className="text-[14px] font-bold text-gray-700 dark:text-white/80 tracking-wide">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 tracking-wide">
                 {label}
               </h3>
-              <span className="text-[11px] text-gray-400 dark:text-white/40">{items.length} {items.length === 1 ? 'place' : 'places'}</span>
+              <span className="text-[11px] text-gray-400 dark:text-gray-500">{items.length} {items.length === 1 ? 'place' : 'places'}</span>
             </div>
             <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2 -mx-1 px-1">
               {items.map((item: ExploreItem) => (

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -8,10 +8,10 @@ import type { Trip } from '@travyl/shared';
 import { usePathname, useRouter } from 'next/navigation';
 import TripTabs, { getTabMeta } from '@/components/trip-tabs';
 import { useItineraryScreen, formatDateRange, useAuthStore, isTripOwner, canViewTrip } from '@travyl/shared';
-import { OceanWave, Footer } from '@/components/home';
+// Footer/OceanWave removed — trip pages use workspace layout
 import { ItineraryProvider, useItineraryContext } from '@/components/itinerary/ItineraryContext';
 import { TripThemeProvider } from '@/components/trip/TripThemeContext';
-import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
+import { CompactTripHeader } from '@/components/trip/CompactTripHeader';
 import { PlaceDetailModal } from '@/components/trip/PlaceDetailModal';
 import { useTripSettingsRegistration } from '@/stores/tripSettingsStore';
 import type { PlaceItem } from '@travyl/shared';
@@ -33,11 +33,8 @@ function ContentHeader({ tripId, mapOpen, onToggleMap }: {
   if (!tab) return null;
   const Icon = tab.icon;
 
-  // Overview + Itinerary: clean magazine look — no header bar
-  if (segment === '' || segment === 'itinerary') return null;
-
   return (
-    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-20 pt-4 pb-3 sticky top-0 z-20">
+    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-6 pt-4 pb-3 sticky top-0 z-20">
       <div className="flex items-center gap-3">
         <div className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm shrink-0" style={{ backgroundColor: tab.color }}>
           <Icon size={15} className="text-white" />
@@ -271,25 +268,6 @@ function TripLayoutContent({
   const currentSegment = pathname.replace(basePath, '').replace(/^\//, '') || '';
   const isOverview = currentSegment === '';
   const isCalendar = currentSegment === 'calendar';
-  const isMagazineLayout = isOverview || currentSegment === 'itinerary';
-
-  // Track exit animation from magazine pages to prevent white flash
-  const [exitingFromMagazine, setExitingFromMagazine] = useState(false);
-  const wasMagazineRef = useRef(isMagazineLayout);
-
-  useEffect(() => {
-    if (wasMagazineRef.current && !isMagazineLayout) {
-      setExitingFromMagazine(true);
-    }
-    wasMagazineRef.current = isMagazineLayout;
-  }, [isMagazineLayout]);
-
-  const handleExitComplete = () => {
-    setExitingFromMagazine(false);
-  };
-
-  const isItinerary = currentSegment === 'itinerary';
-  const useOverviewBg = isMagazineLayout || exitingFromMagazine;
 
   const tabOrder = ['', 'itinerary', 'calendar', 'hotels', 'flights', 'restaurants', 'activities', 'packing', 'budget', 'cars', 'favorites'];
   const prevSegmentRef = useRef(currentSegment);
@@ -345,73 +323,47 @@ function TripLayoutContent({
   }
 
   return (
-    <div
-      className={`pb-14 md:pb-0 ${useOverviewBg ? 'relative' : 'bg-white dark:bg-[var(--background)]'}`}
-      style={{ transition: 'background-color 0.5s ease' }}
-    >
-      {/* Trip navigation sidebar — vertical on desktop, bottom bar on mobile */}
-      <TripTabs tripId={tripId} position="left" dark={isMagazineLayout} />
+    <div className="pb-14 md:pb-0 bg-white dark:bg-[var(--background)]">
+      {/* Sidebar — always icon-only spine on desktop, bottom bar on mobile */}
+      <TripTabs tripId={tripId} position="left" />
 
-      {/* Hero banner — only on overview + itinerary */}
-      {(isOverview || isItinerary) && (
-        <TripMagazineHero tripId={tripId} trip={trip} compact={isItinerary} onTripUpdate={refetch} />
-      )}
+      {/* Compact trip header — all tabs */}
+      <CompactTripHeader tripId={tripId} trip={trip} onTripUpdate={refetch} />
 
+      {/* Content area */}
       <div className="mx-auto max-w-7xl">
+        <div className="relative z-10">
+          <ContentHeader
+            tripId={tripId}
+            mapOpen={mapOpen}
+            onToggleMap={() => setMapOpen(!mapOpen)}
+          />
 
-        {/* Suitcase card */}
-        <div
-          className={`relative z-10 ${
-            isOverview || currentSegment === 'itinerary'
-              ? ''
-              : 'rounded-2xl border border-gray-200/80 dark:border-white/[0.08] bg-white dark:bg-[var(--background)] mx-2 sm:mx-4'
-          }`}
-          style={
-            isOverview || currentSegment === 'itinerary'
-              ? undefined
-              : {
-                  boxShadow:
-                    '0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)',
-                }
-          }
-        >
-        <div>
-          {/* Content area */}
-          <div className="flex-1 flex flex-col min-w-0">
-            <ContentHeader
-              tripId={tripId}
-              mapOpen={mapOpen}
-              onToggleMap={() => setMapOpen(!mapOpen)}
-            />
+          <div className="flex">
+            {/* Main content */}
+            <div className="flex-1 min-w-0 relative overflow-hidden px-5 md:pl-6 pt-4 pb-5">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <motion.div
+                  key={`tab-${currentSegment}`}
+                  initial={pageVariants.initial}
+                  animate={pageVariants.animate}
+                  exit={pageVariants.exit}
+                  transition={{ duration: 0.18, ease: 'easeOut' }}
+                >
+                  {children}
+                </motion.div>
+              </AnimatePresence>
+            </div>
 
-            <div className="flex">
-              <div
-                className={`flex-1 min-w-0 relative overflow-hidden ${
-                  isMagazineLayout ? 'md:pl-20' : 'bg-white dark:bg-[var(--background)] px-5 md:pl-20 pt-4 pb-5'
-                }`}
-              >
-                <AnimatePresence mode="popLayout" initial={false} onExitComplete={handleExitComplete}>
-                  <motion.div
-                    key={`tab-${currentSegment}`}
-                    initial={pageVariants.initial}
-                    animate={pageVariants.animate}
-                    exit={pageVariants.exit}
-                    transition={{ duration: 0.18, ease: 'easeOut' }}
-                  >
-                    {children}
-                  </motion.div>
-                </AnimatePresence>
-              </div>
-
-              {/* Map side panel */}
-              <AnimatePresence>
+            {/* Map side panel */}
+            <AnimatePresence>
               {mapOpen && (
                 <motion.div
                   initial={{ width: 0, opacity: 0 }}
                   animate={{ width: '35%', opacity: 1 }}
                   exit={{ width: 0, opacity: 0 }}
                   transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
-                  className="hidden md:block shrink-0 border-l border-gray-200 overflow-hidden rounded-r-2xl"
+                  className="hidden md:block shrink-0 border-l border-gray-200 dark:border-white/[0.08] overflow-hidden"
                 >
                   <div className="sticky top-0 h-[calc(100vh-80px)] flex flex-col bg-white dark:bg-[var(--background)]">
                     <div className="flex items-center justify-between px-3 py-2.5 border-b border-gray-100 dark:border-white/[0.06] shrink-0">
@@ -465,27 +417,15 @@ function TripLayoutContent({
                   </div>
                 </motion.div>
               )}
-              </AnimatePresence>
-            </div>
+            </AnimatePresence>
           </div>
         </div>
       </div>
 
-      </div>{/* end max-w-7xl */}
-
-      {/* Trip Explore — only on overview page */}
+      {/* Explore section — overview only (useful content, not decoration) */}
       {isOverview && (
-        <div className="w-full relative z-10">
+        <div className="w-full relative z-10 bg-white dark:bg-[var(--background)]">
           <TripExploreSection trip={trip} />
-          <div className="h-24" />
-        </div>
-      )}
-
-      {/* Footer — only on overview */}
-      {isOverview && (
-        <div className="w-full relative z-20 bg-[var(--magazine-bg)] dark:bg-[var(--background)]">
-          <OceanWave />
-          <Footer />
         </div>
       )}
     </div>

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -138,8 +138,8 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
   };
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-      <h2 className="text-2xl font-bold text-white mb-6" style={{ textShadow: '0 2px 8px rgba(0,0,0,0.5)' }}>
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:pl-16 py-8">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
         Explore {city}
       </h2>
 
@@ -147,11 +147,10 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
         {categories.map(({ key, label, items }) => (
           <div key={key}>
             <div className="flex items-center justify-between mb-2">
-              <h3 className="text-[14px] font-bold text-white/80 tracking-wide"
-                style={{ textShadow: '0 1px 4px rgba(0,0,0,0.3)' }}>
+              <h3 className="text-[14px] font-bold text-gray-700 dark:text-white/80 tracking-wide">
                 {label}
               </h3>
-              <span className="text-[11px] text-white/40">{items.length} {items.length === 1 ? 'place' : 'places'}</span>
+              <span className="text-[11px] text-gray-400 dark:text-white/40">{items.length} {items.length === 1 ? 'place' : 'places'}</span>
             </div>
             <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2 -mx-1 px-1">
               {items.map((item: ExploreItem) => (

--- a/apps/web/components/entity/EntityActionsBar.tsx
+++ b/apps/web/components/entity/EntityActionsBar.tsx
@@ -38,9 +38,9 @@ export function EntityActionsBar({ entityId, entityType, entityName, variant = '
 
   if (!user) {
     return (
-      <div className="px-6 md:px-10 py-4 border-b border-gray-100">
-        <p className="text-sm text-gray-500">
-          <Link href="/login" className="text-[#003594] hover:text-[#002B7A] font-medium underline-offset-2 hover:underline">
+      <div className="px-6 md:px-10 py-4 border-b border-gray-100 dark:border-white/[0.06]">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          <Link href="/login" className="text-[#003594] dark:text-blue-400 hover:text-[#002B7A] dark:hover:text-blue-300 font-medium underline-offset-2 hover:underline">
             Sign in
           </Link>{' '}
           to save this {entityType}
@@ -50,7 +50,7 @@ export function EntityActionsBar({ entityId, entityType, entityName, variant = '
   }
 
   return (
-    <div className="px-6 md:px-10 py-4 border-b border-gray-100 flex items-center gap-3">
+    <div className="px-6 md:px-10 py-4 border-b border-gray-100 dark:border-white/[0.06] flex items-center gap-3">
       {/* Primary CTA */}
       <button className="inline-flex items-center gap-2 bg-[#003594] hover:bg-[#002B7A] text-white text-sm font-medium px-4 py-2.5 rounded-xl transition-colors">
         <Plus className="w-4 h-4" />
@@ -63,8 +63,8 @@ export function EntityActionsBar({ entityId, entityType, entityName, variant = '
         aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
         className={`inline-flex items-center justify-center w-10 h-10 rounded-xl border transition-colors ${
           favorited
-            ? 'bg-red-50 border-red-200 text-red-500'
-            : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'
+            ? 'bg-red-50 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-500'
+            : 'bg-white dark:bg-white/[0.03] border-gray-200 dark:border-white/[0.08] text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-white/[0.15]'
         }`}
       >
         {favorited ? (
@@ -78,7 +78,7 @@ export function EntityActionsBar({ entityId, entityType, entityName, variant = '
       <button
         onClick={handleShare}
         aria-label="Share"
-        className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-gray-200 bg-white text-gray-500 hover:border-gray-300 transition-colors"
+        className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-white/[0.15] transition-colors"
       >
         <ShareAndroid className="w-4 h-4" />
       </button>

--- a/apps/web/components/entity/EntityBreadcrumb.tsx
+++ b/apps/web/components/entity/EntityBreadcrumb.tsx
@@ -19,15 +19,15 @@ export function EntityBreadcrumb({ items, current }: Props) {
           <li key={i} className="flex items-center gap-1">
             <Link
               href={item.href}
-              className="text-sm text-gray-500 hover:text-[#003594] transition-colors"
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-[#003594] dark:hover:text-blue-400 transition-colors"
             >
               {item.label}
             </Link>
-            <NavArrowRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
+            <NavArrowRight className="w-3 h-3 text-gray-400 dark:text-gray-500 flex-shrink-0" />
           </li>
         ))}
         <li>
-          <span className="text-sm text-gray-900 font-medium truncate">{current}</span>
+          <span className="text-sm text-gray-900 dark:text-white font-medium truncate">{current}</span>
         </li>
       </ol>
     </nav>

--- a/apps/web/components/entity/EntityError.tsx
+++ b/apps/web/components/entity/EntityError.tsx
@@ -37,11 +37,11 @@ export function EntityError({ type, variant, onRetry }: Props) {
       <div className="text-center max-w-md">
         {variant === '404' ? (
           <>
-            <p className="text-6xl font-serif font-normal text-gray-200 mb-4">404</p>
-            <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-3">
+            <p className="text-6xl font-semibold text-gray-200 dark:text-white/10 mb-4">404</p>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">
               We couldn&apos;t find this {label}
             </h1>
-            <p className="text-sm text-gray-500 mb-8">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
               It may have been removed or the link might be incorrect.
             </p>
             <Link
@@ -54,10 +54,10 @@ export function EntityError({ type, variant, onRetry }: Props) {
         ) : (
           <>
             <p className="text-6xl mb-4">⚠</p>
-            <h1 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-3">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">
               Something went wrong
             </h1>
-            <p className="text-sm text-gray-500 mb-8">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
               We had trouble loading this {label}. Please try again.
             </p>
             <div className="flex items-center justify-center gap-3">
@@ -71,7 +71,7 @@ export function EntityError({ type, variant, onRetry }: Props) {
               )}
               <Link
                 href={href}
-                className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                className="inline-flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
               >
                 Browse {plural}
               </Link>

--- a/apps/web/components/entity/EntityHero.tsx
+++ b/apps/web/components/entity/EntityHero.tsx
@@ -66,7 +66,7 @@ export function EntityHero({
         </p>
 
         {/* Title */}
-        <h1 className="font-serif font-normal tracking-wide text-3xl md:text-5xl text-white mb-4">
+        <h1 className="font-semibold tracking-tight text-3xl md:text-5xl text-white mb-4">
           {title}
         </h1>
 

--- a/apps/web/components/entity/EntitySection.tsx
+++ b/apps/web/components/entity/EntitySection.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export function EntitySection({ title, children, className }: Props) {
   return (
-    <section className={`px-6 md:px-10 py-6 ${className ?? ''}`}>
-      <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide mb-4">
+    <section className={`px-6 md:px-10 py-6 border-t border-gray-100 dark:border-white/[0.06] ${className ?? ''}`}>
+      <h2 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wide mb-4">
         {title}
       </h2>
       {children}

--- a/apps/web/components/entity/NearbySection.tsx
+++ b/apps/web/components/entity/NearbySection.tsx
@@ -36,19 +36,19 @@ export function NearbySection({ title, items }: Props) {
   return (
     <section className="px-6 md:px-10 py-6">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-serif font-normal text-[#1e3a5f] tracking-wide">{title}</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white uppercase tracking-wide">{title}</h2>
         <div className="hidden md:flex items-center gap-2">
           <button
             onClick={() => scroll('left')}
             aria-label="Scroll left"
-            className="w-8 h-8 rounded-full border border-gray-200 bg-white flex items-center justify-center text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+            className="w-8 h-8 rounded-full border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] flex items-center justify-center text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-white/[0.15] hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
           >
             <NavArrowLeft className="w-4 h-4" />
           </button>
           <button
             onClick={() => scroll('right')}
             aria-label="Scroll right"
-            className="w-8 h-8 rounded-full border border-gray-200 bg-white flex items-center justify-center text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+            className="w-8 h-8 rounded-full border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] flex items-center justify-center text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-white/[0.15] hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
           >
             <NavArrowRight className="w-4 h-4" />
           </button>
@@ -63,7 +63,7 @@ export function NearbySection({ title, items }: Props) {
           <Link
             key={item.id}
             href={item.href}
-            className="flex-shrink-0 w-56 snap-start rounded-xl border border-gray-200 overflow-hidden group hover:border-gray-300 hover:shadow-md transition-all"
+            className="flex-shrink-0 w-56 snap-start rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] overflow-hidden group hover:border-gray-300 dark:hover:border-white/[0.15] hover:shadow-md transition-all"
           >
             <div className="relative aspect-[4/3] overflow-hidden">
               <Image
@@ -73,15 +73,15 @@ export function NearbySection({ title, items }: Props) {
                 className="object-cover group-hover:scale-105 transition-transform duration-300"
               />
               {item.rating != null && (
-                <div className="absolute top-2 right-2 flex items-center gap-1 bg-white/90 backdrop-blur-sm rounded-md px-2 py-0.5">
+                <div className="absolute top-2 right-2 flex items-center gap-1 bg-white/90 dark:bg-black/60 backdrop-blur-sm rounded-md px-2 py-0.5">
                   <StarSolid className="w-3 h-3 text-amber-400" />
-                  <span className="text-xs font-medium text-gray-900">{item.rating.toFixed(1)}</span>
+                  <span className="text-xs font-medium text-gray-900 dark:text-white">{item.rating.toFixed(1)}</span>
                 </div>
               )}
             </div>
             <div className="p-3">
-              <p className="text-sm font-medium text-gray-900 truncate">{item.name}</p>
-              <p className="text-xs text-gray-500 mt-0.5">{item.type}</p>
+              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{item.name}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{item.type}</p>
             </div>
           </Link>
         ))}

--- a/apps/web/components/itinerary/FlightSection.tsx
+++ b/apps/web/components/itinerary/FlightSection.tsx
@@ -74,40 +74,40 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
           willChange: 'max-height, opacity',
         }}
       >
-        <div className="bg-white rounded-lg overflow-hidden border border-blue-200 shadow-sm">
+        <div className="bg-white dark:bg-white/[0.03] rounded-xl overflow-hidden border border-gray-200 dark:border-white/[0.08] shadow-sm">
           {/* Flight Route Visualization */}
           <div className="p-4">
             <div className="flex items-center justify-between">
               <div className="text-center flex-1">
-                <p className="text-xs text-gray-500 mb-0.5">Departure</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Departure</p>
                 <p className="text-xl" style={{ color: 'var(--trip-base)' }}>{flight.originIata}</p>
-                <p className="text-sm font-medium text-gray-800 mt-1">{flight.departureTime}</p>
-                <p className="text-[11px] text-gray-400 mt-0.5">{flight.departureTerminal} &middot; Gate {flight.gate}</p>
-                <p className="text-[11px] text-gray-400">Boarding: {flight.boardingTime}</p>
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mt-1">{flight.departureTime}</p>
+                <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">{flight.departureTerminal} &middot; Gate {flight.gate}</p>
+                <p className="text-[11px] text-gray-400 dark:text-gray-500">Boarding: {flight.boardingTime}</p>
               </div>
               <div className="flex-1 flex flex-col items-center px-2">
                 <div className="relative w-full">
-                  <div className="border-t border-dashed border-gray-300 w-full" />
+                  <div className="border-t border-dashed border-gray-300 dark:border-white/[0.15] w-full" />
                   <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full p-1" style={{ backgroundColor: 'var(--trip-base)' }}>
                     <PaperPlane size={12} className="text-white" />
                   </div>
                 </div>
-                <p className="text-xs text-gray-500 mt-2">{flight.duration}</p>
-                <p className="text-[11px] font-medium text-emerald-600">Direct</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">{flight.duration}</p>
+                <p className="text-[11px] font-medium text-emerald-600 dark:text-emerald-400">Direct</p>
               </div>
               <div className="text-center flex-1">
-                <p className="text-xs text-gray-500 mb-0.5">Arrival</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Arrival</p>
                 <p className="text-xl" style={{ color: 'var(--trip-base)' }}>{flight.destIata}</p>
-                <p className="text-sm font-medium text-gray-800 mt-1">{flight.arrivalTime}</p>
-                <p className="text-[11px] text-gray-400 mt-0.5">{flight.arrivalTerminal}</p>
+                <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mt-1">{flight.arrivalTime}</p>
+                <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5">{flight.arrivalTerminal}</p>
               </div>
             </div>
 
             {/* Airline & Status */}
-            <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between text-xs">
-              <span className="text-gray-800 font-medium">{flight.airline}</span>
+            <div className="mt-3 pt-3 border-t border-gray-100 dark:border-white/[0.06] flex items-center justify-between text-xs">
+              <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.airline}</span>
               <div className="flex items-center gap-2">
-                <span className="text-gray-500">Check-in by: {flight.boardingTime}</span>
+                <span className="text-gray-500 dark:text-gray-400">Check-in by: {flight.boardingTime}</span>
                 <span
                   className="px-2 py-0.5 rounded-full text-[11px] font-medium"
                   style={{ backgroundColor: 'rgb(var(--trip-base-rgb) / 0.08)', color: 'var(--trip-base)' }}
@@ -119,52 +119,52 @@ export function FlightSection({ flight, collapsed }: FlightSectionProps) {
           </div>
 
           {/* Details Grid */}
-          <div className="px-4 pb-4 border-t border-gray-100">
+          <div className="px-4 pb-4 border-t border-gray-100 dark:border-white/[0.06]">
             <div className="pt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
               <div className="flex justify-between">
-                <span className="text-gray-500">Flight</span>
-                <span className="text-gray-800 font-medium">{flight.flightNumber}</span>
+                <span className="text-gray-500 dark:text-gray-400">Flight</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.flightNumber}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Duration</span>
-                <span className="text-gray-800 font-medium">{flight.duration}</span>
+                <span className="text-gray-500 dark:text-gray-400">Duration</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.duration}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Aircraft</span>
-                <span className="text-gray-800 font-medium">{flight.aircraft}</span>
+                <span className="text-gray-500 dark:text-gray-400">Aircraft</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.aircraft}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Class</span>
-                <span className="text-gray-800 font-medium">{flight.cabinClass}</span>
+                <span className="text-gray-500 dark:text-gray-400">Class</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.cabinClass}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Seats</span>
-                <span className="text-gray-800 font-medium">{flight.seats}</span>
+                <span className="text-gray-500 dark:text-gray-400">Seats</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.seats}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Baggage</span>
-                <span className="text-gray-800 font-medium">{flight.baggage}</span>
+                <span className="text-gray-500 dark:text-gray-400">Baggage</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.baggage}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Meal</span>
-                <span className="text-gray-800 font-medium">{flight.meal}</span>
+                <span className="text-gray-500 dark:text-gray-400">Meal</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.meal}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-500">Wi-Fi</span>
-                <span className="text-gray-800 font-medium">{flight.wifi ? 'Available' : 'N/A'}</span>
+                <span className="text-gray-500 dark:text-gray-400">Wi-Fi</span>
+                <span className="text-gray-800 dark:text-gray-200 font-medium">{flight.wifi ? 'Available' : 'N/A'}</span>
               </div>
               <div className="flex justify-between col-span-2">
-                <span className="text-gray-500">Confirmation</span>
+                <span className="text-gray-500 dark:text-gray-400">Confirmation</span>
                 <span className="font-semibold font-mono" style={{ color: 'var(--trip-base)' }}>{flight.confirmation}</span>
               </div>
             </div>
 
             {/* Booking Section */}
-            <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between">
+            <div className="mt-3 pt-3 border-t border-gray-100 dark:border-white/[0.06] flex items-center justify-between">
               <div>
-                <p className="text-[11px] text-gray-500">Per traveler</p>
+                <p className="text-[11px] text-gray-500 dark:text-gray-400">Per traveler</p>
                 <p className="text-lg" style={{ color: 'var(--trip-base)' }}>${flight.pricePerTraveler}</p>
-                <p className="text-[11px] text-gray-400">Total: ${flight.totalPrice}</p>
+                <p className="text-[11px] text-gray-400 dark:text-gray-500">Total: ${flight.totalPrice}</p>
               </div>
               <button
                 className={`px-5 py-2 rounded-lg font-medium text-xs transition-all flex items-center gap-2 ${

--- a/apps/web/components/itinerary/ItineraryPinCard.tsx
+++ b/apps/web/components/itinerary/ItineraryPinCard.tsx
@@ -36,7 +36,7 @@ function hasTape(id: string): boolean {
 }
 
 const frameClasses: Record<FrameStyle, { container: string; image: string }> = {
-  polaroid: { container: 'rounded-sm bg-white p-1.5 pb-2.5 shadow-md', image: 'rounded-sm' },
+  polaroid: { container: 'rounded-sm bg-white dark:bg-white/[0.03] p-1.5 pb-2.5 shadow-md', image: 'rounded-sm' },
   rounded: { container: 'rounded-2xl overflow-hidden shadow-sm', image: 'rounded-2xl' },
   sharp: { container: 'rounded-none overflow-hidden shadow-sm', image: 'rounded-none' },
   asymmetric: { container: 'rounded-tl-3xl rounded-br-3xl rounded-tr-md rounded-bl-md overflow-hidden shadow-sm', image: 'rounded-tl-3xl rounded-br-3xl rounded-tr-md rounded-bl-md' },

--- a/apps/web/components/itinerary/TimeGroupSection.tsx
+++ b/apps/web/components/itinerary/TimeGroupSection.tsx
@@ -107,8 +107,8 @@ export function TimeGroupSection({ group, onActivityClick, onAddActivity, cardSt
               {/* Inline add button */}
               <button
                 onClick={() => onAddActivity?.(group.timeOfDay)}
-                className="shrink-0 w-[200px] h-full min-h-[200px] flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed transition-colors"
-                style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.3)', color: 'var(--trip-base)', backgroundColor: 'var(--magazine-bg, rgba(255,255,255,0.85))' }}
+                className="shrink-0 w-[200px] h-full min-h-[200px] flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed transition-colors bg-white/85 dark:bg-white/[0.03]"
+                style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.3)', color: 'var(--trip-base)' }}
               >
                 <Plus size={20} style={{ opacity: 0.5 }} />
                 <span className="text-[11px] font-medium" style={{ opacity: 0.7 }}>Add {config.label} Activity</span>
@@ -130,8 +130,8 @@ export function TimeGroupSection({ group, onActivityClick, onAddActivity, cardSt
             ))}
             <button
               onClick={() => onAddActivity?.(group.timeOfDay)}
-              className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl border-2 border-dashed hover:border-trip-base/40 transition-colors backdrop-blur-md"
-              style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.3)', color: 'var(--trip-base)', backgroundColor: 'var(--magazine-bg, rgba(255,255,255,0.85))' }}
+              className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl border-2 border-dashed hover:border-trip-base/40 transition-colors backdrop-blur-md bg-white/85 dark:bg-white/[0.03]"
+              style={{ borderColor: 'rgb(var(--trip-base-rgb) / 0.3)', color: 'var(--trip-base)' }}
             >
               <Plus size={14} />
               <span className="text-[12px] font-medium">Add {config.label} Activity</span>

--- a/apps/web/components/packing/PackingActivityFeed.tsx
+++ b/apps/web/components/packing/PackingActivityFeed.tsx
@@ -99,16 +99,16 @@ export function PackingActivityFeed({ entries, defaultCollapsed = false, current
     return (
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--cal-text-muted)]">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
             Activity
           </h3>
           <div className="flex gap-1">
             <button onClick={() => setFilterMine(false)}
-              className={`text-[10px] px-2 py-0.5 rounded-full ${!filterMine ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'}`}>
+              className={`text-[10px] px-2 py-0.5 rounded-full ${!filterMine ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400'}`}>
               All
             </button>
             <button onClick={() => setFilterMine(true)}
-              className={`text-[10px] px-2 py-0.5 rounded-full ${filterMine ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'}`}>
+              className={`text-[10px] px-2 py-0.5 rounded-full ${filterMine ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400'}`}>
               Mine
             </button>
           </div>
@@ -137,11 +137,11 @@ export function PackingActivityFeed({ entries, defaultCollapsed = false, current
         </button>
         <div className="flex gap-1">
           <button onClick={() => setFilterMine(false)}
-            className={`text-[10px] px-2 py-0.5 rounded-full ${!filterMine ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'}`}>
+            className={`text-[10px] px-2 py-0.5 rounded-full ${!filterMine ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400'}`}>
             All
           </button>
           <button onClick={() => setFilterMine(true)}
-            className={`text-[10px] px-2 py-0.5 rounded-full ${filterMine ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'}`}>
+            className={`text-[10px] px-2 py-0.5 rounded-full ${filterMine ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400' : 'bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400'}`}>
             Mine
           </button>
         </div>

--- a/apps/web/components/packing/PackingCategoryList.tsx
+++ b/apps/web/components/packing/PackingCategoryList.tsx
@@ -43,7 +43,7 @@ export function PackingCategoryList({
       return (
         <div className="flex flex-col gap-3 py-6 px-2">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-10 rounded-lg bg-[var(--cal-surface)] animate-pulse" />
+            <div key={i} className="h-10 rounded-lg bg-gray-100 dark:bg-white/[0.06] animate-pulse" />
           ))}
         </div>
       )
@@ -51,7 +51,7 @@ export function PackingCategoryList({
     return (
       <div className="flex flex-col items-center justify-center py-10 gap-2">
         <span className="text-3xl">🧳</span>
-        <p className="text-sm text-[var(--cal-text-muted)]">No items yet — search above to add</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400">No items yet — search above to add</p>
       </div>
     )
   }

--- a/apps/web/components/packing/PackingItem.tsx
+++ b/apps/web/components/packing/PackingItem.tsx
@@ -168,13 +168,13 @@ export function PackingItem({ item, onToggle, onIncrementPacked, onUpdateQuantit
       {/* Claim/Release buttons — appear on hover */}
       {!item.owner_id && !item.group_tag && onClaim && (
         <button onClick={() => onClaim(item.id)}
-          className="opacity-0 group-hover:opacity-100 text-[10px] text-blue-600 hover:text-blue-800 transition-opacity">
+          className="opacity-0 group-hover:opacity-100 text-[10px] text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-opacity">
           Claim
         </button>
       )}
       {item.owner_id === currentUserId && onRelease && (
         <button onClick={() => onRelease(item.id)}
-          className="opacity-0 group-hover:opacity-100 text-[10px] text-gray-500 hover:text-gray-700 transition-opacity">
+          className="opacity-0 group-hover:opacity-100 text-[10px] text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-opacity">
           Release
         </button>
       )}

--- a/apps/web/components/packing/PackingPage.tsx
+++ b/apps/web/components/packing/PackingPage.tsx
@@ -31,7 +31,7 @@ export function PackingPage({ tripId }: PackingPageProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="w-6 h-6 border-2 border-[var(--cal-border,#334155)] border-t-[#003594] rounded-full animate-spin" />
+        <div className="w-6 h-6 border-2 border-gray-200 dark:border-white/[0.08] border-t-[#003594] rounded-full animate-spin" />
       </div>
     )
   }
@@ -39,7 +39,7 @@ export function PackingPage({ tripId }: PackingPageProps) {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <p className="text-[13px] text-red-400">Failed to load packing list.</p>
+        <p className="text-sm text-red-500 dark:text-red-400">Failed to load packing list.</p>
       </div>
     )
   }
@@ -77,7 +77,9 @@ export function PackingPage({ tripId }: PackingPageProps) {
         {(userId ? ['all', 'mine', 'shared', 'kids', 'adults'] : ['all', 'kids', 'adults']).map((filter) => (
           <button key={filter} onClick={() => setFilterBy(filter)}
             className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-              filterBy === filter ? 'bg-[#1e3a5f] text-white' : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-white/10'
+              filterBy === filter
+                ? 'bg-[#1e3a5f] text-white'
+                : 'text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-white/[0.03] hover:bg-gray-100 dark:hover:bg-white/[0.06]'
             }`}>
             {filter === 'all' ? 'All' : filter === 'mine' ? 'My Items' : filter.charAt(0).toUpperCase() + filter.slice(1)}
           </button>
@@ -125,7 +127,7 @@ export function PackingPage({ tripId }: PackingPageProps) {
 
         {/* Collapsible activity sidebar */}
         {sidebarOpen && (
-          <div className="w-72 shrink-0 border-l border-gray-200 dark:border-white/10 pl-4 overflow-auto">
+          <div className="w-72 shrink-0 border-l border-gray-200 dark:border-white/[0.08] pl-4 overflow-auto">
             <PackingActivityFeed entries={auditLog} currentUserId={userId} />
           </div>
         )}

--- a/apps/web/components/packing/PackingPanel.tsx
+++ b/apps/web/components/packing/PackingPanel.tsx
@@ -28,7 +28,7 @@ export function PackingPanel({ tripId }: PackingPanelProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="w-6 h-6 border-2 border-[var(--cal-border,#334155)] border-t-[#003594] rounded-full animate-spin" />
+        <div className="w-6 h-6 border-2 border-gray-200 dark:border-white/[0.08] border-t-[#003594] rounded-full animate-spin" />
       </div>
     )
   }
@@ -36,7 +36,7 @@ export function PackingPanel({ tripId }: PackingPanelProps) {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <p className="text-[13px] text-red-400">Failed to load packing list.</p>
+        <p className="text-sm text-red-500 dark:text-red-400">Failed to load packing list.</p>
       </div>
     )
   }

--- a/apps/web/components/packing/PackingProgress.tsx
+++ b/apps/web/components/packing/PackingProgress.tsx
@@ -14,12 +14,12 @@ export function PackingProgress({ packed, total, percent, compact = false }: Pac
     return (
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-[var(--cal-text-muted)]">Packing Progress</span>
-          <span className="text-xs tabular-nums font-semibold text-[var(--cal-text)]">
+          <span className="text-xs font-medium text-gray-600 dark:text-gray-400">Packing Progress</span>
+          <span className="text-xs tabular-nums font-semibold text-gray-900 dark:text-white">
             {packed}/{total}
           </span>
         </div>
-        <div className="h-1.5 rounded-full bg-[var(--cal-border)] overflow-hidden">
+        <div className="h-1.5 rounded-full bg-gray-100 dark:bg-white/[0.06] overflow-hidden">
           <motion.div
             className="h-full rounded-full"
             initial={{ width: 0 }}
@@ -35,13 +35,13 @@ export function PackingProgress({ packed, total, percent, compact = false }: Pac
   }
 
   return (
-    <div className="rounded-xl border border-[var(--cal-border)] bg-[var(--cal-surface)] p-5 flex flex-col gap-3">
+    <div className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-5 flex flex-col gap-3">
       <div className="flex items-end gap-2">
-        <span className="text-4xl font-bold tabular-nums text-[var(--cal-text)]">{percent}%</span>
-        <span className="text-sm text-[var(--cal-text-muted)] pb-1">packed</span>
+        <span className="text-4xl font-bold tabular-nums text-gray-900 dark:text-white">{percent}%</span>
+        <span className="text-sm text-gray-600 dark:text-gray-400 pb-1">packed</span>
       </div>
 
-      <div className="h-2 rounded-full bg-[var(--cal-border)] overflow-hidden">
+      <div className="h-2 rounded-full bg-gray-100 dark:bg-white/[0.06] overflow-hidden">
         <motion.div
           className="h-full rounded-full"
           initial={{ width: 0 }}
@@ -53,7 +53,7 @@ export function PackingProgress({ packed, total, percent, compact = false }: Pac
         />
       </div>
 
-      <p className="text-sm text-[var(--cal-text-muted)]">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
         {packed} of {total} item{total !== 1 ? 's' : ''} packed
       </p>
     </div>

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import Image from 'next/image';
+import { Pencil, X, Check, Calendar, Users } from 'lucide-react';
+import { formatDateRange, updateTripDetails } from '@travyl/shared';
+import type { Trip } from '@travyl/shared';
+
+export function CompactTripHeader({
+  tripId,
+  trip,
+  onTripUpdate,
+}: {
+  tripId: string;
+  trip: Trip | null;
+  onTripUpdate?: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editStart, setEditStart] = useState('');
+  const [editEnd, setEditEnd] = useState('');
+  const [editTravelers, setEditTravelers] = useState(1);
+  const [saving, setSaving] = useState(false);
+
+  const rawCover = trip?.trip_context?.hero_image_url;
+  const coverImage = rawCover?.includes('googleusercontent.com')
+    ? rawCover.replace(/=w\d+-h\d+[^&]*/, '=w1600-h600-k-no')
+    : rawCover;
+
+  const destination = trip?.destination;
+  const cityName = destination ? destination.split(',')[0].trim() : '';
+  const countryName = destination ? destination.split(',').slice(1).join(',').trim() : '';
+  const dateStr = trip?.start_date && trip?.end_date ? formatDateRange(trip.start_date, trip.end_date) : null;
+  const travelersCount = trip?.travelers || 1;
+
+  const countryFlag = trip?.trip_context?.country?.flag as string | undefined;
+  const countryCca2 = trip?.trip_context?.country?.cca2 as string | undefined;
+  const flagUrl = countryFlag || (countryCca2 ? `https://flagcdn.com/24x18/${countryCca2.toLowerCase()}.png` : null);
+
+  const openEditor = useCallback(() => {
+    setEditTitle(trip?.title || '');
+    setEditStart(trip?.start_date || '');
+    setEditEnd(trip?.end_date || '');
+    setEditTravelers(trip?.travelers || 1);
+    setEditing(true);
+  }, [trip]);
+
+  const saveEdits = useCallback(async () => {
+    if (!tripId || saving) return;
+    setSaving(true);
+    try {
+      await updateTripDetails(tripId, {
+        title: editTitle || undefined,
+        start_date: editStart || undefined,
+        end_date: editEnd || undefined,
+        travelers: editTravelers,
+      });
+      setEditing(false);
+      onTripUpdate?.();
+    } catch (e) {
+      console.error('Failed to update trip:', e);
+    } finally {
+      setSaving(false);
+    }
+  }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
+
+  return (
+    <div className="relative w-full overflow-hidden" style={{ height: 180 }}>
+      {/* Background image */}
+      {coverImage ? (
+        <Image
+          src={coverImage}
+          alt={destination || ''}
+          fill
+          referrerPolicy="no-referrer"
+          className="object-cover"
+          style={{ objectPosition: 'center 30%' }}
+          sizes="100vw"
+          priority
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
+      )}
+
+      {/* Gradient overlay */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(to bottom, rgba(0,0,0,0.2) 0%, rgba(0,0,0,0.5) 60%, rgba(0,0,0,0.7) 100%)',
+        }}
+      />
+
+      {/* Content */}
+      <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pb-5">
+        {/* Country tag */}
+        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5"
+          style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px]" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.3)' }} />}
+          <span>{countryName || ''}</span>
+        </p>
+
+        {/* Title row */}
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h1
+              className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif"
+              style={{ letterSpacing: '0.02em', textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}
+            >
+              {cityName || trip?.title || 'Untitled Trip'}
+            </h1>
+
+            {/* Meta row */}
+            {!editing && (
+              <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
+                {dateStr && (
+                  <span className="flex items-center gap-1.5">
+                    <Calendar size={12} className="text-white/50" />
+                    {dateStr}
+                  </span>
+                )}
+                <span className="flex items-center gap-1.5">
+                  <Users size={12} className="text-white/50" />
+                  {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
+                </span>
+                <button
+                  onClick={openEditor}
+                  className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
+                  title="Edit trip details"
+                >
+                  <Pencil size={12} />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Inline editor */}
+        {editing && (
+          <div className="flex flex-wrap items-end gap-2.5 mt-2">
+            <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
+            <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+            <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+            <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
+            <button onClick={saveEdits} disabled={saving}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
+              <Check size={13} /> {saving ? '...' : 'Save'}
+            </button>
+            <button onClick={() => setEditing(false)}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
+              <X size={13} /> Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -1,3 +1,3 @@
 export function Skeleton({ className = '', style }: { className?: string; style?: React.CSSProperties }) {
-  return <div className={`bg-gray-200 rounded animate-pulse ${className}`} style={style} />;
+  return <div className={`bg-gray-200 dark:bg-white/[0.08] rounded animate-pulse ${className}`} style={style} />;
 }

--- a/docs/superpowers/plans/2026-04-02-trip-page-restyle.md
+++ b/docs/superpowers/plans/2026-04-02-trip-page-restyle.md
@@ -1,0 +1,460 @@
+# Trip Page Restyle — Unified App Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dual magazine/suitcase-card layout on trip pages with a single consistent app-shell layout — compact header, no card wrapper, no footer, consistent sidebar.
+
+**Architecture:** Modify `trip-layout-inner.tsx` to remove the magazine-vs-card branching. Replace `TripMagazineHero` (full-viewport parallax) with a new `CompactTripHeader` (~180px). Hide footer on trip routes via the dashboard layout. Keep calendar full-screen layout unchanged.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind CSS 4, Framer Motion, Supabase
+
+**Spec:** `docs/superpowers/specs/2026-04-02-trip-page-restyle-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `apps/web/components/trip/CompactTripHeader.tsx` | New ~180px trip header with bg image, title, dates, edit |
+| Modify | `apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx` | Remove dual layout, unified shell, no footer/OceanWave |
+| Modify | `apps/web/components/dashboard/DashboardLayout.tsx` | Accept `hideFooter` prop, conditionally render footer |
+| Modify | `apps/web/app/(dashboard)/layout.tsx` | Pass route info to decide footer visibility |
+| Keep | `apps/web/components/trip/TripMagazineHero.tsx` | Not deleted yet — keep for reference, unused after changes |
+| Keep | `apps/web/components/trip-tabs.tsx` | No changes needed — already icon-only spine on desktop |
+
+---
+
+### Task 1: Create CompactTripHeader Component
+
+**Files:**
+- Create: `apps/web/components/trip/CompactTripHeader.tsx`
+
+This replaces the full-viewport `TripMagazineHero` with a compact ~180px header showing trip identity.
+
+- [ ] **Step 1: Create the CompactTripHeader component**
+
+```tsx
+'use client';
+
+import { useState, useCallback } from 'react';
+import Image from 'next/image';
+import { Pencil, X, Check, Calendar, Users } from 'lucide-react';
+import { formatDateRange, updateTripDetails } from '@travyl/shared';
+import type { Trip } from '@travyl/shared';
+
+export function CompactTripHeader({
+  tripId,
+  trip,
+  onTripUpdate,
+}: {
+  tripId: string;
+  trip: Trip | null;
+  onTripUpdate?: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editStart, setEditStart] = useState('');
+  const [editEnd, setEditEnd] = useState('');
+  const [editTravelers, setEditTravelers] = useState(1);
+  const [saving, setSaving] = useState(false);
+
+  const rawCover = trip?.trip_context?.hero_image_url;
+  const coverImage = rawCover?.includes('googleusercontent.com')
+    ? rawCover.replace(/=w\d+-h\d+[^&]*/, '=w1600-h600-k-no')
+    : rawCover;
+
+  const destination = trip?.destination;
+  const cityName = destination ? destination.split(',')[0].trim() : '';
+  const countryName = destination ? destination.split(',').slice(1).join(',').trim() : '';
+  const dateStr = trip?.start_date && trip?.end_date ? formatDateRange(trip.start_date, trip.end_date) : null;
+  const travelersCount = trip?.travelers || 1;
+
+  const countryFlag = trip?.trip_context?.country?.flag as string | undefined;
+  const countryCca2 = trip?.trip_context?.country?.cca2 as string | undefined;
+  const flagUrl = countryFlag || (countryCca2 ? `https://flagcdn.com/24x18/${countryCca2.toLowerCase()}.png` : null);
+
+  const openEditor = useCallback(() => {
+    setEditTitle(trip?.title || '');
+    setEditStart(trip?.start_date || '');
+    setEditEnd(trip?.end_date || '');
+    setEditTravelers(trip?.travelers || 1);
+    setEditing(true);
+  }, [trip]);
+
+  const saveEdits = useCallback(async () => {
+    if (!tripId || saving) return;
+    setSaving(true);
+    try {
+      await updateTripDetails(tripId, {
+        title: editTitle || undefined,
+        start_date: editStart || undefined,
+        end_date: editEnd || undefined,
+        travelers: editTravelers,
+      });
+      setEditing(false);
+      onTripUpdate?.();
+    } catch (e) {
+      console.error('Failed to update trip:', e);
+    } finally {
+      setSaving(false);
+    }
+  }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
+
+  return (
+    <div className="relative w-full overflow-hidden" style={{ height: 180 }}>
+      {/* Background image */}
+      {coverImage ? (
+        <Image
+          src={coverImage}
+          alt={destination || ''}
+          fill
+          referrerPolicy="no-referrer"
+          className="object-cover"
+          style={{ objectPosition: 'center 30%' }}
+          sizes="100vw"
+          priority
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
+      )}
+
+      {/* Gradient overlay */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(to bottom, rgba(0,0,0,0.2) 0%, rgba(0,0,0,0.5) 60%, rgba(0,0,0,0.7) 100%)',
+        }}
+      />
+
+      {/* Content */}
+      <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pb-5">
+        {/* Country tag */}
+        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5"
+          style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px]" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.3)' }} />}
+          <span>{countryName || ''}</span>
+        </p>
+
+        {/* Title row */}
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h1
+              className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif"
+              style={{ letterSpacing: '0.02em', textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}
+            >
+              {cityName || trip?.title || 'Untitled Trip'}
+            </h1>
+
+            {/* Meta row */}
+            {!editing && (
+              <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
+                {dateStr && (
+                  <span className="flex items-center gap-1.5">
+                    <Calendar size={12} className="text-white/50" />
+                    {dateStr}
+                  </span>
+                )}
+                <span className="flex items-center gap-1.5">
+                  <Users size={12} className="text-white/50" />
+                  {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
+                </span>
+                <button
+                  onClick={openEditor}
+                  className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
+                  title="Edit trip details"
+                >
+                  <Pencil size={12} />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Inline editor */}
+        {editing && (
+          <div className="flex flex-wrap items-end gap-2.5 mt-2">
+            <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
+            <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+            <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+            <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
+              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
+            <button onClick={saveEdits} disabled={saving}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
+              <Check size={13} /> {saving ? '...' : 'Save'}
+            </button>
+            <button onClick={() => setEditing(false)}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
+              <X size={13} /> Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify file was created**
+
+Run: `ls -la apps/web/components/trip/CompactTripHeader.tsx`
+Expected: File exists
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/trip/CompactTripHeader.tsx
+git commit -m "Add CompactTripHeader component for unified trip shell"
+```
+
+---
+
+### Task 2: Rewrite trip-layout-inner.tsx — Unified Shell
+
+**Files:**
+- Modify: `apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx`
+
+Remove the dual magazine/suitcase-card branching. All non-calendar tabs use the same layout: CompactTripHeader + flat content area. Keep TripExploreSection on overview (it's useful content), but remove footer/OceanWave.
+
+- [ ] **Step 1: Update imports**
+
+Replace TripMagazineHero import with CompactTripHeader. Remove OceanWave and Footer imports.
+
+In `trip-layout-inner.tsx`, change:
+```tsx
+import { OceanWave, Footer } from '@/components/home';
+```
+to:
+```tsx
+// Footer/OceanWave removed — trip pages are a workspace, no marketing footer
+```
+
+And change:
+```tsx
+import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
+```
+to:
+```tsx
+import { CompactTripHeader } from '@/components/trip/CompactTripHeader';
+```
+
+- [ ] **Step 2: Simplify TripLayoutContent**
+
+Remove these variables and logic:
+- `isMagazineLayout` const and its usage
+- `exitingFromMagazine` state and `wasMagazineRef`
+- `useOverviewBg` const
+- The `handleExitComplete` callback
+- `isItinerary` const
+
+Replace the main return (after the calendar early-return) with a unified layout:
+
+```tsx
+  return (
+    <div className="pb-14 md:pb-0 bg-white dark:bg-[var(--background)]">
+      {/* Sidebar — always icon-only spine on desktop, bottom bar on mobile */}
+      <TripTabs tripId={tripId} position="left" />
+
+      {/* Compact trip header — all tabs */}
+      <CompactTripHeader tripId={tripId} trip={trip} onTripUpdate={refetch} />
+
+      {/* Content area */}
+      <div className="mx-auto max-w-7xl">
+        <div className="relative z-10">
+          <ContentHeader
+            tripId={tripId}
+            mapOpen={mapOpen}
+            onToggleMap={() => setMapOpen(!mapOpen)}
+          />
+
+          <div className="flex">
+            {/* Main content */}
+            <div className="flex-1 min-w-0 relative overflow-hidden px-5 md:pl-20 pt-4 pb-5">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <motion.div
+                  key={`tab-${currentSegment}`}
+                  initial={pageVariants.initial}
+                  animate={pageVariants.animate}
+                  exit={pageVariants.exit}
+                  transition={{ duration: 0.18, ease: 'easeOut' }}
+                >
+                  {children}
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            {/* Map side panel — unchanged */}
+            <AnimatePresence>
+              {mapOpen && (
+                <motion.div
+                  initial={{ width: 0, opacity: 0 }}
+                  animate={{ width: '35%', opacity: 1 }}
+                  exit={{ width: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
+                  className="hidden md:block shrink-0 border-l border-gray-200 dark:border-white/[0.08] overflow-hidden"
+                >
+                  {/* ... existing map panel content stays exactly as-is ... */}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+
+      {/* Explore section — overview only (useful content, not decoration) */}
+      {isOverview && (
+        <div className="w-full relative z-10 bg-white dark:bg-[var(--background)]">
+          <TripExploreSection trip={trip} />
+        </div>
+      )}
+
+      {/* NO footer, NO OceanWave — this is a workspace */}
+    </div>
+  );
+```
+
+- [ ] **Step 3: Update ContentHeader to show on all tabs**
+
+Change the ContentHeader to render on ALL tabs (not skip overview/itinerary):
+
+```tsx
+  // Remove this early return:
+  // if (segment === '' || segment === 'itinerary') return null;
+  
+  // Instead, show on all tabs. Overview gets a simple label too.
+  if (!tab) return null;
+```
+
+- [ ] **Step 4: Clean up unused variables**
+
+Remove these now-unused declarations from TripLayoutContent:
+- `isItinerary`
+- `isMagazineLayout`
+- `exitingFromMagazine` / `setExitingFromMagazine`
+- `wasMagazineRef`
+- `useOverviewBg`
+- `handleExitComplete`
+
+Update `pageVariants` — remove `onExitComplete={handleExitComplete}` from AnimatePresence.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd /home/noah-gallego/Dropbox/Desktop/travyl-combined/travyl-frontend/.worktrees/feature-tra-404 && npx tsc --noEmit -p apps/web/tsconfig.json 2>&1 | head -30`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/\(dashboard\)/trip/\[id\]/trip-layout-inner.tsx
+git commit -m "Unify trip layout: compact header, remove card wrapper and footer"
+```
+
+---
+
+### Task 3: Hide Footer on Trip Routes
+
+**Files:**
+- Modify: `apps/web/components/dashboard/DashboardLayout.tsx`
+- Modify: `apps/web/app/(dashboard)/layout.tsx`
+
+The dashboard layout currently doesn't render a footer (the trip layout was doing it internally). But verify no footer leaks in from elsewhere, and ensure the DashboardLayout cleanly supports trip-route detection.
+
+- [ ] **Step 1: Verify no footer in DashboardLayout**
+
+Read `apps/web/components/dashboard/DashboardLayout.tsx` — confirm it doesn't render a Footer. If it does, make footer conditional based on a `hideFooter` prop.
+
+Current code has no footer — just `<main>{children}</main>`. No change needed here unless a footer was added elsewhere.
+
+- [ ] **Step 2: Check root layout for footer**
+
+Read `apps/web/app/layout.tsx` to verify the global footer isn't rendered at root level (it shouldn't be — the trip layout was rendering it conditionally).
+
+- [ ] **Step 3: Commit (if changes were needed)**
+
+```bash
+git add -A
+git commit -m "Ensure footer is hidden on trip routes"
+```
+
+---
+
+### Task 4: Visual QA with Playwright
+
+**Files:** No code changes — testing only.
+
+- [ ] **Step 1: Start local dev server**
+
+Copy `.env.local` from main tree if needed, then start:
+```bash
+cp ../../apps/web/.env.local apps/web/.env.local 2>/dev/null
+npm run web
+```
+
+- [ ] **Step 2: Navigate to trip page and screenshot**
+
+Use Playwright MCP to navigate to `http://localhost:3000/trip/b2e1743f-6356-4d42-9859-fd9c8720ba63` and take a screenshot. Verify:
+- Compact header (~180px) with trip image, title, destination, dates
+- No quote/blockquote
+- Consistent sidebar (icon-only spine)
+- No rounded card wrapper on content
+- No footer
+
+- [ ] **Step 3: Check itinerary tab**
+
+Navigate to `/trip/.../itinerary`, screenshot. Verify same compact header, same layout pattern.
+
+- [ ] **Step 4: Check a utility tab (e.g. packing)**
+
+Navigate to `/trip/.../packing`, screenshot. Verify no suitcase card, same header, no footer.
+
+- [ ] **Step 5: Check calendar tab**
+
+Navigate to `/trip/.../calendar`, screenshot. Verify calendar still uses full-screen layout (unchanged).
+
+- [ ] **Step 6: Check mobile viewport**
+
+Resize to 375x812, navigate to overview. Verify bottom tab bar, compact header scales, no footer.
+
+---
+
+### Task 5: Create Planning File and Final Commit
+
+**Files:**
+- Create: `planning/TRA-404.md`
+
+- [ ] **Step 1: Write planning file**
+
+```markdown
+# TRA-404: Restyle Trip Pages — Unified App Shell
+
+## Goal
+Replace dual magazine/suitcase-card layout with one consistent app shell.
+
+## Completed
+- CompactTripHeader component (180px, bg image, title, dates, edit)
+- Unified layout in trip-layout-inner.tsx (no card wrapper, no footer)
+- ContentHeader shows on all tabs
+- Footer/OceanWave removed from trip pages
+- Calendar layout unchanged
+
+## Files Changed
+- `apps/web/components/trip/CompactTripHeader.tsx` (new)
+- `apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx` (rewritten)
+- `apps/web/components/dashboard/DashboardLayout.tsx` (verified)
+
+## Linear
+https://linear.app/travyl/issue/TRA-404
+```
+
+- [ ] **Step 2: Final commit and push**
+
+```bash
+git add planning/TRA-404.md
+git commit -m "Add TRA-404 planning file"
+git push -u origin feature/TRA-404
+```

--- a/packages/shared/src/hooks/useActivityFilters.ts
+++ b/packages/shared/src/hooks/useActivityFilters.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useMemo, useEffect } from 'react';
 import type { DiscoverItem } from '../types';
 import type { ItineraryDayViewModel } from '../viewmodels/itineraryViewModel';

--- a/packages/shared/src/hooks/useCollaborators.ts
+++ b/packages/shared/src/hooks/useCollaborators.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchCollaborators, updateCollaboratorRole, removeCollaborator } from '../services/api';
 import type { CollaboratorRole } from '../types';

--- a/packages/shared/src/hooks/useExchangeRates.ts
+++ b/packages/shared/src/hooks/useExchangeRates.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query'
 
 interface ExchangeRatesResult {

--- a/packages/shared/src/hooks/useExploreData.ts
+++ b/packages/shared/src/hooks/useExploreData.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { shuffle } from '../utils';

--- a/packages/shared/src/hooks/useExploreRows.ts
+++ b/packages/shared/src/hooks/useExploreRows.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useCallback, useMemo } from 'react';
 import { getCyclicGradient } from '../config/homeData';
 import { useExploreData } from './useExploreData';

--- a/packages/shared/src/hooks/useFlights.ts
+++ b/packages/shared/src/hooks/useFlights.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchFlights } from '../services/api';
 

--- a/packages/shared/src/hooks/useForkTrip.ts
+++ b/packages/shared/src/hooks/useForkTrip.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { forkTrip } from '../services/api';
 import type { Trip } from '../types';

--- a/packages/shared/src/hooks/useHeroConfig.ts
+++ b/packages/shared/src/hooks/useHeroConfig.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchHeroConfig } from '../services/api';
 

--- a/packages/shared/src/hooks/useHomeCurrency.ts
+++ b/packages/shared/src/hooks/useHomeCurrency.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useExchangeRates } from './useExchangeRates'

--- a/packages/shared/src/hooks/useHomeScreen.ts
+++ b/packages/shared/src/hooks/useHomeScreen.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useMemo, useCallback } from 'react';
 import { useAuthStore } from '../stores';
 import { useTrips } from './useTrips';

--- a/packages/shared/src/hooks/useHotels.ts
+++ b/packages/shared/src/hooks/useHotels.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchHotels } from '../services/api';
 

--- a/packages/shared/src/hooks/useInspirationCards.ts
+++ b/packages/shared/src/hooks/useInspirationCards.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchInspirationCards } from '../services/api';

--- a/packages/shared/src/hooks/useItineraryDays.ts
+++ b/packages/shared/src/hooks/useItineraryDays.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchItineraryDays } from '../services/api';
 

--- a/packages/shared/src/hooks/useItineraryScreen.ts
+++ b/packages/shared/src/hooks/useItineraryScreen.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useMemo, useCallback } from 'react';
 import { useTrip } from './useTrip';
 import { useItineraryDays } from './useItineraryDays';

--- a/packages/shared/src/hooks/useMosaicTiles.ts
+++ b/packages/shared/src/hooks/useMosaicTiles.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchMosaicTiles } from '../services/api';

--- a/packages/shared/src/hooks/usePackingList.ts
+++ b/packages/shared/src/hooks/usePackingList.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useMemo, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../services/supabase'

--- a/packages/shared/src/hooks/usePackingSuggestions.ts
+++ b/packages/shared/src/hooks/usePackingSuggestions.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useMemo, useCallback, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../services/supabase'

--- a/packages/shared/src/hooks/usePlaceImage.ts
+++ b/packages/shared/src/hooks/usePlaceImage.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery, useQueries } from '@tanstack/react-query';
 
 // Use our own Next.js API proxy to avoid CORS issues

--- a/packages/shared/src/hooks/useProfile.ts
+++ b/packages/shared/src/hooks/useProfile.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchProfile } from '../services/api';
 import { useAuthStore } from '../stores/authStore';

--- a/packages/shared/src/hooks/useRestaurantFilters.ts
+++ b/packages/shared/src/hooks/useRestaurantFilters.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useMemo, useEffect } from 'react';
 import type { DiscoverItem } from '../types';
 

--- a/packages/shared/src/hooks/useSimilarPlaces.ts
+++ b/packages/shared/src/hooks/useSimilarPlaces.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 import type { PlaceItem } from '../types';
 import { haversineKm } from '../utils';

--- a/packages/shared/src/hooks/useTagUsDestinations.ts
+++ b/packages/shared/src/hooks/useTagUsDestinations.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 import { useMosaicTiles } from './useMosaicTiles';
 import { useInspirationCards } from './useInspirationCards';

--- a/packages/shared/src/hooks/useTrip.ts
+++ b/packages/shared/src/hooks/useTrip.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import type { Trip } from '../types';
 import { fetchTripById } from '../services/api';

--- a/packages/shared/src/hooks/useTripBudget.ts
+++ b/packages/shared/src/hooks/useTripBudget.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useItineraryDays } from './useItineraryDays'

--- a/packages/shared/src/hooks/useTripPlanner.ts
+++ b/packages/shared/src/hooks/useTripPlanner.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useCallback, useRef } from 'react';
 
 // On web: use our own API proxy routes (relative URLs, no prefix needed)

--- a/packages/shared/src/hooks/useTrips.ts
+++ b/packages/shared/src/hooks/useTrips.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchTrips, fetchCollaboratorTrips } from '../services/api';
 import { supabase } from '../services/supabase';

--- a/packages/shared/src/stores/authStore.ts
+++ b/packages/shared/src/stores/authStore.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { create } from 'zustand';
 import { supabase } from '../services/supabase';
 import type { User, Session } from '@supabase/supabase-js';

--- a/packages/shared/src/stores/settingsStore.ts
+++ b/packages/shared/src/stores/settingsStore.ts
@@ -1,3 +1,5 @@
+'use client';
+
 // packages/shared/src/stores/settingsStore.ts
 import { create } from 'zustand';
 import { supabase } from '../services/supabase';

--- a/planning/TRA-404.md
+++ b/planning/TRA-404.md
@@ -1,0 +1,23 @@
+# TRA-404: Restyle Trip Pages — Unified App Shell
+
+## Goal
+Replace dual magazine/suitcase-card layout with one consistent app shell.
+
+## Completed
+- CompactTripHeader component (180px, bg image, title, destination, dates, inline edit)
+- Unified layout in trip-layout-inner.tsx (no card wrapper, no footer, no OceanWave)
+- ContentHeader shows on all tabs including overview/itinerary
+- Footer removed from trip pages — workspace, not marketing
+- Sidebar padding fixed so content clears the 56px icon spine
+- Calendar layout unchanged (full-screen with hover-reveal sidebar)
+- TripExploreSection kept on overview (useful content)
+
+## Files Changed
+- `apps/web/components/trip/CompactTripHeader.tsx` (new)
+- `apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx` (rewritten)
+
+## Manual Step
+- TripMagazineHero.tsx can be deleted once this is merged and stable
+
+## Linear
+https://linear.app/travyl/issue/TRA-404


### PR DESCRIPTION
## Summary
- Replace dual magazine/suitcase-card layout with single unified app shell
- New `CompactTripHeader` (180px) replaces full-viewport parallax hero on all tabs
- Remove rounded card wrapper (window-in-window gone)
- Remove footer + OceanWave from trip pages
- ContentHeader with tab icon/label shows on all tabs (including overview/itinerary)
- Consistent sidebar — no dark/light mode switching between tabs
- Fix sidebar overlap on content headings and explore section (pl-16 clearance)
- Fix explore section text colors for light background (was white-on-white)
- Remove budget page redundant card wrapper (card-in-card gone)
- Add flights empty state placeholder when no search has run
- Calendar layout unchanged (full-screen with hover-reveal sidebar)
- TripExploreSection kept on overview (useful content)

## Issues Fixed
1. Two competing layouts (magazine vs card) — unified
2. Window-in-window from card wrapper — removed
3. No trip identity on utility tabs — compact header on all tabs
4. Full-viewport hero too tall — 180px compact header
5. Random travel quote wasting space — removed
6. "Hide Info" button floating awkwardly — removed
7. Sidebar overlapping content — padding fix
8. Sidebar dark/light switching per tab — consistent now
9. Itinerary giant photo overlap — hero removed
10. Flights empty whitespace — empty state added
11. Budget card-in-card — outer wrapper removed
12. Footer on workspace pages — removed

## Test Plan
- [x] Typecheck passes (web + shared)
- [x] Playwright: overview compact header, no footer, no quote
- [x] Playwright: itinerary same layout as overview
- [x] Playwright: packing tab no card wrapper, content clears sidebar
- [x] Playwright: calendar unchanged (full-screen)
- [x] Playwright: created trip on dev.gotravyl.com, audited all tabs
- [ ] Manual: verify with populated trip on localhost after login

Closes TRA-404