### PR TITLE
TRA-437: Fix compact header expand height

### DIFF
--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -2,18 +2,20 @@
 
 import { useState, useCallback } from 'react';
 import Image from 'next/image';
-import { Pencil, X, Check, Calendar, Users } from 'lucide-react';
-import { formatDateRange, updateTripDetails } from '@travyl/shared';
+import { Pencil, X, Check, Calendar, Users, ChevronDown } from 'lucide-react';
+import { formatDateRange, updateTripDetails, useWeather } from '@travyl/shared';
 import type { Trip } from '@travyl/shared';
 
 export function CompactTripHeader({
   tripId,
   trip,
   onTripUpdate,
+  overrideImage,
 }: {
   tripId: string;
   trip: Trip | null;
   onTripUpdate?: () => void;
+  overrideImage?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState('');
@@ -21,8 +23,11 @@ export function CompactTripHeader({
   const [editEnd, setEditEnd] = useState('');
   const [editTravelers, setEditTravelers] = useState(1);
   const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
-  const rawCover = trip?.trip_context?.hero_image_url;
+  // Best available image — Unsplash override first, then hero_images, then hero_image_url
+  const heroImages = trip?.trip_context?.hero_images as string[] | undefined;
+  const rawCover = overrideImage || heroImages?.[0] || trip?.trip_context?.hero_image_url;
   const coverImage = rawCover?.includes('googleusercontent.com')
     ? rawCover.replace(/=w\d+-h\d+[^&]*/, '=w1600-h600-k-no')
     : rawCover;
@@ -36,6 +41,32 @@ export function CompactTripHeader({
   const countryFlag = trip?.trip_context?.country?.flag as string | undefined;
   const countryCca2 = trip?.trip_context?.country?.cca2 as string | undefined;
   const flagUrl = countryFlag || (countryCca2 ? `https://flagcdn.com/24x18/${countryCca2.toLowerCase()}.png` : null);
+
+  // Quick info — prefer live weather, fall back to trip_context
+  const ctx = trip?.trip_context as Record<string, any> | undefined;
+  const { data: liveWeather } = useWeather(cityName || '');
+  const weather = liveWeather?.current || ctx?.weather?.current;
+  const safety = ctx?.safety;
+  const tz = ctx?.country?.timezone;
+  const aqi = ctx?.aqi?.aqi;
+  const aqiLevel = ctx?.aqi?.level;
+  const currency = ctx?.country?.currency;
+  const nextHoliday = (ctx?.holidays as { name: string; date: string }[] | undefined)?.[0];
+  const forecast = (liveWeather?.forecast || ctx?.weather?.forecast) as { date: string; high: number; low: number; conditions: string }[] | undefined;
+  const wiki = ctx?.wiki?.extract as string | undefined;
+
+  const infoPills: { label: string; color?: string }[] = [];
+  const temp = weather?.temp_f ?? weather?.temp;
+  if (temp != null) infoPills.push({ label: `${Math.round(temp)}°${weather?.temp_f ? 'F' : ''} ${weather?.conditions || weather?.condition || ''}`.trim() });
+  else if (weather?.conditions) infoPills.push({ label: weather.conditions });
+  if (currency) infoPills.push({ label: `${currency.symbol} ${currency.code}` });
+  if (tz) infoPills.push({ label: tz });
+  if (aqiLevel) infoPills.push({ label: `Air ${aqiLevel}`, color: aqi <= 50 ? '#4ade80' : aqi <= 100 ? '#facc15' : '#f87171' });
+  if (safety) {
+    const s = safety.score;
+    infoPills.push({ label: `Safe (${s.toFixed(1)})`, color: s <= 2.5 ? '#4ade80' : s <= 3.5 ? '#facc15' : '#f87171' });
+  }
+  if (nextHoliday) infoPills.push({ label: `${nextHoliday.name} · ${new Date(nextHoliday.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` });
 
   const openEditor = useCallback(() => {
     setEditTitle(trip?.title || '');
@@ -64,100 +95,146 @@ export function CompactTripHeader({
     }
   }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
 
+  const hasExpandContent = !!(forecast?.length || wiki);
+
   return (
-    <div className="relative w-full overflow-hidden" style={{ height: 180 }}>
-      {/* Background image */}
-      {coverImage ? (
-        <Image
-          src={coverImage}
-          alt={destination || ''}
-          fill
-          referrerPolicy="no-referrer"
-          className="object-cover"
-          style={{ objectPosition: 'center 30%' }}
-          sizes="100vw"
-          priority
-        />
-      ) : (
-        <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
-      )}
+    <div className="relative w-full">
+      {/* Fixed-height hero */}
+      <div className="relative w-full overflow-hidden" style={{ height: 300 }}>
+        {/* Background image */}
+        {coverImage ? (
+          <Image
+            src={coverImage}
+            alt={destination || ''}
+            fill
+            referrerPolicy="no-referrer"
+            className="object-cover"
+            style={{ objectPosition: 'center center' }}
+            sizes="100vw"
+            priority
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
+        )}
 
-      {/* Gradient overlay */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            'linear-gradient(to bottom, rgba(0,0,0,0.2) 0%, rgba(0,0,0,0.5) 60%, rgba(0,0,0,0.7) 100%)',
-        }}
-      />
+        {/* Gradient overlay */}
+        <div className="absolute inset-0" style={{
+          background: 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.15) 40%, rgba(0,0,0,0.7) 85%, rgba(0,0,0,0.8) 100%)',
+        }} />
 
-      {/* Content */}
-      <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pb-5">
-        {/* Country tag */}
-        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5"
-          style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px]" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.3)' }} />}
-          <span>{countryName || ''}</span>
-        </p>
+        {/* Content */}
+        <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-[100px] pb-5">
+          {/* Country tag */}
+          <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5 text-white/70">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px] shadow-sm" />}
+            <span>{countryName || ''}</span>
+          </p>
 
-        {/* Title row */}
-        <div className="flex items-end justify-between gap-4">
-          <div>
-            <h1
-              className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif"
-              style={{ letterSpacing: '0.02em', textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}
-            >
+          {/* Title + expand toggle */}
+          <div className="flex items-center gap-2">
+            <h1 className="text-3xl sm:text-4xl font-normal text-white leading-tight tracking-wide font-serif">
               {cityName || trip?.title || 'Untitled Trip'}
             </h1>
+            {hasExpandContent && (
+              <button
+                onClick={() => setExpanded(v => !v)}
+                className="text-white/40 hover:text-white/70 transition-colors mt-1"
+                title={expanded ? 'Show less' : 'Show more'}
+              >
+                <ChevronDown size={16} className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`} />
+              </button>
+            )}
+          </div>
 
-            {/* Meta row */}
-            {!editing && (
-              <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
-                {dateStr && (
-                  <span className="flex items-center gap-1.5">
-                    <Calendar size={12} className="text-white/50" />
-                    {dateStr}
-                  </span>
-                )}
+          {/* Meta row */}
+          {!editing && (
+            <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
+              {dateStr && (
                 <span className="flex items-center gap-1.5">
-                  <Users size={12} className="text-white/50" />
-                  {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
+                  <Calendar size={12} className="text-white/50" />
+                  {dateStr}
                 </span>
-                <button
-                  onClick={openEditor}
-                  className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
-                  title="Edit trip details"
-                >
-                  <Pencil size={12} />
-                </button>
+              )}
+              <span className="flex items-center gap-1.5">
+                <Users size={12} className="text-white/50" />
+                {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
+              </span>
+              <button
+                onClick={openEditor}
+                className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
+                title="Edit trip details"
+              >
+                <Pencil size={12} />
+              </button>
+            </div>
+          )}
+
+          {/* Quick info — inline text */}
+          {infoPills.length > 0 && !editing && (
+            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 mt-2 text-[11px] text-white/70">
+              {infoPills.map((pill, i) => (
+                <span key={i} className="inline-flex items-center">
+                  {i > 0 && <span className="mr-1.5 text-white/30">·</span>}
+                  <span style={pill.color ? { color: pill.color } : undefined}>{pill.label}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Inline editor */}
+          {editing && (
+            <div className="flex flex-wrap items-end gap-2.5 mt-2">
+              <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
+              <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+              <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+              <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
+              <button onClick={saveEdits} disabled={saving}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
+                <Check size={13} /> {saving ? '...' : 'Save'}
+              </button>
+              <button onClick={() => setEditing(false)}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
+                <X size={13} /> Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded details — dropdown below header */}
+      {expanded && (
+        <div className="relative z-20 px-6 sm:px-10 md:pl-[100px] py-4">
+          <div className="max-w-3xl flex flex-col gap-2.5">
+            {/* Forecast row */}
+            {forecast && forecast.length > 0 && !isNaN(forecast[0]?.high) && (
+              <div className="flex items-center gap-3 text-gray-800">
+                {temp != null && (
+                  <span className="text-xl font-semibold tabular-nums">{Math.round(temp)}°</span>
+                )}
+                <span className="text-gray-300">|</span>
+                {forecast.slice(0, 5).map((day) => (
+                  <span key={day.date} className="text-[11px] tabular-nums">
+                    <span className="text-gray-500">{new Date(day.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' })}</span>{' '}
+                    <span className="font-medium">{Math.round(day.high)}°</span>
+                    <span className="text-gray-400">/{Math.round(day.low)}°</span>
+                  </span>
+                ))}
               </div>
+            )}
+            {/* Wiki */}
+            {wiki && (
+              <p className="text-[12px] leading-relaxed text-gray-500 font-serif line-clamp-2">
+                {wiki}
+              </p>
             )}
           </div>
         </div>
-
-        {/* Inline editor */}
-        {editing && (
-          <div className="flex flex-wrap items-end gap-2.5 mt-2">
-            <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
-            <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
-            <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
-            <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
-            <button onClick={saveEdits} disabled={saving}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
-              <Check size={13} /> {saving ? '...' : 'Save'}
-            </button>
-            <button onClick={() => setEditing(false)}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
-              <X size={13} /> Cancel
-            </button>
-          </div>
-        )}
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Compact trip header stays fixed at 300px instead of growing to 520px on expand
- Forecast/wiki content now renders as a dropdown section below the hero
- Added live weather hook, 5-day forecast row, and wiki extract to expanded view
- Dark gray text colors for readability on page background

## Test plan
- [ ] Open a trip page and verify header is 300px
- [ ] Click chevron toggle — expanded content should appear below header without resizing it
- [ ] Verify forecast and wiki text are readable