### PR TITLE
fix: overview tab bugs + explore section overhaul (TRA-459–462)

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
@@ -525,7 +525,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
       {/* Title + count */}
       <div className="px-4 pt-4 pb-2 flex items-baseline justify-between">
         <div>
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white" style={{ color: 'var(--trip-base)' }}>
+          <h2 className="text-lg font-normal tracking-wide text-gray-900 dark:text-white font-serif" style={{ color: 'var(--trip-base)' }}>
             Explore {destination}
           </h2>
           <p className="text-[12px] text-gray-400 dark:text-gray-500">{filtered.length} places to discover</p>
@@ -585,7 +585,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
                       <SectionIcon size={16} />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-[15px] font-bold text-gray-900 dark:text-white leading-tight">
+                      <h3 className="text-[15px] font-normal text-gray-900 dark:text-white leading-tight font-serif">
                         {section.label}
                       </h3>
                       <p className="text-[11px] text-gray-400">

--- a/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
@@ -980,7 +980,7 @@ function BrowsingHotelGridCard({
       <div className="p-3.5 flex flex-col flex-1 bg-white dark:bg-white/[0.03]">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <h4 className="text-sm font-bold text-gray-900 dark:text-white truncate">{hotel.name}</h4>
+            <h4 className="text-sm font-normal text-gray-900 dark:text-white truncate font-serif">{hotel.name}</h4>
             <StarRating count={hotel.stars} />
           </div>
           <div className="text-right shrink-0">
@@ -1038,7 +1038,7 @@ function BrowsingHotelListCard({
         <div>
           <div className="flex items-start justify-between gap-2">
             <div>
-              <h4 className="text-sm font-bold text-gray-900 dark:text-white">{hotel.name}</h4>
+              <h4 className="text-sm font-normal text-gray-900 dark:text-white font-serif">{hotel.name}</h4>
               <StarRating count={hotel.stars} />
             </div>
             <div className="text-right shrink-0">
@@ -1141,7 +1141,7 @@ function BrowsingHotelBookView({
                       {hotel.rating}
                     </span>
                   </div>
-                  <h3 className="text-xl font-bold text-gray-900 dark:text-white">{hotel.name}</h3>
+                  <h3 className="text-xl font-normal text-gray-900 dark:text-white font-serif tracking-wide">{hotel.name}</h3>
                   <div className="flex items-center gap-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
                     <MapPin size={12} />
                     <span>{hotel.neighborhood} &middot; {hotel.address}</span>
@@ -1489,7 +1489,7 @@ function BookedHotelCard({
               </span>
             </div>
 
-            <h3 className="text-lg font-bold text-gray-900 dark:text-white">{hotel.name}</h3>
+            <h3 className="text-lg font-normal text-gray-900 dark:text-white font-serif tracking-wide">{hotel.name}</h3>
 
             {/* Check-in / check-out */}
             {(hotel.checkIn || hotel.checkOut) && (
@@ -1527,7 +1527,7 @@ function BookedHotelCard({
                       <div className="flex items-end justify-between">
                         <div>
                           <span className="text-[9px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded-full bg-white/20 backdrop-blur-sm text-white">Your Room</span>
-                          <h4 className="text-sm font-bold text-white mt-1">{room.type}</h4>
+                          <h4 className="text-sm font-normal text-white mt-1 font-serif">{room.type}</h4>
                         </div>
                         <div className="text-right">
                           <p className="text-lg font-bold text-white">{cs}{room.price}<span className="text-[10px] font-normal opacity-70">/night</span></p>

--- a/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
@@ -241,7 +241,7 @@ export default function InfoPage({ params }: { params: Promise<{ id: string }> }
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
               <MapPin size={20} />
-              <h4 className="text-lg font-bold">{trip.destination}</h4>
+              <h4 className="text-lg font-normal font-serif tracking-wide">{trip.destination}</h4>
             </div>
             <div className="flex items-center gap-2 text-white/90 text-sm">
               <Calendar size={16} />

--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -1269,8 +1269,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
             <div className="flex items-center gap-3">
               <div>
                 <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-white/70">Your Itinerary</p>
-                <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white tracking-wide"
-                  style={{ textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}>At a Glance</h2>
+                <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white tracking-wide">At a Glance</h2>
               </div>
               <TripHistoryToggle tripId={id} variant="pill" dark />
             </div>

--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -271,7 +271,7 @@ function GlanceView({
                     {day.dateLabel}
                   </p>
                   <div className="flex items-end justify-between">
-                    <h3 className="text-base font-bold text-white">{day.dayLabel}</h3>
+                    <h3 className="text-base font-normal text-white font-serif tracking-wide">{day.dayLabel}</h3>
                     <span className="text-[9px] text-white/40">
                       {day.activityCount} {day.activityCount === 1 ? 'activity' : 'activities'}
                     </span>
@@ -1269,7 +1269,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
             <div className="flex items-center gap-3">
               <div>
                 <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-white/70">Your Itinerary</p>
-                <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white tracking-wide">At a Glance</h2>
+                <h2 className="text-2xl sm:text-3xl font-normal text-gray-900 dark:text-white tracking-wide font-serif">At a Glance</h2>
               </div>
               <TripHistoryToggle tripId={id} variant="pill" dark />
             </div>

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -93,7 +93,7 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
     <section>
       <div className="mb-4 flex items-end justify-between">
         <div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Things to Do</h2>
+          <h2 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white font-serif">Things to Do</h2>
         </div>
         <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-gray-100 dark:bg-white/[0.06]">
           {!gridView && (
@@ -111,18 +111,6 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
               </button>
             </>
           )}
-          {gridView && (
-            <button onClick={() => setFlush(f => !f)} title="Flush grid"
-              className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-200 dark:border-white/[0.12]"
-              style={{ backgroundColor: flush ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
-              <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />
-            </button>
-          )}
-          <button onClick={() => setGridView(v => !v)} title={gridView ? 'Carousel view' : 'Grid view'}
-            className="w-7 h-7 rounded-full flex items-center justify-center transition-all border border-gray-200 dark:border-white/[0.12]"
-            style={{ backgroundColor: gridView ? 'rgba(0,0,0,0.06)' : 'transparent' }}>
-            {gridView ? <LayoutList size={12} className="text-gray-500 dark:text-white/70" /> : <LayoutGrid size={12} className="text-gray-500 dark:text-white/70" />}
-          </button>
         </div>
       </div>
 
@@ -147,7 +135,7 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
                   </span>
                 </div>
                 <div className="absolute bottom-0 left-0 right-0 p-5">
-                  <h3 className="text-lg font-bold text-white leading-tight mb-1">{item.title}</h3>
+                  <h3 className="text-lg font-normal text-white leading-tight mb-1 font-serif">{item.title}</h3>
                   <p className="text-[12px] text-white/60 mb-3 line-clamp-2">{item.description}</p>
                   <AddToTripButton isAdded={addedItems.has(item.id)} onToggle={() => onToggleAdd(item.id)} />
                 </div>
@@ -185,7 +173,7 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
                 </span>
               </div>
               <div className="absolute bottom-0 left-0 right-0 p-3">
-                <h3 className="text-sm font-bold text-white leading-tight">{item.title}</h3>
+                <h3 className="text-sm font-normal text-white leading-tight font-serif">{item.title}</h3>
               </div>
             </div>
           ))}
@@ -201,7 +189,7 @@ function NewsSection({ news }: { news: NonNullable<TripContextData['news']> }) {
 
   return (
     <section>
-      <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">News</h2>
+      <h2 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white mb-4 font-serif">News</h2>
 
       {/* Scrollable news list capped to match What's Going On card height */}
       <div className="max-h-[360px] overflow-y-auto scrollbar-hide pr-1">
@@ -215,7 +203,7 @@ function NewsSection({ news }: { news: NonNullable<TripContextData['news']> }) {
                   <span className="text-[10px] uppercase tracking-wider font-bold text-[color:var(--trip-base)] opacity-50">· {item.source}</span>
                 )}
               </div>
-              <h3 className="text-[14px] font-bold leading-snug mb-0.5 line-clamp-2 text-gray-900 dark:text-white">{item.title}</h3>
+              <h3 className="text-[14px] font-normal leading-snug mb-0.5 line-clamp-2 text-gray-900 dark:text-white font-serif">{item.title}</h3>
               <p className="text-[12px] leading-relaxed line-clamp-1 text-gray-600 dark:text-gray-400 opacity-60">{item.snippet}</p>
             </a>
           ))}
@@ -249,7 +237,7 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
     <section>
       <div className="mb-4 flex items-end justify-between">
         <div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white">What&apos;s Going On</h2>
+          <h2 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white font-serif">What&apos;s Going On</h2>
         </div>
         <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-gray-100 dark:bg-white/[0.06]">
           <span className="text-[11px] tabular-nums mr-1 text-gray-500 dark:text-white/80">
@@ -297,7 +285,7 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
               </div>
               {/* Content overlay on image */}
               <div className="absolute bottom-0 left-0 right-0 p-4">
-                <h3 className="text-[15px] font-bold text-white leading-tight mb-0.5 line-clamp-2">
+                <h3 className="text-[15px] font-normal text-white leading-tight mb-0.5 line-clamp-2 font-serif">
                   {item.title}
                 </h3>
                 <p className="text-[11px] text-white/60 leading-snug line-clamp-1 mb-2">{item.description}</p>
@@ -328,13 +316,13 @@ function NearbyCitiesSection({ cities }: { cities: NonNullable<TripContextData['
   if (!cities.length) return null;
   return (
     <section>
-      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Also Consider Visiting</h3>
+      <h3 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white mb-4 font-serif">Also Consider Visiting</h3>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {cities.map((city) => (
           <div key={city.id} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-4 transition-all hover:scale-[1.02]">
             <div className="flex items-center gap-2 mb-1">
               <MapPin size={12} className="text-[color:var(--trip-base)]" />
-              <span className="text-[14px] font-bold text-gray-900 dark:text-white">{city.name}</span>
+              <span className="text-[14px] font-normal text-gray-900 dark:text-white font-serif">{city.name}</span>
             </div>
             <p className="text-[11px] text-gray-600 dark:text-gray-400 opacity-60">{city.country}</p>
             <p className="text-[11px] font-semibold mt-1 text-[color:var(--trip-base)]">{Math.round(city.distance)} km away</p>
@@ -363,7 +351,7 @@ function CostOfLivingSection({ cost, currency }: { cost: NonNullable<TripContext
   ];
   return (
     <section>
-      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Cost of Living</h3>
+      <h3 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white mb-4 font-serif">Cost of Living</h3>
       <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
         {items.map(({ icon: Icon, label, value }) => (
           <div key={label} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-3 text-center">
@@ -437,7 +425,7 @@ function PhrasesSection({ phrases, language }: { phrases: Record<string, string>
     <section>
       <div className="flex items-center gap-2 mb-4">
         <Languages size={14} className="text-[color:var(--trip-base)]" />
-        <h3 className="text-xl font-bold text-gray-900 dark:text-white">Essential Phrases</h3>
+        <h3 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white font-serif">Essential Phrases</h3>
         {language && <span className="text-xs font-medium text-gray-500 dark:text-gray-400">({language})</span>}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
@@ -732,14 +720,17 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
     category: e.category || 'Event',
     image: e.photo_url || '',
   }));
-  // Fallback: use explore_items as "What's Going On" when no real events exist
-  const exploreFallback = exploreItems.slice(0, 6).map((e: any) => ({
-    id: e.id || e.name,
-    title: e.title || e.name,
-    description: e.description || e.category || '',
-    category: e.category || 'Attraction',
-    image: hiRes(e.image),
-  }));
+  // Fallback: use explore_items that AREN'T already in "Things to Do" (which shows the first items)
+  // Take from the back half of the list to avoid duplicates
+  const exploreFallback = exploreItems.length > 6
+    ? exploreItems.slice(-6).map((e: any) => ({
+        id: e.id || e.name,
+        title: e.title || e.name,
+        description: e.description || e.category || '',
+        category: e.category || 'Attraction',
+        image: hiRes(e.image),
+      }))
+    : [];
   // Priority: live events → tier1 events → trip_context events → explore_items fallback
   const allEvents = events.length > 0 ? events
     : tier1EventsMapped.length > 0 ? tier1EventsMapped
@@ -751,38 +742,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
       <div className="relative z-10">
         <div ref={revealRef}>
 
-          {/* ── Weather Widget — only show if hero doesn't already have weather from trip_context ── */}
-          {weatherData?.current && !trip?.trip_context?.weather?.current && (
-            <div className="px-0 mt-4 mb-2">
-              <div className="inline-flex items-center gap-4 px-5 py-3 rounded-2xl backdrop-blur-md bg-gray-100 dark:bg-white/[0.06] border border-gray-200 dark:border-white/[0.08]">
-                <div>
-                  <span className="text-3xl font-bold text-gray-900 dark:text-white">{Math.round(weatherData.current.temp)}°</span>
-                </div>
-                <div>
-                  <p className="text-[13px] font-semibold text-gray-900 dark:text-white">{weatherData.current.conditions}</p>
-                  <p className="text-[11px] text-gray-500 dark:text-gray-400">
-                    Feels like {Math.round(weatherData.current.feelslike)}° · {weatherData.current.humidity}% humidity
-                  </p>
-                </div>
-                {/* Mini forecast — next 3 days */}
-                {weatherData.forecast && weatherData.forecast.length > 0 && (
-                  <div className="flex gap-3 ml-2 pl-4 border-l border-gray-200 dark:border-white/[0.08]">
-                    {weatherData.forecast.slice(0, 3).map((day) => (
-                      <div key={day.date} className="text-center">
-                        <p className="text-[10px] text-gray-400 dark:text-gray-500">
-                          {new Date(day.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' })}
-                        </p>
-                        <p className="text-[12px] font-bold text-gray-900 dark:text-white">
-                          {Math.round(day.high)}°<span className="opacity-40">/{Math.round(day.low)}°</span>
-                        </p>
-                        <p className="text-[9px] text-gray-500 dark:text-gray-400 truncate max-w-[60px]">{day.conditions}</p>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
+          {/* Weather is now shown in the compact header toggle — removed duplicate widget */}
 
           {/* ── Row 1: Things to Do (left) + Restaurants (right) ── */}
           <div className="px-0 mt-6">
@@ -804,7 +764,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
               {hasRestaurants && (
                 <div className="shrink-0 w-full lg:w-[380px]">
                   <div className="mb-4">
-                    <h3 className="text-xl font-bold text-gray-900 dark:text-white">Must-Try Restaurants</h3>
+                    <h3 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white font-serif">Must-Try Restaurants</h3>
                   </div>
                   <div className="flex gap-2 overflow-x-auto scrollbar-hide snap-x snap-mandatory">
                     {restaurantData.slice(0, 6).map((r: any) => (
@@ -833,7 +793,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
                               {r.reviewCount && <span className="text-[10px] text-white/40">({r.reviewCount.toLocaleString()})</span>}
                             </div>
                           )}
-                          <h3 className="text-lg font-bold text-white leading-tight">{r.name}</h3>
+                          <h3 className="text-lg font-normal text-white leading-tight font-serif">{r.name}</h3>
                           {(r.tagline || r.address) && (
                             <p className="text-[11px] text-white/50 mt-1 line-clamp-1">{r.tagline || r.address}</p>
                           )}

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -724,7 +724,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
   const costData = trip?.trip_context?.cost_of_living ?? liveCostOfLiving;
   const hasNewsArticles = news.some(n => n.category === 'news' || n.category === 'advisory');
 
-  // Merge tier1Events into events display if available
+  // Merge tier1Events (from useEvents hook → TRA-436 aggregated API) into display
   const tier1EventsMapped = (tier1Events || []).map((e) => ({
     id: e.id,
     title: e.name,
@@ -732,12 +732,18 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
     category: e.category || 'Event',
     image: e.photo_url || '',
   }));
-  // Use: live events → tier1 events → trip_context.foursquare_venues (best photos) → trip_context events
-  const contextVenues = (trip?.trip_context?.foursquare_venues || []) as any[];
+  // Fallback: use explore_items as "What's Going On" when no real events exist
+  const exploreFallback = exploreItems.slice(0, 6).map((e: any) => ({
+    id: e.id || e.name,
+    title: e.title || e.name,
+    description: e.description || e.category || '',
+    category: e.category || 'Attraction',
+    image: hiRes(e.image),
+  }));
+  // Priority: live events → tier1 events → trip_context events → explore_items fallback
   const allEvents = events.length > 0 ? events
     : tier1EventsMapped.length > 0 ? tier1EventsMapped
-    : contextVenues.length > 0 ? contextVenues
-    : [];
+    : exploreFallback;
 
   return (
     <div className="relative overflow-hidden">

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -396,29 +396,30 @@ function PhrasesSection({ phrases, language }: { phrases: Record<string, string>
   const langCode = language ? langMap[language.toLowerCase()] || language.slice(0, 2).toLowerCase() : '';
 
   const speak = (text: string) => {
+    if (typeof window === 'undefined' || !window.speechSynthesis) return;
     setSpeaking(text);
-    // Use Google Translate TTS for natural-sounding pronunciation
-    const audio = new Audio(`https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=${langCode || 'ja'}&q=${encodeURIComponent(text)}`);
-    audio.onended = () => setSpeaking(null);
-    audio.onerror = () => {
-      // Fallback to browser TTS
-      if (typeof window !== 'undefined' && window.speechSynthesis) {
-        window.speechSynthesis.cancel();
-        const utterance = new SpeechSynthesisUtterance(text);
-        const voices = window.speechSynthesis.getVoices();
-        const match = voices.find(v => v.lang.toLowerCase().startsWith(langCode));
-        if (match) utterance.voice = match;
-        utterance.rate = 0.85;
-        utterance.onend = () => setSpeaking(null);
-        window.speechSynthesis.speak(utterance);
-      } else {
-        setSpeaking(null);
-      }
+    window.speechSynthesis.cancel();
+
+    const doSpeak = () => {
+      const utterance = new SpeechSynthesisUtterance(text);
+      const voices = window.speechSynthesis.getVoices();
+      const match = voices.find(v => v.lang.toLowerCase().startsWith(langCode))
+        || voices.find(v => v.lang.toLowerCase().includes(langCode));
+      if (match) utterance.voice = match;
+      utterance.rate = 0.85;
+      utterance.onend = () => setSpeaking(null);
+      utterance.onerror = () => setSpeaking(null);
+      window.speechSynthesis.speak(utterance);
     };
-    audio.play().catch(() => {
-      // If autoplay blocked, fall back to browser TTS
-      audio.onerror?.(new Event('error'));
-    });
+
+    // Voices load async — wait for them if needed
+    if (window.speechSynthesis.getVoices().length > 0) {
+      doSpeak();
+    } else {
+      window.speechSynthesis.onvoiceschanged = () => { doSpeak(); window.speechSynthesis.onvoiceschanged = null; };
+      // Fallback if event never fires
+      setTimeout(doSpeak, 200);
+    }
   };
 
   return (
@@ -468,8 +469,18 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
   const [addedItems, setAddedItems] = useState<Set<string>>(new Set());
   const [selectedPlace, setSelectedPlace] = useState<PlaceItem | null>(null);
   const [enriching, setEnriching] = useState(false);
+  const [isMagazine, setIsMagazine] = useState(false);
   const enrichAttempted = useRef(false);
   const revealRef = useRevealOnScroll(!!trip);
+
+  // Detect magazine layout for per-section glass card styling
+  useEffect(() => {
+    const check = () => setIsMagazine(localStorage.getItem('travyl-layout-mode') === 'magazine');
+    check();
+    window.addEventListener('layout-mode-change', check);
+    window.addEventListener('storage', check);
+    return () => { window.removeEventListener('layout-mode-change', check); window.removeEventListener('storage', check); };
+  }, []);
 
   // Auto-enrich: if trip exists but trip_context is incomplete, trigger enrichment and poll
   const autoEnrich = useCallback(async () => {
@@ -722,8 +733,8 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
   }));
   // Fallback: use explore_items that AREN'T already in "Things to Do" (which shows the first items)
   // Take from the back half of the list to avoid duplicates
-  const exploreFallback = exploreItems.length > 6
-    ? exploreItems.slice(-6).map((e: any) => ({
+  const exploreFallback = exploreItems.length > 2
+    ? exploreItems.slice(-Math.min(6, exploreItems.length)).map((e: any) => ({
         id: e.id || e.name,
         title: e.title || e.name,
         description: e.description || e.category || '',
@@ -736,6 +747,8 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
     : tier1EventsMapped.length > 0 ? tier1EventsMapped
     : exploreFallback;
 
+  const sectionCard = isMagazine ? 'bg-white/85 backdrop-blur-xl rounded-2xl p-5' : '';
+
   return (
     <div className="relative overflow-hidden">
       {/* Header image bleeds down naturally from TripMagazineHero — no separate background needed */}
@@ -745,7 +758,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
           {/* Weather is now shown in the compact header toggle — removed duplicate widget */}
 
           {/* ── Row 1: Things to Do (left) + Restaurants (right) ── */}
-          <div className="px-0 mt-6">
+          <div className={`mt-6 ${sectionCard}`}>
             <div className="flex flex-col lg:flex-row gap-6">
               {/* Things to Do — fills left column */}
               <div className="flex-1 min-w-0">
@@ -808,7 +821,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 2: News (left) + What's Going On (right) ── */}
           {(hasNewsArticles || allEvents.length > 0) && (
-            <div className="relative z-10 px-0 mt-8">
+            <div className={`relative z-10 mt-8 ${sectionCard}`}>
               <div className="flex flex-col lg:flex-row gap-6">
                 {hasNewsArticles && (
                   <div className="flex-1 min-w-0">
@@ -826,7 +839,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 3: Phrases + Cost of Living ── */}
           {(phrasesData || costData) && (
-            <div className="relative z-10 px-0 mt-8">
+            <div className={`relative z-10 mt-8 ${sectionCard}`}>
               <div className="flex flex-col lg:flex-row gap-6 items-start">
                 {phrasesData && Object.keys(phrasesData).length > 0 && (
                   <div className="flex-1 min-w-0">
@@ -844,7 +857,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
 
           {/* ── Row 4: Nearby Cities ── */}
           {trip?.trip_context?.nearby_cities && trip.trip_context.nearby_cities.length > 0 && (
-            <div className="px-0 mt-8">
+            <div className={`mt-8 ${sectionCard}`}>
               <NearbyCitiesSection cities={trip.trip_context.nearby_cities} />
             </div>
           )}

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, Suspense } from 'react';
+import { useState, useRef, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'motion/react';
 import { MapPin, Map, X } from 'lucide-react';
@@ -15,6 +15,7 @@ import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
 import { PlaceDetailModal } from '@/components/trip/PlaceDetailModal';
 import { TripOnboardingBanner } from '@/components/trip/TripOnboardingBanner';
 import { useTripSettingsRegistration } from '@/stores/tripSettingsStore';
+import { useQuery } from '@tanstack/react-query';
 import type { PlaceItem } from '@travyl/shared';
 
 const LeafletMap = dynamic(() => import('@/components/leaflet-map'), { ssr: false });
@@ -57,46 +58,139 @@ function ContentHeader({ tripId, mapOpen, onToggleMap }: {
 
 // ─── Trip Explore Section (overview page — shows trip_context data) ──
 
-export function TripExploreSection({ trip }: { trip: Trip | null }) {
-  const city = trip?.destination?.split(',')[0]?.trim() || 'Destination';
-  const ctx = trip?.trip_context;
+export function TripExploreSection({ trip, embedded }: { trip: Trip | null; embedded?: boolean }) {
+  const city = trip?.destination?.split(',')[0]?.trim() || '';
+  const lat = trip?.trip_context?.lat as number | undefined;
+  const lng = trip?.trip_context?.lng as number | undefined;
   const [selectedPlace, setSelectedPlace] = useState<PlaceItem | null>(null);
   const [favorites, setFavorites] = useState<string[]>([]);
+  const [extraItems, setExtraItems] = useState<Record<string, ExploreItem[]>>({});
+  const [loadingMore, setLoadingMore] = useState<Record<string, boolean>>({});
+  const loadingRef = useRef<Record<string, boolean>>({});
+  const [brokenImages, setBrokenImages] = useState<Set<string>>(new Set());
 
-  type ExploreItem = { id: string; title?: string; name?: string; description?: string; category?: string; image?: string; images?: string[]; rating?: number; cuisines?: string[]; priceLevel?: string; tripAdvisorUrl?: string; lat?: number; lng?: number; address?: string; phone?: string; website?: string; reviewCount?: number };
-
-  // Collect ALL items from every source
-  const allItems: ExploreItem[] = [];
-  const seen = new Set<string>();
-  const addItems = (items: any[], fallbackCategory?: string) => {
-    for (const item of items) {
-      const key = item.id || item.title || item.name;
-      if (!key || seen.has(key) || !item.image) continue;
-      seen.add(key);
-      allItems.push({ ...item, title: item.title || item.name, image: upscaleGoogleImage(item.image) || item.image, category: item.category || fallbackCategory || 'Attraction' });
-    }
+  // Strip items with no real image URL or known broken ones
+  const hasValidImage = (item: ExploreItem) => {
+    const url = item.image;
+    if (!url || url.length < 10) return false;
+    if (brokenImages.has(item.id)) return false;
+    return true;
   };
-  addItems(ctx?.explore_items || []);
-  addItems(ctx?.foursquare_venues || []);
-  if (ctx?.restaurants?.length) addItems(ctx.restaurants, 'Restaurant');
-  for (const e of (ctx?.events || []) as any[]) {
-    const key = e.id || e.title || e.name;
-    if (!key || seen.has(key) || !(e.image || e.photo_url)) continue;
-    seen.add(key);
-    allItems.push({ id: e.id, title: e.title || e.name, name: e.title || e.name, description: `${e.date ? new Date(e.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : ''} ${e.venue ? '· ' + e.venue : ''}`.trim() || e.description || '', category: e.category || 'Event', image: e.image || e.photo_url });
-  }
+  const onImgError = (id: string) => {
+    setBrokenImages(prev => new Set(prev).add(id));
+  };
 
-  // Group by category dynamically
-  const grouped: Record<string, ExploreItem[]> = {};
-  for (const item of allItems) {
-    const cat = item.category || 'Other';
-    if (!grouped[cat]) grouped[cat] = [];
-    grouped[cat].push(item);
-  }
-  const toLabel = (cat: string) => cat.replace(/[_-]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-  const categories = Object.entries(grouped).filter(([, items]) => items.length > 0).map(([key, items]) => ({ key, label: toLabel(key), items }));
+  type ExploreItem = { id: string; title?: string; name?: string; description?: string; category?: string; image?: string; images?: string[]; rating?: number; lat?: number; lng?: number; address?: string; phone?: string; website?: string; reviewCount?: number; priceLevel?: string; cuisines?: string[] };
 
-  if (categories.length === 0) return null;
+  const coordParams = lat && lng ? `&lat=${lat}&lng=${lng}` : '';
+
+  const mapPlace = (p: any): ExploreItem => ({
+    id: p.id, title: p.name, name: p.name,
+    description: p.description || p.tagline || '',
+    category: p.category || '',
+    image: upscaleGoogleImage(p.images?.[0] || p.image) || p.image || '',
+    images: p.images, rating: p.rating,
+    lat: p.latitude, lng: p.longitude,
+    address: p.address, phone: p.phone, website: p.website,
+    reviewCount: p.reviewCount, priceLevel: p.priceLevel,
+  });
+
+  // Fetch places across all categories the API supports — uses lat/lng + category param
+  const { data: liveCategories, isLoading: liveFetching } = useQuery({
+    queryKey: ['explore-section', trip?.id, city, lat, lng],
+    queryFn: async () => {
+      if (!city && !lat) return [];
+      // First: discover available categories by fetching with text query
+      const discoveryRes = await fetch(`/api/places?q=${encodeURIComponent(city)}&limit=30${coordParams}`);
+      const discoveryPlaces: any[] = discoveryRes.ok ? await discoveryRes.json() : [];
+
+      // Extract unique category params from what came back, plus use nearby endpoint
+      const seenCats = new Set(discoveryPlaces.map((p: any) => p.type || '').filter(Boolean));
+      // Also fetch from the nearby endpoint which returns different (Foursquare) results
+      const nearbyCats = lat && lng ? ['sightseeing', 'restaurant', 'nightlife', 'shopping', 'park', 'museum'] : [];
+      const nearbyResults = await Promise.all(
+        nearbyCats.map(async (cat) => {
+          try {
+            const res = await fetch(`/api/places?lat=${lat}&lng=${lng}&category=${cat}&limit=15`);
+            if (!res.ok) return [];
+            return res.json();
+          } catch { return []; }
+        })
+      );
+
+      // Merge all results, deduplicate by name, group by display category
+      const allPlaces = [...discoveryPlaces, ...nearbyResults.flat()];
+      const seen = new Set<string>();
+      const grouped: Record<string, ExploreItem[]> = {};
+      for (const p of allPlaces) {
+        if (!p.name || seen.has(p.name)) continue;
+        const img = p.images?.[0] || p.image;
+        if (!img) continue;
+        seen.add(p.name);
+        const cat = p.category || 'Other';
+        if (!grouped[cat]) grouped[cat] = [];
+        grouped[cat].push(mapPlace(p));
+      }
+
+      return Object.entries(grouped)
+        .filter(([, items]) => items.length >= 3)
+        .map(([key, items]) => ({ key, label: `${key} in ${city}`, items }));
+    },
+    enabled: !!(city || lat),
+    staleTime: 10 * 60 * 1000,
+  });
+
+  // Load more — text search to get SerpAPI results (different source than initial nearby/Foursquare)
+  const loadMore = useCallback(async (catKey: string, existingNames: Set<string>) => {
+    if (loadingRef.current[catKey]) return;
+    loadingRef.current[catKey] = true;
+    setLoadingMore(prev => ({ ...prev, [catKey]: true }));
+    try {
+      const url = `/api/places?q=${encodeURIComponent(`${city} ${catKey}`)}&limit=20${coordParams}`;
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const places: any[] = await res.json();
+      const newItems: ExploreItem[] = places
+        .filter((p: any) => p.name && (p.images?.[0] || p.image) && !existingNames.has(p.name))
+        .map((p: any) => mapPlace(p));
+      if (newItems.length > 0) {
+        setExtraItems(prev => ({ ...prev, [catKey]: [...(prev[catKey] || []), ...newItems] }));
+      }
+    } catch { /* ignore */ } finally {
+      loadingRef.current[catKey] = false;
+      setLoadingMore(prev => ({ ...prev, [catKey]: false }));
+    }
+  }, [city, coordParams]);
+
+  const handleRowScroll = useCallback((e: React.UIEvent<HTMLDivElement>, catKey: string, allNames: Set<string>) => {
+    const el = e.currentTarget;
+    if (el.scrollLeft + el.clientWidth >= el.scrollWidth - 400) {
+      loadMore(catKey, allNames);
+    }
+  }, [loadMore]);
+
+  // Fallback: trip_context data while live data loads
+  const ctx = trip?.trip_context;
+  const fallbackCategories = (() => {
+    if (liveCategories && liveCategories.length > 0) return null;
+    const allItems: ExploreItem[] = [];
+    const seen = new Set<string>();
+    const add = (items: any[], fallbackCat?: string) => {
+      for (const item of items) {
+        const key = item.id || item.title || item.name;
+        if (!key || seen.has(key) || !item.image) continue;
+        seen.add(key);
+        allItems.push({ ...item, title: item.title || item.name, image: upscaleGoogleImage(item.image) || item.image, category: item.category || fallbackCat || 'Attraction' });
+      }
+    };
+    add(ctx?.explore_items || []);
+    add(ctx?.foursquare_venues || []);
+    if (ctx?.restaurants?.length) add(ctx.restaurants as any[], 'Restaurant');
+    if (!allItems.length) return null;
+    return [{ key: 'all', label: `Explore ${city}`, items: allItems }];
+  })();
+
+  const categories = liveCategories ?? fallbackCategories ?? [];
 
   const toPlaceItem = (item: ExploreItem): PlaceItem => ({
     id: item.id, name: item.title || item.name || '', image: item.image || '',
@@ -105,34 +199,57 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
     rating: item.rating || 0, tagline: item.description || item.category || '',
     category: item.category || '', description: item.description || '',
     tags: item.cuisines || (item.category ? [item.category] : []),
-    latitude: item.lat || (trip?.trip_context?.lat ?? undefined),
-    longitude: item.lng || (trip?.trip_context?.lng ?? undefined),
-    address: item.address, phone: item.phone, website: item.website || item.tripAdvisorUrl,
+    latitude: item.lat || lat, longitude: item.lng || lng,
+    address: item.address, phone: item.phone, website: item.website,
     reviewCount: item.reviewCount,
     priceLevel: item.priceLevel === '$' ? 1 : item.priceLevel === '$$' ? 2 : item.priceLevel === '$$$' ? 3 : item.priceLevel === '$$$$' ? 4 : undefined,
   });
 
+  if (categories.length === 0 && !liveFetching) return null;
+
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:pl-[100px] py-8">
-      <h2 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white mb-6 font-serif">
-        Explore {city}
+    <div className={embedded ? 'py-2' : 'max-w-7xl mx-auto px-4 sm:px-6 md:pl-[100px] py-8'}>
+      <h2 className={`text-xl font-normal tracking-wide mb-6 font-serif ${embedded ? 'text-white' : 'text-gray-900 dark:text-white'}`}
+        style={embedded ? { textShadow: '0 2px 10px rgba(0,0,0,0.5)' } : undefined}>
+        Explore {city || 'Destination'}
       </h2>
 
+      {liveFetching && categories.length === 0 && (
+        <div className="space-y-6">
+          {[1, 2, 3].map(i => (
+            <div key={i}>
+              <div className={`h-4 w-48 rounded mb-3 animate-pulse ${embedded ? 'bg-white/10' : 'bg-gray-200'}`} />
+              <div className="flex gap-3">
+                {[1, 2, 3, 4].map(j => (
+                  <div key={j} className={`flex-shrink-0 w-[220px] rounded-2xl animate-pulse ${embedded ? 'bg-white/10' : 'bg-gray-100'}`} style={{ height: 280 }} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="space-y-6">
-        {categories.map(({ key, label, items }) => (
+        {categories.map(({ key, label, items }) => {
+          const merged = [...items, ...(extraItems[key] || [])].filter(hasValidImage);
+          const nameSet = new Set(merged.map(i => (i.title || i.name || '')));
+          const totalCount = merged.length;
+          if (totalCount === 0) return null;
+          return (
           <div key={key}>
             <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 tracking-wide">
+              <h3 className={`text-sm font-semibold tracking-wide ${embedded ? 'text-white/80' : 'text-gray-700 dark:text-gray-300'}`}>
                 {label}
               </h3>
-              <span className="text-[11px] text-gray-400 dark:text-gray-500">{items.length} {items.length === 1 ? 'place' : 'places'}</span>
+              <span className={`text-[11px] ${embedded ? 'text-white/40' : 'text-gray-400 dark:text-gray-500'}`}>{totalCount} {totalCount === 1 ? 'place' : 'places'}</span>
             </div>
-            <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2 -mx-1 px-1">
-              {items.map((item: ExploreItem, idx: number) => (
+            <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2 -mx-1 px-1"
+              onScroll={(e) => handleRowScroll(e, key, nameSet)}>
+              {merged.map((item: ExploreItem, idx: number) => (
                 <div key={`${item.id}-${idx}`} onClick={() => setSelectedPlace(toPlaceItem(item))}
                   className="relative flex-shrink-0 w-[220px] rounded-2xl overflow-hidden shadow-lg group cursor-pointer hover:shadow-xl transition-shadow" style={{ height: 280 }}>
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={item.image!} alt={item.title || item.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+                  <img src={item.image!} alt={item.title || item.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" onError={() => onImgError(item.id)} />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                   <button onClick={(e) => { e.stopPropagation(); setFavorites((prev) => prev.includes(item.id) ? prev.filter((f) => f !== item.id) : [...prev, item.id]); }}
                     className={`absolute top-2.5 right-2.5 w-8 h-8 rounded-full backdrop-blur-sm flex items-center justify-center shadow-sm hover:scale-110 transition-transform z-10 ${favorites.includes(item.id) ? 'bg-red-500' : 'bg-black/30'}`}>
@@ -150,9 +267,15 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
                   </div>
                 </div>
               ))}
+              {loadingMore[key] && (
+                <div className="flex-shrink-0 w-[220px] rounded-2xl flex items-center justify-center" style={{ height: 280 }}>
+                  <div className={`w-6 h-6 border-2 rounded-full animate-spin ${embedded ? 'border-white/20 border-t-white/60' : 'border-gray-200 border-t-gray-500'}`} />
+                </div>
+              )}
             </div>
           </div>
-        ))}
+          );
+        })}
       </div>
       {selectedPlace && (
         <PlaceDetailModal place={selectedPlace} isFavorited={favorites.includes(selectedPlace.id)}
@@ -240,6 +363,7 @@ function TripLayoutContent({
     const next = layoutMode === 'magazine' ? 'compact' : 'magazine';
     setLayoutMode(next);
     localStorage.setItem('travyl-layout-mode', next);
+    window.dispatchEvent(new Event('layout-mode-change'));
   };
   const isMagazine = layoutMode === 'magazine';
 
@@ -371,8 +495,8 @@ function TripLayoutContent({
       )}
 
       {/* Content area */}
-      <div className="mx-auto max-w-7xl">
-        <div className="relative z-10">
+      <div className="relative z-10">
+        <div className={isMagazine ? '' : 'mx-auto max-w-7xl'}>
           {!isMagazine && (
             <ContentHeader
               tripId={tripId}
@@ -385,7 +509,7 @@ function TripLayoutContent({
 
           <div className="flex">
             {/* Main content */}
-            <div className={`flex-1 min-w-0 relative overflow-hidden ${isMagazine ? 'md:pl-20' : 'px-5 md:pl-[100px] pt-4 pb-5'}`}>
+            <div className={`flex-1 min-w-0 relative overflow-hidden ${isMagazine ? 'px-6 sm:px-10 md:pl-[120px] md:pr-10' : 'px-5 md:pl-[100px] pt-4 pb-5'}`}>
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.div
                   key={`tab-${currentSegment}`}
@@ -393,8 +517,8 @@ function TripLayoutContent({
                   animate={pageVariants.animate}
                   exit={pageVariants.exit}
                   transition={{ duration: 0.18, ease: 'easeOut' }}
-                  className={isMagazine && !isOverview && currentSegment !== 'itinerary' ? 'px-4 sm:px-6 pt-2 pb-8 mb-8 rounded-2xl backdrop-blur-md' : ''}
-                  style={isMagazine && !isOverview && currentSegment !== 'itinerary' ? { background: 'linear-gradient(to bottom, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0.95) 60px, rgba(255,255,255,0.98) 100%)' } : undefined}
+                  className={isMagazine && isOverview ? 'pt-2' : ''}
+                  style={undefined}
                 >
                   {children}
                 </motion.div>
@@ -468,16 +592,28 @@ function TripLayoutContent({
         </div>
       </div>
 
-      {/* Bottom photo mosaic — overview only */}
-      {isOverview && (destImageData?.images?.length ?? 0) > 0 && (
-        <TripPhotoMosaic photos={destImageData!.images} destination={trip?.destination} />
+      {/* Below-the-fold content */}
+      {isOverview && (
+        <div className="relative z-10">
+          {!isMagazine && (destImageData?.images?.length ?? 0) > 0 && (
+            <TripPhotoMosaic photos={destImageData!.images} destination={trip?.destination} />
+          )}
+          {isMagazine ? (
+            <div className="px-6 sm:px-10 md:pl-[120px] md:pr-10 mt-4 pb-8">
+              <TripExploreSection trip={trip} embedded />
+            </div>
+          ) : (
+            <div className="bg-white dark:bg-[var(--background)]">
+              <TripExploreSection trip={trip} />
+            </div>
+          )}
+        </div>
       )}
 
-      {/* Explore section — overview only */}
-      {isOverview && (
-        <div className="w-full relative z-10 bg-white dark:bg-[var(--background)]">
-          <TripExploreSection trip={trip} />
-        </div>
+      {/* Magazine footer — gradient floor so the page has a defined end */}
+      {isMagazine && (
+        <div className="relative z-10 h-40 pointer-events-none"
+          style={{ background: 'linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 50%, rgba(0,0,0,0.85) 100%)' }} />
       )}
     </div>
   );

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -35,17 +35,17 @@ function ContentHeader({ tripId, mapOpen, onToggleMap }: {
   const Icon = tab.icon;
 
   return (
-    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-16 pt-4 pb-3 sticky top-0 z-20">
+    <div className="shrink-0 border-b bg-white dark:bg-[var(--background)] border-gray-100 dark:border-white/[0.06] px-5 md:pl-[100px] pt-4 pb-3 sticky top-12 z-20">
       <div className="flex items-center gap-3">
-        <div className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm shrink-0 backdrop-blur-md" style={{ backgroundColor: `${tab.color}cc` }}>
-          <Icon size={15} className="text-white" />
+        <div className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm shrink-0" style={{ backgroundColor: `${tab.color}18`, color: tab.color }}>
+          <Icon size={15} />
         </div>
         <div className="flex-1">
-          <h2 className="text-[17px] tracking-tight text-white font-bold" style={{ textShadow: '0 2px 8px rgba(0,0,0,0.4)' }}>{tab.label}</h2>
-          <p className="text-[12px] text-white/60" style={{ textShadow: '0 1px 4px rgba(0,0,0,0.3)' }}>{tab.subtitle}</p>
+          <h2 className="text-[17px] tracking-wide font-normal text-gray-900 dark:text-white font-serif">{tab.label}</h2>
+          <p className="text-[12px] text-gray-500 dark:text-gray-400">{tab.subtitle}</p>
         </div>
         <div className="flex items-center gap-1.5">
-          <button onClick={onToggleMap} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border backdrop-blur-md transition-all duration-200 ${mapOpen ? 'text-white shadow-md' : 'border-white/30 hover:bg-white/20 text-white'}`} style={mapOpen ? { borderColor: 'var(--trip-base)', backgroundColor: 'var(--trip-base)' } : undefined} title={mapOpen ? 'Hide map' : 'Show map'}>
+          <button onClick={onToggleMap} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border transition-all duration-200 ${mapOpen ? 'text-white shadow-md' : 'border-gray-200 dark:border-white/[0.12] hover:bg-gray-50 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300'}`} style={mapOpen ? { borderColor: 'var(--trip-base)', backgroundColor: 'var(--trip-base)' } : undefined} title={mapOpen ? 'Hide map' : 'Show map'}>
             <Map size={13} />
             <span className="text-[12px] font-medium">Map</span>
           </button>
@@ -113,8 +113,8 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
   });
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:pl-16 py-8">
-      <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-6">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:pl-[100px] py-8">
+      <h2 className="text-xl font-normal tracking-wide text-gray-900 dark:text-white mb-6 font-serif">
         Explore {city}
       </h2>
 
@@ -140,7 +140,7 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
                   </button>
                   <div className="absolute bottom-0 left-0 right-0 p-3.5">
                     <p className="text-[10px] uppercase tracking-wider font-semibold text-white/50 mb-1">{item.category}</p>
-                    <p className="text-[15px] font-bold text-white leading-tight line-clamp-2 mb-1">{item.title || item.name}</p>
+                    <p className="text-[15px] font-normal text-white leading-tight line-clamp-2 mb-1 font-serif">{item.title || item.name}</p>
                     {item.rating ? (
                       <div className="flex items-center gap-1">
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="#fbbf24" stroke="#fbbf24" strokeWidth="1"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>
@@ -385,7 +385,7 @@ function TripLayoutContent({
 
           <div className="flex">
             {/* Main content */}
-            <div className={`flex-1 min-w-0 relative overflow-hidden ${isMagazine ? 'md:pl-20' : 'px-5 md:pl-16 pt-4 pb-5'}`}>
+            <div className={`flex-1 min-w-0 relative overflow-hidden ${isMagazine ? 'md:pl-20' : 'px-5 md:pl-[100px] pt-4 pb-5'}`}>
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.div
                   key={`tab-${currentSegment}`}

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -7,11 +7,11 @@ import { MapPin, Map, X } from 'lucide-react';
 import type { Trip } from '@travyl/shared';
 import { usePathname, useRouter } from 'next/navigation';
 import TripTabs, { getTabMeta } from '@/components/trip-tabs';
-import { useItineraryScreen, useAuthStore, canViewTrip } from '@travyl/shared';
-// Footer/OceanWave removed — trip pages use workspace layout
+import { useItineraryScreen, useAuthStore, canViewTrip, useDestinationImage, upscaleGoogleImage } from '@travyl/shared';
 import { ItineraryProvider, useItineraryContext } from '@/components/itinerary/ItineraryContext';
 import { TripThemeProvider } from '@/components/trip/TripThemeContext';
 import { CompactTripHeader } from '@/components/trip/CompactTripHeader';
+import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
 import { PlaceDetailModal } from '@/components/trip/PlaceDetailModal';
 import { TripOnboardingBanner } from '@/components/trip/TripOnboardingBanner';
 import { useTripSettingsRegistration } from '@/stores/tripSettingsStore';
@@ -73,7 +73,7 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
       const key = item.id || item.title || item.name;
       if (!key || seen.has(key) || !item.image) continue;
       seen.add(key);
-      allItems.push({ ...item, title: item.title || item.name, category: item.category || fallbackCategory || 'Attraction' });
+      allItems.push({ ...item, title: item.title || item.name, image: upscaleGoogleImage(item.image) || item.image, category: item.category || fallbackCategory || 'Attraction' });
     }
   };
   addItems(ctx?.explore_items || []);
@@ -163,6 +163,40 @@ export function TripExploreSection({ trip }: { trip: Trip | null }) {
   );
 }
 
+// ─── Bottom Photo Mosaic (full-bleed, auto-rotating) ───
+
+function TripPhotoMosaic({ photos, destination }: { photos: string[]; destination?: string }) {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    setCurrent(0);
+    if (photos.length <= 1) return;
+    const interval = setInterval(() => {
+      setCurrent((c) => (c + 1) % photos.length);
+    }, 6000);
+    return () => clearInterval(interval);
+  }, [photos]);
+
+  return (
+    <div className="w-full relative overflow-hidden" style={{ height: 600 }}>
+      {photos.map((src, i) => (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          key={i}
+          src={src}
+          alt={destination || 'Trip photo'}
+          className="absolute inset-0 w-full h-full object-cover transition-opacity duration-[2000ms]"
+          style={{ opacity: i === current ? 1 : 0, objectPosition: 'center 40%' }}
+        />
+      ))}
+      <div className="absolute bottom-0 left-0 right-0 pointer-events-none" style={{
+        height: '25%',
+        background: 'linear-gradient(to top, white 0%, transparent 100%)',
+      }} />
+    </div>
+  );
+}
+
 // ─── Main Layout ────────────────────────────────────────────
 
 export default function TripLayoutInner({
@@ -195,6 +229,23 @@ function TripLayoutContent({
   const user = useAuthStore((s) => s.user);
   const router = useRouter();
   useTripSettingsRegistration(tripId);
+
+  // Layout mode toggle — persisted in localStorage
+  const [layoutMode, setLayoutMode] = useState<'magazine' | 'compact'>('compact');
+  useEffect(() => {
+    const saved = localStorage.getItem('travyl-layout-mode');
+    if (saved === 'magazine' || saved === 'compact') setLayoutMode(saved);
+  }, []);
+  const toggleLayout = () => {
+    const next = layoutMode === 'magazine' ? 'compact' : 'magazine';
+    setLayoutMode(next);
+    localStorage.setItem('travyl-layout-mode', next);
+  };
+  const isMagazine = layoutMode === 'magazine';
+
+  // Destination image for magazine hero
+  const city = trip?.destination?.split(',')[0]?.trim();
+  const { data: destImageData, isLoading: destImageLoading } = useDestinationImage(city || '');
 
   // Redirect to login if the trip has loaded and the user can't view it
   useEffect(() => {
@@ -277,28 +328,64 @@ function TripLayoutContent({
     );
   }
 
-  return (
-    <div className="pb-14 md:pb-0 bg-white dark:bg-[var(--background)]">
-      {/* Sidebar — always icon-only spine on desktop, bottom bar on mobile */}
-      <TripTabs tripId={tripId} position="left" />
+  // Layout toggle button (floating, bottom-right)
+  const layoutToggle = (
+    <button
+      onClick={toggleLayout}
+      className="fixed bottom-20 md:bottom-6 right-4 z-50 flex items-center gap-2 px-3 py-2 rounded-full shadow-lg border text-xs font-medium transition-all hover:scale-105"
+      style={{
+        backgroundColor: isMagazine ? 'rgba(30,58,95,0.9)' : 'rgba(255,255,255,0.95)',
+        borderColor: isMagazine ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.1)',
+        color: isMagazine ? 'white' : '#1e3a5f',
+        backdropFilter: 'blur(12px)',
+      }}
+      title={`Switch to ${isMagazine ? 'compact' : 'magazine'} layout`}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        {isMagazine ? (
+          <><rect x="3" y="3" width="18" height="18" rx="2" /><line x1="3" y1="9" x2="21" y2="9" /><line x1="9" y1="21" x2="9" y2="9" /></>
+        ) : (
+          <><rect x="2" y="2" width="20" height="20" rx="2" /><line x1="2" y1="10" x2="22" y2="10" /></>
+        )}
+      </svg>
+      {isMagazine ? 'Compact' : 'Magazine'}
+    </button>
+  );
 
-      {/* Compact trip header — all tabs */}
-      <CompactTripHeader tripId={tripId} trip={trip} onTripUpdate={refetch} />
+  return (
+    <div
+      className={`pb-14 md:pb-0 ${isMagazine ? 'relative' : 'bg-white dark:bg-[var(--background)]'}`}
+      style={{ transition: 'background-color 0.3s ease' }}
+    >
+      {layoutToggle}
+
+      {/* Sidebar */}
+      <TripTabs tripId={tripId} position="left" dark={isMagazine} />
+
+      {/* Header — magazine hero or compact */}
+      {isMagazine ? (
+        <TripMagazineHero tripId={tripId} trip={trip} compact={!isOverview} onTripUpdate={refetch}
+          overrideImage={destImageData?.url ?? undefined} suppressFallback={destImageLoading} />
+      ) : (
+        <CompactTripHeader tripId={tripId} trip={trip} onTripUpdate={refetch} overrideImage={destImageData?.url ?? undefined} />
+      )}
 
       {/* Content area */}
       <div className="mx-auto max-w-7xl">
         <div className="relative z-10">
-          <ContentHeader
-            tripId={tripId}
-            mapOpen={mapOpen}
-            onToggleMap={() => setMapOpen(!mapOpen)}
-          />
+          {!isMagazine && (
+            <ContentHeader
+              tripId={tripId}
+              mapOpen={mapOpen}
+              onToggleMap={() => setMapOpen(!mapOpen)}
+            />
+          )}
 
           {isOverview && <TripOnboardingBanner />}
 
           <div className="flex">
             {/* Main content */}
-            <div className="flex-1 min-w-0 relative overflow-hidden px-5 md:pl-16 pt-4 pb-5">
+            <div className={`flex-1 min-w-0 relative overflow-hidden ${isMagazine ? 'md:pl-20' : 'px-5 md:pl-16 pt-4 pb-5'}`}>
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.div
                   key={`tab-${currentSegment}`}
@@ -306,6 +393,8 @@ function TripLayoutContent({
                   animate={pageVariants.animate}
                   exit={pageVariants.exit}
                   transition={{ duration: 0.18, ease: 'easeOut' }}
+                  className={isMagazine && !isOverview && currentSegment !== 'itinerary' ? 'px-4 sm:px-6 pt-2 pb-8 mb-8 rounded-2xl backdrop-blur-md' : ''}
+                  style={isMagazine && !isOverview && currentSegment !== 'itinerary' ? { background: 'linear-gradient(to bottom, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0.95) 60px, rgba(255,255,255,0.98) 100%)' } : undefined}
                 >
                   {children}
                 </motion.div>
@@ -378,6 +467,11 @@ function TripLayoutContent({
           </div>
         </div>
       </div>
+
+      {/* Bottom photo mosaic — overview only */}
+      {isOverview && (destImageData?.images?.length ?? 0) > 0 && (
+        <TripPhotoMosaic photos={destImageData!.images} destination={trip?.destination} />
+      )}
 
       {/* Explore section — overview only */}
       {isOverview && (

--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import {
   BackendPlace,
   mapBackendToPlaceItem,
+  isValidImageUrl,
 } from '@travyl/shared'
 import { filterByRadius } from '@/lib/haversine'
 
@@ -76,9 +77,11 @@ export async function GET(req: NextRequest) {
     const searchLng = parseFloat(lng)
     data = filterByRadius(data, searchLat, searchLng, 50)
 
-    // Map to PlaceItem format using the canonical shared mapper
+    // Map to PlaceItem format using the canonical shared mapper — strip items with no valid image
     const requestedCat = category
-    const places = data.map((p, idx) => mapBackendToPlaceItem(p, idx, requestedCat))
+    const places = data
+      .map((p, idx) => mapBackendToPlaceItem(p, idx, requestedCat))
+      .filter(p => isValidImageUrl(p.image))
 
     const res_out = NextResponse.json(places)
     // Cache for 1 hour, revalidate in background for 24h

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -107,7 +107,6 @@ export function CompactTripHeader({
             src={coverImage}
             alt={destination || ''}
             fill
-            referrerPolicy="no-referrer"
             className="object-cover"
             style={{ objectPosition: 'center center' }}
             sizes="100vw"
@@ -207,8 +206,8 @@ export function CompactTripHeader({
       </div>
 
       {/* Expanded details — dropdown below header */}
-      {expanded && (
-        <div className="relative z-20 px-6 sm:px-10 md:pl-[100px] py-4">
+      {hasExpandContent && (
+        <div className={`relative z-20 px-6 sm:px-10 md:pl-[100px] overflow-hidden transition-all duration-300 ease-out ${expanded ? 'max-h-[400px] opacity-100 py-4' : 'max-h-0 opacity-0'}`}>
           <div className="max-w-3xl flex flex-col gap-2.5">
             {/* Forecast row */}
             {forecast && forecast.length > 0 && !isNaN(forecast[0]?.high) && (

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useCallback } from 'react';
 import Image from 'next/image';
-import { Pencil, X, Check, Calendar, Users } from 'lucide-react';
-import { formatDateRange, updateTripDetails } from '@travyl/shared';
+import { Pencil, X, Check, Calendar, Users, ChevronDown } from 'lucide-react';
+import { formatDateRange, updateTripDetails, useWeather } from '@travyl/shared';
 import type { Trip } from '@travyl/shared';
 
 export function CompactTripHeader({
@@ -23,6 +23,7 @@ export function CompactTripHeader({
   const [editEnd, setEditEnd] = useState('');
   const [editTravelers, setEditTravelers] = useState(1);
   const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   // Best available image — Unsplash override first, then hero_images, then hero_image_url
   const heroImages = trip?.trip_context?.hero_images as string[] | undefined;
@@ -41,18 +42,22 @@ export function CompactTripHeader({
   const countryCca2 = trip?.trip_context?.country?.cca2 as string | undefined;
   const flagUrl = countryFlag || (countryCca2 ? `https://flagcdn.com/24x18/${countryCca2.toLowerCase()}.png` : null);
 
-  // Quick info from trip_context
+  // Quick info — prefer live weather, fall back to trip_context
   const ctx = trip?.trip_context as Record<string, any> | undefined;
-  const weather = ctx?.weather?.current;
+  const { data: liveWeather } = useWeather(cityName || '');
+  const weather = liveWeather?.current || ctx?.weather?.current;
   const safety = ctx?.safety;
   const tz = ctx?.country?.timezone;
   const aqi = ctx?.aqi?.aqi;
   const aqiLevel = ctx?.aqi?.level;
   const currency = ctx?.country?.currency;
   const nextHoliday = (ctx?.holidays as { name: string; date: string }[] | undefined)?.[0];
+  const forecast = (liveWeather?.forecast || ctx?.weather?.forecast) as { date: string; high: number; low: number; conditions: string }[] | undefined;
+  const wiki = ctx?.wiki?.extract as string | undefined;
 
   const infoPills: { label: string; color?: string }[] = [];
-  if (weather?.temp_f) infoPills.push({ label: `${Math.round(weather.temp_f)}°F ${weather.conditions || weather.condition || ''}`.trim() });
+  const temp = weather?.temp_f ?? weather?.temp;
+  if (temp != null) infoPills.push({ label: `${Math.round(temp)}°${weather?.temp_f ? 'F' : ''} ${weather?.conditions || weather?.condition || ''}`.trim() });
   else if (weather?.conditions) infoPills.push({ label: weather.conditions });
   if (currency) infoPills.push({ label: `${currency.symbol} ${currency.code}` });
   if (tz) infoPills.push({ label: tz });
@@ -90,105 +95,146 @@ export function CompactTripHeader({
     }
   }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
 
+  const hasExpandContent = !!(forecast?.length || wiki);
+
   return (
-    <div className="relative w-full overflow-hidden" style={{ height: 260 }}>
-      {/* Background image */}
-      {coverImage ? (
-        <Image
-          src={coverImage}
-          alt={destination || ''}
-          fill
-          referrerPolicy="no-referrer"
-          className="object-cover"
-          style={{ objectPosition: 'center 35%' }}
-          sizes="100vw"
-          priority
-        />
-      ) : (
-        <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
-      )}
+    <div className="relative w-full">
+      {/* Fixed-height hero */}
+      <div className="relative w-full overflow-hidden" style={{ height: 300 }}>
+        {/* Background image */}
+        {coverImage ? (
+          <Image
+            src={coverImage}
+            alt={destination || ''}
+            fill
+            referrerPolicy="no-referrer"
+            className="object-cover"
+            style={{ objectPosition: 'center center' }}
+            sizes="100vw"
+            priority
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-br from-gray-700 to-gray-900" />
+        )}
 
-      {/* Gradient overlay */}
-      <div className="absolute inset-0" style={{
-        background: 'linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.3) 40%, rgba(0,0,0,0.75) 100%)',
-      }} />
+        {/* Gradient overlay */}
+        <div className="absolute inset-0" style={{
+          background: 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.15) 40%, rgba(0,0,0,0.7) 85%, rgba(0,0,0,0.8) 100%)',
+        }} />
 
-      {/* Content */}
-      <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pb-5">
-        {/* Country tag */}
-        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5 text-white/70">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px] shadow-sm" />}
-          <span>{countryName || ''}</span>
-        </p>
+        {/* Content */}
+        <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-[100px] pb-5">
+          {/* Country tag */}
+          <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5 text-white/70">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px] shadow-sm" />}
+            <span>{countryName || ''}</span>
+          </p>
 
-        {/* Title */}
-        <h1 className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif tracking-tight">
-          {cityName || trip?.title || 'Untitled Trip'}
-        </h1>
-
-        {/* Meta row */}
-        {!editing && (
-          <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
-            {dateStr && (
-              <span className="flex items-center gap-1.5">
-                <Calendar size={12} className="text-white/50" />
-                {dateStr}
-              </span>
+          {/* Title + expand toggle */}
+          <div className="flex items-center gap-2">
+            <h1 className="text-3xl sm:text-4xl font-normal text-white leading-tight tracking-wide font-serif">
+              {cityName || trip?.title || 'Untitled Trip'}
+            </h1>
+            {hasExpandContent && (
+              <button
+                onClick={() => setExpanded(v => !v)}
+                className="text-white/40 hover:text-white/70 transition-colors mt-1"
+                title={expanded ? 'Show less' : 'Show more'}
+              >
+                <ChevronDown size={16} className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`} />
+              </button>
             )}
-            <span className="flex items-center gap-1.5">
-              <Users size={12} className="text-white/50" />
-              {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
-            </span>
-            <button
-              onClick={openEditor}
-              className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
-              title="Edit trip details"
-            >
-              <Pencil size={12} />
-            </button>
           </div>
-        )}
 
-        {/* Info pills — inside the hero */}
-        {infoPills.length > 0 && !editing && (
-          <div className="flex flex-wrap items-center gap-1.5 mt-3">
-            {infoPills.map((pill, i) => (
-              <span key={i}
-                className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold backdrop-blur-md"
-                style={{
-                  backgroundColor: pill.color ? pill.color + '25' : 'rgba(255,255,255,0.15)',
-                  border: `1px solid ${pill.color ? pill.color + '50' : 'rgba(255,255,255,0.25)'}`,
-                  color: pill.color || 'rgba(255,255,255,0.9)',
-                }}>
-                {pill.label}
+          {/* Meta row */}
+          {!editing && (
+            <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
+              {dateStr && (
+                <span className="flex items-center gap-1.5">
+                  <Calendar size={12} className="text-white/50" />
+                  {dateStr}
+                </span>
+              )}
+              <span className="flex items-center gap-1.5">
+                <Users size={12} className="text-white/50" />
+                {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
               </span>
-            ))}
-          </div>
-        )}
+              <button
+                onClick={openEditor}
+                className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
+                title="Edit trip details"
+              >
+                <Pencil size={12} />
+              </button>
+            </div>
+          )}
 
-        {/* Inline editor */}
-        {editing && (
-          <div className="flex flex-wrap items-end gap-2.5 mt-2">
-            <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
-            <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
-            <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
-            <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
-              className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
-            <button onClick={saveEdits} disabled={saving}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
-              <Check size={13} /> {saving ? '...' : 'Save'}
-            </button>
-            <button onClick={() => setEditing(false)}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
-              <X size={13} /> Cancel
-            </button>
-          </div>
-        )}
+          {/* Quick info — inline text */}
+          {infoPills.length > 0 && !editing && (
+            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 mt-2 text-[11px] text-white/70">
+              {infoPills.map((pill, i) => (
+                <span key={i} className="inline-flex items-center">
+                  {i > 0 && <span className="mr-1.5 text-white/30">·</span>}
+                  <span style={pill.color ? { color: pill.color } : undefined}>{pill.label}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Inline editor */}
+          {editing && (
+            <div className="flex flex-wrap items-end gap-2.5 mt-2">
+              <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Trip title"
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-white/40 w-40" />
+              <input type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+              <input type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 [color-scheme:dark]" />
+              <input type="number" min={1} max={20} value={editTravelers} onChange={(e) => setEditTravelers(Number(e.target.value))}
+                className="bg-white/10 border border-white/20 rounded-lg px-2.5 py-1 text-sm text-white focus:outline-none focus:ring-1 focus:ring-white/40 w-16" />
+              <button onClick={saveEdits} disabled={saving}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white text-[#0f1f33] text-sm font-semibold hover:bg-white/90 transition-colors disabled:opacity-50">
+                <Check size={13} /> {saving ? '...' : 'Save'}
+              </button>
+              <button onClick={() => setEditing(false)}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-white/10 text-white text-sm hover:bg-white/20 transition-colors border border-white/20">
+                <X size={13} /> Cancel
+              </button>
+            </div>
+          )}
+        </div>
       </div>
+
+      {/* Expanded details — dropdown below header */}
+      {expanded && (
+        <div className="relative z-20 px-6 sm:px-10 md:pl-[100px] py-4">
+          <div className="max-w-3xl flex flex-col gap-2.5">
+            {/* Forecast row */}
+            {forecast && forecast.length > 0 && !isNaN(forecast[0]?.high) && (
+              <div className="flex items-center gap-3 text-gray-800">
+                {temp != null && (
+                  <span className="text-xl font-semibold tabular-nums">{Math.round(temp)}°</span>
+                )}
+                <span className="text-gray-300">|</span>
+                {forecast.slice(0, 5).map((day) => (
+                  <span key={day.date} className="text-[11px] tabular-nums">
+                    <span className="text-gray-500">{new Date(day.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' })}</span>{' '}
+                    <span className="font-medium">{Math.round(day.high)}°</span>
+                    <span className="text-gray-400">/{Math.round(day.low)}°</span>
+                  </span>
+                ))}
+              </div>
+            )}
+            {/* Wiki */}
+            {wiki && (
+              <p className="text-[12px] leading-relaxed text-gray-500 font-serif line-clamp-2">
+                {wiki}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -10,10 +10,12 @@ export function CompactTripHeader({
   tripId,
   trip,
   onTripUpdate,
+  overrideImage,
 }: {
   tripId: string;
   trip: Trip | null;
   onTripUpdate?: () => void;
+  overrideImage?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState('');
@@ -22,7 +24,9 @@ export function CompactTripHeader({
   const [editTravelers, setEditTravelers] = useState(1);
   const [saving, setSaving] = useState(false);
 
-  const rawCover = trip?.trip_context?.hero_image_url;
+  // Best available image — Unsplash override first, then hero_images, then hero_image_url
+  const heroImages = trip?.trip_context?.hero_images as string[] | undefined;
+  const rawCover = overrideImage || heroImages?.[0] || trip?.trip_context?.hero_image_url;
   const coverImage = rawCover?.includes('googleusercontent.com')
     ? rawCover.replace(/=w\d+-h\d+[^&]*/, '=w1600-h600-k-no')
     : rawCover;
@@ -36,6 +40,28 @@ export function CompactTripHeader({
   const countryFlag = trip?.trip_context?.country?.flag as string | undefined;
   const countryCca2 = trip?.trip_context?.country?.cca2 as string | undefined;
   const flagUrl = countryFlag || (countryCca2 ? `https://flagcdn.com/24x18/${countryCca2.toLowerCase()}.png` : null);
+
+  // Quick info from trip_context
+  const ctx = trip?.trip_context as Record<string, any> | undefined;
+  const weather = ctx?.weather?.current;
+  const safety = ctx?.safety;
+  const tz = ctx?.country?.timezone;
+  const aqi = ctx?.aqi?.aqi;
+  const aqiLevel = ctx?.aqi?.level;
+  const currency = ctx?.country?.currency;
+  const nextHoliday = (ctx?.holidays as { name: string; date: string }[] | undefined)?.[0];
+
+  const infoPills: { label: string; color?: string }[] = [];
+  if (weather?.temp_f) infoPills.push({ label: `${Math.round(weather.temp_f)}°F ${weather.conditions || weather.condition || ''}`.trim() });
+  else if (weather?.conditions) infoPills.push({ label: weather.conditions });
+  if (currency) infoPills.push({ label: `${currency.symbol} ${currency.code}` });
+  if (tz) infoPills.push({ label: tz });
+  if (aqiLevel) infoPills.push({ label: `Air ${aqiLevel}`, color: aqi <= 50 ? '#4ade80' : aqi <= 100 ? '#facc15' : '#f87171' });
+  if (safety) {
+    const s = safety.score;
+    infoPills.push({ label: `Safe (${s.toFixed(1)})`, color: s <= 2.5 ? '#4ade80' : s <= 3.5 ? '#facc15' : '#f87171' });
+  }
+  if (nextHoliday) infoPills.push({ label: `${nextHoliday.name} · ${new Date(nextHoliday.date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` });
 
   const openEditor = useCallback(() => {
     setEditTitle(trip?.title || '');
@@ -65,7 +91,7 @@ export function CompactTripHeader({
   }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
 
   return (
-    <div className="relative w-full overflow-hidden" style={{ height: 180 }}>
+    <div className="relative w-full overflow-hidden" style={{ height: 260 }}>
       {/* Background image */}
       {coverImage ? (
         <Image
@@ -74,7 +100,7 @@ export function CompactTripHeader({
           fill
           referrerPolicy="no-referrer"
           className="object-cover"
-          style={{ objectPosition: 'center 30%' }}
+          style={{ objectPosition: 'center 35%' }}
           sizes="100vw"
           priority
         />
@@ -83,58 +109,63 @@ export function CompactTripHeader({
       )}
 
       {/* Gradient overlay */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            'linear-gradient(to bottom, rgba(0,0,0,0.2) 0%, rgba(0,0,0,0.5) 60%, rgba(0,0,0,0.7) 100%)',
-        }}
-      />
+      <div className="absolute inset-0" style={{
+        background: 'linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.3) 40%, rgba(0,0,0,0.75) 100%)',
+      }} />
 
       {/* Content */}
       <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pb-5">
         {/* Country tag */}
-        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5"
-          style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
+        <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5 text-white/70">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px]" style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.3)' }} />}
+          {flagUrl && <img src={flagUrl} alt="flag" width={20} height={15} className="rounded-[2px] shadow-sm" />}
           <span>{countryName || ''}</span>
         </p>
 
-        {/* Title row */}
-        <div className="flex items-end justify-between gap-4">
-          <div>
-            <h1
-              className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif"
-              style={{ letterSpacing: '0.02em', textShadow: '0 2px 12px rgba(0,0,0,0.5)' }}
-            >
-              {cityName || trip?.title || 'Untitled Trip'}
-            </h1>
+        {/* Title */}
+        <h1 className="text-3xl sm:text-4xl font-bold text-white leading-tight font-serif tracking-tight">
+          {cityName || trip?.title || 'Untitled Trip'}
+        </h1>
 
-            {/* Meta row */}
-            {!editing && (
-              <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
-                {dateStr && (
-                  <span className="flex items-center gap-1.5">
-                    <Calendar size={12} className="text-white/50" />
-                    {dateStr}
-                  </span>
-                )}
-                <span className="flex items-center gap-1.5">
-                  <Users size={12} className="text-white/50" />
-                  {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
-                </span>
-                <button
-                  onClick={openEditor}
-                  className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
-                  title="Edit trip details"
-                >
-                  <Pencil size={12} />
-                </button>
-              </div>
+        {/* Meta row */}
+        {!editing && (
+          <div className="flex items-center gap-3 mt-1.5 text-[13px] text-white/80">
+            {dateStr && (
+              <span className="flex items-center gap-1.5">
+                <Calendar size={12} className="text-white/50" />
+                {dateStr}
+              </span>
             )}
+            <span className="flex items-center gap-1.5">
+              <Users size={12} className="text-white/50" />
+              {travelersCount} {travelersCount === 1 ? 'traveler' : 'travelers'}
+            </span>
+            <button
+              onClick={openEditor}
+              className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors"
+              title="Edit trip details"
+            >
+              <Pencil size={12} />
+            </button>
           </div>
-        </div>
+        )}
+
+        {/* Info pills — inside the hero */}
+        {infoPills.length > 0 && !editing && (
+          <div className="flex flex-wrap items-center gap-1.5 mt-3">
+            {infoPills.map((pill, i) => (
+              <span key={i}
+                className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold backdrop-blur-md"
+                style={{
+                  backgroundColor: pill.color ? pill.color + '25' : 'rgba(255,255,255,0.15)',
+                  border: `1px solid ${pill.color ? pill.color + '50' : 'rgba(255,255,255,0.25)'}`,
+                  color: pill.color || 'rgba(255,255,255,0.9)',
+                }}>
+                {pill.label}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* Inline editor */}
         {editing && (

--- a/apps/web/components/trip/TripMagazineHero.tsx
+++ b/apps/web/components/trip/TripMagazineHero.tsx
@@ -224,8 +224,8 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
         </p>
         <div className="flex items-center gap-4">
           {cityName ? (
-            <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-white leading-[0.95] font-serif"
-              style={{ letterSpacing: '0.02em', textShadow: '0 4px 30px rgba(0,0,0,0.5)' }}>
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-normal text-white leading-[0.95] font-serif"
+              style={{ letterSpacing: '0.04em', textShadow: '0 4px 30px rgba(0,0,0,0.5)' }}>
               {cityName.toUpperCase()}
             </h1>
           ) : (

--- a/apps/web/components/trip/TripMagazineHero.tsx
+++ b/apps/web/components/trip/TripMagazineHero.tsx
@@ -60,6 +60,7 @@ function useQuote() {
 
 export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripUpdate, suppressFallback }: { tripId?: string; trip?: Trip | null; overrideImage?: string; compact?: boolean; onTripUpdate?: () => void; suppressFallback?: boolean }) {
   const bgRef = useRef<HTMLDivElement>(null);
+  const [scrollY, setScrollY] = useState(0);
 
   useEffect(() => {
     const el = bgRef.current;
@@ -68,7 +69,10 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
     const handleScroll = () => {
       cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
-        el.style.transform = `translateY(${window.scrollY * 0.15}px)`;
+        const y = window.scrollY;
+        setScrollY(y);
+        // Ken Burns zoom — subtle scale increase as you scroll
+        el.style.transform = `scale(${1 + y * 0.0003})`;
       });
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -76,7 +80,7 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
       window.removeEventListener('scroll', handleScroll);
       cancelAnimationFrame(rafId);
     };
-  }, []);
+  }, [compact]);
 
   const [editing, setEditing] = useState(false);
   const [editStart, setEditStart] = useState('');
@@ -124,7 +128,7 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
     }
   }, [tripId, editTitle, editStart, editEnd, editTravelers, saving, onTripUpdate]);
 
-  const [essentialsOpen, setEssentialsOpen] = useState(true);
+  const [essentialsOpen, setEssentialsOpen] = useState(!compact);
   const [convertAmount, setConvertAmount] = useState<number | string>(1);
   const [convertEditing, setConvertEditing] = useState(false);
   // Temperature unit follows user's distance preference: miles = °F, kilometers = °C
@@ -202,68 +206,69 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
 
   return (
     <>
-      {/* Background image — bleeds behind nav and all content */}
+      {/* Pinned background image — all tabs */}
       {coverImage && (
-        <div className="absolute inset-x-0 top-0 z-0 pointer-events-none overflow-hidden" style={{ height: '160vh' }}>
+        <div className="fixed inset-0 z-0 pointer-events-none">
           <div ref={bgRef} className="absolute inset-0" style={{ willChange: 'transform' }}>
-            <Image src={coverImage} alt="" fill  className="object-cover"
-              style={{ objectPosition: 'center 30%' }} sizes="100vw" priority />
+            <Image src={coverImage} alt="" fill className="object-cover"
+              style={{ objectPosition: 'center center' }} sizes="100vw" priority />
           </div>
-          {/* Gradient overlay — longer fade so hero bleeds through Things to Do */}
           <div className="absolute inset-0"
-            style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.25) 10%, rgba(0,0,0,0.35) 20%, rgba(0,0,0,0.45) 30%, rgba(0,0,0,0.55) 40%, rgba(0,0,0,0.65) 50%, var(--magazine-bg, var(--background)) 75%, var(--magazine-bg, var(--background)) 100%)' }} />
+            style={{ background: compact
+              ? 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.1) 40%, rgba(0,0,0,0.4) 75%, rgba(0,0,0,0.7) 100%)'
+              : 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0) 20%, rgba(0,0,0,0) 50%, rgba(0,0,0,0.4) 80%, rgba(0,0,0,0.7) 100%)'
+            }} />
         </div>
       )}
 
-      {/* Hero text — aligned with content area (max-w-7xl + spine offset) */}
-      <div className="relative z-10 max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 pt-[68px] pb-8">
-        <p className="flex items-center gap-2 text-[10px] tracking-[0.4em] uppercase font-semibold mb-1" style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          {flagUrl && <img src={flagUrl} alt="flag" width={24} height={18} className="rounded-[2px]" style={{ boxShadow: '0 1px 4px rgba(0,0,0,0.3)' }} />}
-          <span>{countryName || (trip ? 'Your Trip Guide' : '')}</span>
-        </p>
-        <div className="flex items-center gap-4">
-          {cityName ? (
-            <h1 className="text-4xl sm:text-5xl md:text-6xl font-normal text-white leading-[0.95] font-serif"
-              style={{ letterSpacing: '0.04em', textShadow: '0 4px 30px rgba(0,0,0,0.5)' }}>
-              {cityName.toUpperCase()}
-            </h1>
-          ) : (
-            <div className="h-14 sm:h-16 md:h-20 w-[60%] rounded-lg bg-white/15 animate-pulse" />
-          )}
-          {hasEssentials && (
-            <button
-              onClick={() => setEssentialsOpen((v) => !v)}
-              className="p-1.5 rounded-full transition-all shrink-0 hover:bg-white/15 active:scale-90"
-              title={essentialsOpen ? 'Hide trip info' : 'Show trip info'}
-            >
-              <ChevronDown size={16} className={`text-white/60 transition-transform duration-300 ${essentialsOpen ? 'rotate-180' : ''}`} />
-            </button>
-          )}
-          {!compact && tripId && (
-            <a
-              href={`/trip/${tripId}/itinerary`}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-semibold transition-all hover:scale-105 active:scale-95 backdrop-blur-sm ml-2"
-              style={{
-                backgroundColor: 'rgba(255,255,255,0.12)',
-                border: '1px solid rgba(255,255,255,0.2)',
-                color: 'rgba(255,255,255,0.8)',
-              }}
-            >
-              View Itinerary &rarr;
-            </a>
-          )}
+      {/* Hero text — unified for all tabs, just different height */}
+      <div className="relative z-10 flex flex-col justify-end" style={{ height: compact ? '35vh' : '70vh' }}>
+        <div className="w-full px-6 sm:px-10 md:pl-[120px] pb-2"
+          style={!compact ? { opacity: Math.max(0, 1 - scrollY / 800) } : undefined}>
+          <p className="flex items-center gap-2 text-[11px] tracking-[0.4em] uppercase font-semibold mb-1" style={{ color: 'var(--magazine-accent, #c8a96a)' }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {flagUrl && <img src={flagUrl} alt="flag" width={24} height={18} className="rounded-[2px]" style={{ boxShadow: '0 1px 4px rgba(0,0,0,0.3)' }} />}
+            <span>{countryName || (trip ? 'Your Trip Guide' : '')}</span>
+          </p>
+          <div className="flex items-center gap-3">
+            {cityName ? (
+              <h1 className={`font-normal text-white leading-[0.9] font-serif ${compact ? 'text-4xl sm:text-5xl md:text-6xl' : 'text-5xl sm:text-6xl md:text-7xl lg:text-8xl'}`}
+                style={{ letterSpacing: '0.03em', textShadow: '0 4px 40px rgba(0,0,0,0.4)' }}>
+                {cityName.toUpperCase()}
+              </h1>
+            ) : (
+              <div className={`${compact ? 'h-14 sm:h-16 md:h-20' : 'h-16 sm:h-20 md:h-24'} w-[60%] rounded-lg bg-white/15 animate-pulse`} />
+            )}
+            {hasEssentials && (
+              <button
+                onClick={() => setEssentialsOpen((v) => !v)}
+                className="p-1.5 rounded-full transition-all shrink-0 hover:bg-white/15 active:scale-90"
+                title={essentialsOpen ? 'Hide trip info' : 'Show trip info'}
+              >
+                <ChevronDown size={18} className={`text-white/50 transition-transform duration-300 ${essentialsOpen ? 'rotate-180' : ''}`} />
+              </button>
+            )}
+          </div>
         </div>
       </div>
 
-      {/* Collapsible trip info */}
-      {hasEssentials && (
-        <div className={`relative z-10 max-w-7xl mx-auto px-6 sm:px-10 md:pl-24 transition-all duration-300 ${essentialsOpen ? 'mb-6' : 'mb-0'}`}>
-          <div className={`transition-all duration-300 overflow-hidden ${essentialsOpen ? `${essentialsMaxH} opacity-100` : 'max-h-0 opacity-0'}`}
-            style={{ textShadow: '0 2px 10px rgba(0,0,0,0.6), 0 0 20px rgba(0,0,0,0.3)' }}>
+      {/* Trip meta + collapsible details */}
+      <div className={`relative z-10 px-6 sm:px-10 md:pl-[120px] transition-all duration-300 ${essentialsOpen ? 'mb-6' : 'mb-3'}`}
+        style={{ textShadow: '0 2px 10px rgba(0,0,0,0.6), 0 0 20px rgba(0,0,0,0.3)' }}>
 
-            {/* Dates + travelers — inline editable */}
-            {editing ? (
+        {/* Dates + travelers — always visible */}
+        {!editing ? (
+          <div className="flex items-center gap-4 text-[14px] sm:text-[15px] text-white/80 font-medium mb-3">
+            {dateStr && <span>{dateStr}</span>}
+            {dateStr && travelersStr && <span className="text-white/30">&middot;</span>}
+            {travelersStr && <span>{travelersStr}</span>}
+            {tripId && (
+              <button onClick={openEditor} className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors" title="Edit trip details">
+                <Pencil size={13} />
+              </button>
+            )}
+          </div>
+        ) : (
               <div className="flex flex-wrap items-end gap-3 mb-4 animate-[fadeSlideIn_0.2s_ease-out]">
                 <div>
                   <label className="block text-[10px] uppercase tracking-wider text-white/50 mb-1">Destination</label>
@@ -300,19 +305,11 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
                   <X size={14} /> Cancel
                 </button>
               </div>
-            ) : (
-              <div className="flex items-center gap-4 text-[14px] sm:text-[15px] text-white/80 font-medium mb-4">
-                {dateStr && <span>{dateStr}</span>}
-                {dateStr && travelersStr && <span className="text-white/30">&middot;</span>}
-                {travelersStr && <span>{travelersStr}</span>}
-                {tripId && (
-                  <button onClick={openEditor} className="ml-1 p-1 rounded-full hover:bg-white/15 text-white/50 hover:text-white transition-colors" title="Edit trip details">
-                    <Pencil size={13} />
-                  </button>
-                )}
-              </div>
             )}
 
+        {/* Collapsible details */}
+        {hasEssentials && (
+          <div className={`transition-all duration-300 overflow-hidden ${essentialsOpen ? `${essentialsMaxH} opacity-100` : 'max-h-0 opacity-0'}`}>
             {/* Quick facts, holidays, weather */}
             <div className="space-y-2.5 mb-4">
             {/* Quick facts — currency, language, timezone, emergency, sunrise/sunset */}
@@ -456,9 +453,9 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
               </div>
             )}
 
-          </div>{/* end collapsible */}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -13,15 +13,28 @@ export function formatCurrency(amount: number, currency = 'USD'): string {
   }).format(amount);
 }
 
-/** Upscale Google Places proxy image URLs from tiny thumbnails to usable sizes */
+/** Upscale image URLs from various sources to usable sizes */
 export function upscaleGoogleImage(url: string | null | undefined, width = 1200, height = 800): string | null {
-  if (!url) return null;
+  if (!url || url.length < 10) return null;
+  // Google Places / googleusercontent thumbnails
   if (url.includes('googleusercontent.com')) {
     return url
       .replace(/=w\d+-h\d+[^&\s]*/, `=w${width}-h${height}-k-no`)
       .replace(/=s\d+-w\d+-h\d+[^&\s]*/, `=w${width}-h${height}-k-no`);
   }
+  // Foursquare — replace size tokens with 'original' for full res
+  if (url.includes('4sqi.net') || url.includes('foursquare.com') || url.includes('fsq.com')) {
+    return url.replace(/\/(\d+x\d+|cap\d+|width\d+)\//, '/original/');
+  }
   return url;
+}
+
+/** Check if an image URL looks valid enough to render */
+export function isValidImageUrl(url: string | null | undefined): boolean {
+  if (!url || url.length < 10) return false;
+  // Must start with http
+  if (!url.startsWith('http')) return false;
+  return true;
 }
 
 /**

--- a/packages/shared/src/utils/places.ts
+++ b/packages/shared/src/utils/places.ts
@@ -1,4 +1,4 @@
-import { upscaleGoogleImage } from './index';
+import { upscaleGoogleImage, isValidImageUrl } from './index';
 import type { PlaceItem } from '../types';
 
 // ─── Backend response shape ─────────────────────────────────
@@ -120,10 +120,11 @@ export function getFallbackImage(_name: string, _idx: number): string {
 // ─── Canonical mapper ───────────────────────────────────────
 
 export function mapBackendToPlaceItem(p: BackendPlace, idx = 0, requestedCategory?: string): PlaceItem {
+  const img = upscaleGoogleImage(p.photo_url);
   return {
     id: p.id,
     name: p.name,
-    image: upscaleGoogleImage(p.photo_url) ?? getFallbackImage(p.name, idx),
+    image: isValidImageUrl(img) ? img! : '',
     type: mapType(p.category, requestedCategory),
     rating: p.rating ?? 0,
     tagline: p.description?.split('.')[0] ?? p.category,

--- a/planning/TRA-436.md
+++ b/planning/TRA-436.md
@@ -1,0 +1,15 @@
+# TRA-436: Aggregated Events API
+
+## Goal
+Replace the non-existent backend `/api/events/search` with a Next.js route that fans out to Ticketmaster, Eventbrite, and SerpAPI Google Events in parallel, deduplicates, and returns unified event data for the "What's Going On" section.
+
+## Status
+- [x] Linear issue created
+- [ ] Get API keys (Ticketmaster, Eventbrite)
+- [ ] Build `/api/events/search` route with multi-source fan-out
+- [ ] Wire into overview page `allEvents`
+- [ ] Test with real trip data
+- [ ] Verify works for anonymous users
+
+## Links
+- Linear: https://linear.app/travyl/issue/TRA-436


### PR DESCRIPTION
## Summary
- **TRA-459**: Compact header expand/collapse uses smooth CSS transition instead of conditional render
- **TRA-460**: "What's Going On" fallback threshold lowered so it shows with 3+ explore items
- **TRA-461**: Explore section rewritten — fetches live data from API (SerpAPI + Foursquare nearby), groups by API-returned categories, infinite horizontal scroll with load-more, broken image filtering at API + runtime level
- **TRA-462**: Magazine content left-aligned with hero text (`md:pl-[120px]`) instead of centered
- Per-section glass cards on overview rows in magazine mode
- Image pipeline: `upscaleGoogleImage` handles Foursquare URLs, `isValidImageUrl` rejects bad URLs, `/api/places` filters out imageless places

## Test plan
- [ ] Open a trip in magazine mode — overview sections should have individual glass cards, left-aligned with hero
- [ ] Switch to compact mode — sections should render normally with white background
- [ ] Scroll the Explore section horizontally — should load more items when nearing the end
- [ ] Check that no broken/empty image cards appear
- [ ] Verify "What's Going On" section shows on overview
- [ ] Toggle compact header expand/collapse — should animate smoothly