### PR TITLE
fix: web + mobile polish — explore, animations, flights, navigation, images (TRA-463)

### DIFF
--- a/apps/mobile/.maestro/screenshot-all.yaml
+++ b/apps/mobile/.maestro/screenshot-all.yaml
@@ -1,0 +1,23 @@
+appId: com.ze-ee.mobile
+---
+- takeScreenshot: "01-places"
+
+- tapOn:
+    text: "Trips, tab, 3 of 4"
+- waitForAnimationToEnd
+- takeScreenshot: "02-trips"
+
+- tapOn:
+    text: "Profile, tab, 4 of 4"
+- waitForAnimationToEnd
+- takeScreenshot: "03-profile"
+
+- tapOn:
+    text: "Discover, tab, 1 of 4"
+- waitForAnimationToEnd
+- takeScreenshot: "04-discover"
+
+- tapOn:
+    text: "Places, tab, 2 of 4"
+- waitForAnimationToEnd
+- takeScreenshot: "05-places-back"

--- a/apps/mobile/app/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/(tabs)/(home)/index.tsx
@@ -395,8 +395,9 @@ export default function HomeScreen() {
           const tripId = await savePlanToSupabase(s.plan as any);
           await saveAnonTripId(tripId);
           planner.reset();
-          setShowTakeoff(false);
+          // Navigate first, THEN hide takeoff — prevents flash of home screen
           router.push(`/trip/${tripId}` as any);
+          setTimeout(() => setShowTakeoff(false), 500);
         } catch (err: any) {
           console.error('Failed to save trip:', err?.message || err);
           planner.reset();

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -20,6 +20,7 @@ export default function TabLayout() {
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
+        freezeOnBlur: false,
       }}>
       <Tabs.Screen
         name="(home)"

--- a/apps/mobile/app/(tabs)/favorites/index.tsx
+++ b/apps/mobile/app/(tabs)/favorites/index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { Image } from 'expo-image';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { Navy, groupPlacesByCollection, TextStyles, FontSize, upscaleGoogleImage, type PlaceItem } from '@travyl/shared';
+import { Navy, TextStyles, FontSize, upscaleGoogleImage, mapCategory, type PlaceItem } from '@travyl/shared';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { ExplorePreview } from '@/components/home/ExplorePreview';
@@ -32,11 +32,11 @@ function mapToPlaceItem(p: any): PlaceItem {
     id: p.id,
     name: p.name,
     image: upscaleGoogleImage(p.image || p.photo_url) ?? '',
-    images: p.images,
+    images: p.images?.map((img: string) => upscaleGoogleImage(img) ?? img),
     type: p.type || 'attraction',
     rating: p.rating || 0,
     tagline: p.tagline || p.description?.split('.')[0] || p.category || '',
-    category: p.category || '',
+    category: mapCategory(p.category || ''),
     description: p.description || '',
     tags: p.tags || [p.category].filter(Boolean),
     latitude: p.latitude ?? p.lat,
@@ -91,30 +91,50 @@ async function fetchNearbyPlaces(lat: number, lng: number): Promise<PlaceItem[]>
 }
 
 // Fetch a page of suggested places — returns items + pagination info
+// Popular cities with coords for the discovery feed — rotated through for variety
+const DISCOVER_CITIES = [
+  { name: 'Paris', lat: 48.8566, lng: 2.3522 },
+  { name: 'Tokyo', lat: 35.6762, lng: 139.6503 },
+  { name: 'New York', lat: 40.7128, lng: -74.006 },
+  { name: 'London', lat: 51.5074, lng: -0.1278 },
+  { name: 'Rome', lat: 41.9028, lng: 12.4964 },
+  { name: 'Barcelona', lat: 41.3874, lng: 2.1686 },
+  { name: 'Bangkok', lat: 13.7563, lng: 100.5018 },
+  { name: 'Istanbul', lat: 41.0082, lng: 28.9784 },
+  { name: 'Dubai', lat: 25.2048, lng: 55.2708 },
+  { name: 'Sydney', lat: -33.8688, lng: 151.2093 },
+];
+const DISCOVER_CATS = ['sightseeing', 'restaurant', 'cafe', 'entertainment'];
+
 async function fetchSuggestPage(page: number): Promise<{ items: PlaceItem[]; hasMore: boolean; nextPage: number | null }> {
   try {
-    const res = await fetch(`${WEB_API}/api/places/suggest?destination=popular&category=all&page=${page}`);
+    // First page: fetch multiple cities in parallel for a rich initial load
+    if (page === 0) {
+      const fetches = DISCOVER_CITIES.slice(0, 5).flatMap(city =>
+        DISCOVER_CATS.slice(0, 2).map(cat =>
+          fetch(`${WEB_API}/api/places?lat=${city.lat}&lng=${city.lng}&category=${cat}&limit=8`)
+            .then(r => r.ok ? r.json() : [])
+            .then((data: any[]) => data.map(mapToPlaceItem))
+            .catch(() => [] as PlaceItem[])
+        )
+      );
+      const results = await Promise.all(fetches);
+      const items = results.flat();
+      return { items, hasMore: true, nextPage: 1 };
+    }
+    // Subsequent pages: one city+category at a time
+    const cityIdx = (page - 1) % DISCOVER_CITIES.length;
+    const catIdx = Math.floor((page - 1) / DISCOVER_CITIES.length) % DISCOVER_CATS.length;
+    const city = DISCOVER_CITIES[cityIdx];
+    const cat = DISCOVER_CATS[catIdx];
+    const res = await fetch(`${WEB_API}/api/places?lat=${city.lat}&lng=${city.lng}&category=${cat}&limit=10`);
     if (!res.ok) return { items: [], hasMore: false, nextPage: null };
-    const data = await res.json();
-    const suggestions = data?.suggestions ?? [];
-    const items = suggestions.map((s: any): PlaceItem => ({
-      id: s.id,
-      name: s.name,
-      image: s.imageUrl ?? s.imageUrls?.[0] ?? '',
-      type: 'destination',
-      rating: s.rating ?? 0,
-      tagline: s.description?.split('.')[0] ?? s.location ?? '',
-      category: s.category ?? '',
-      description: s.description ?? '',
-      tags: s.category ? [s.category] : [],
-      latitude: s.latitude,
-      longitude: s.longitude,
-      address: s.location,
-    }));
+    const data: any[] = await res.json();
+    const items = data.map(mapToPlaceItem);
     return {
       items,
-      hasMore: data?.hasMore ?? items.length > 0,
-      nextPage: data?.nextPage ?? (items.length > 0 ? page + 1 : null),
+      hasMore: page < DISCOVER_CITIES.length * DISCOVER_CATS.length,
+      nextPage: items.length > 0 ? page + 1 : null,
     };
   } catch {
     return { items: [], hasMore: false, nextPage: null };
@@ -208,7 +228,7 @@ const GridPlaceCard = memo(function GridPlaceCard({
         borderWidth: 1, borderColor: colors.border,
       }}>
         <View style={{ height: imgH, position: 'relative' }}>
-          <Image source={imgs[imgIdx]} style={{ width: '100%', height: imgH }} contentFit="cover" cachePolicy="memory-disk" transition={200} />
+          <Image source={{ uri: imgs[imgIdx], headers: { Referer: '' } }} style={{ width: '100%', height: imgH }} contentFit="cover" cachePolicy="memory-disk" transition={200} />
 
           {hasMultiple && (
             <Pressable
@@ -464,7 +484,30 @@ export default function FavoritesScreen() {
     return result;
   }, [tabFiltered, activeSubcategory, searchQuery, sortBy]);
 
-  const baseSections = useMemo(() => groupPlacesByCollection(filteredPlaces), [filteredPlaces]);
+  const baseSections = useMemo(() => {
+    // Group by API category first (Landmark, Culinary, Museum, etc.) — always works
+    const byCategory: Record<string, typeof filteredPlaces> = {};
+    for (const place of filteredPlaces) {
+      const cat = place.category || 'Other';
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push(place);
+    }
+    const sections = Object.entries(byCategory)
+      .filter(([, places]) => places.length >= 2)
+      .sort(([, a], [, b]) => b.length - a.length)
+      .map(([cat, places]) => ({
+        collection: { key: cat.toLowerCase(), label: cat, match: {} },
+        places,
+      }));
+    // Fallback if no categories have 2+ items
+    if (sections.length === 0 && filteredPlaces.length > 0) {
+      sections.push({
+        collection: { key: 'all', label: 'Places', match: {} },
+        places: filteredPlaces,
+      });
+    }
+    return { sections, remaining: [] as typeof filteredPlaces };
+  }, [filteredPlaces]);
 
   // Prepend "Near You" as the first section when available
   const themedSections = useMemo(() => {

--- a/apps/mobile/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/app/(tabs)/profile/index.tsx
@@ -15,7 +15,7 @@ function BoardCard({ board }: { board: typeof TRAVEL_BOARDS[number] }) {
   return (
     <View style={{ borderRadius: 14, overflow: 'hidden', backgroundColor: colors.cardBackground, borderWidth: 1, borderColor: colors.border, marginBottom: 12 }}>
       {firstImage && (
-        <Image source={{ uri: firstImage }} style={{ width: '100%', height: 120 }} resizeMode="cover" />
+        <Image source={{ uri: firstImage, headers: { Referer: '' } }} style={{ width: '100%', height: 120 }} resizeMode="cover" />
       )}
       <View style={{ padding: 10, gap: 4 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -37,7 +37,7 @@ function FavoriteCard({ fav }: { fav: typeof PROFILE_FAVORITES[number] }) {
   const colors = useThemeColors();
   return (
     <View style={{ borderRadius: 14, overflow: 'hidden', backgroundColor: colors.cardBackground, borderWidth: 1, borderColor: colors.border, marginBottom: 10 }}>
-      <Image source={{ uri: fav.image }} style={{ width: '100%', height: 110 }} resizeMode="cover" />
+      <Image source={{ uri: fav.image, headers: { Referer: '' } }} style={{ width: '100%', height: 110 }} resizeMode="cover" />
       <View style={{ padding: 8, gap: 2 }}>
         <Text style={{ fontSize: 12, fontWeight: '600', color: colors.text }} numberOfLines={1}>{fav.name}</Text>
         <Text style={{ fontSize: 10, color: colors.textSecondary }}>{fav.country}</Text>

--- a/apps/mobile/app/(tabs)/trips/index.tsx
+++ b/apps/mobile/app/(tabs)/trips/index.tsx
@@ -149,10 +149,10 @@ function TripCard({ trip, height, width }: { trip: MockTripCard; height: number;
       style={({ pressed }) => ({ opacity: pressed ? 0.95 : 1 })}
     >
       <View style={{ height, borderRadius: 16, overflow: 'hidden', backgroundColor: colors.border }}>
-        <Image source={{ uri: trip.image }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+        <Image source={{ uri: trip.image, headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
         <LinearGradient
-          colors={['rgba(0,0,0,0.25)', 'transparent', 'rgba(0,0,0,0.75)']}
-          locations={[0, 0.3, 1]}
+          colors={['rgba(0,0,0,0.3)', 'transparent', 'rgba(0,0,0,0.5)', 'rgba(0,0,0,0.85)']}
+          locations={[0, 0.25, 0.6, 1]}
           pointerEvents="none"
           style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}
         />
@@ -177,7 +177,7 @@ function TripCard({ trip, height, width }: { trip: MockTripCard; height: number;
                     marginLeft: mi > 0 ? -8 : 0,
                   }}>
                     {m.avatar ? (
-                      <Image source={{ uri: m.avatar }} style={{ width: 20, height: 20, borderRadius: 10 }} />
+                      <Image source={{ uri: m.avatar, headers: { Referer: '' } }} style={{ width: 20, height: 20, borderRadius: 10 }} />
                     ) : (
                       <Text style={{ ...TextStyles.xs, color: '#fff' }}>{m.name.charAt(0)}</Text>
                     )}
@@ -208,16 +208,16 @@ function TripCard({ trip, height, width }: { trip: MockTripCard; height: number;
             </View>
           )}
           <Text style={{
-            ...TextStyles.subhead, color: '#fff',
-            textShadowColor: 'rgba(0,0,0,0.6)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6,
+            ...TextStyles.subhead, color: '#fff', fontWeight: '700',
+            textShadowColor: 'rgba(0,0,0,0.8)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 8,
           }} numberOfLines={1}>
             {trip.title}
           </Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 3 }}>
             <FontAwesome name="map-marker" size={11} color="rgba(255,255,255,0.7)" />
             <Text style={{
-              ...TextStyles.body, color: 'rgba(255,255,255,0.9)',
-              textShadowColor: 'rgba(0,0,0,0.5)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 4,
+              ...TextStyles.body, color: '#fff',
+              textShadowColor: 'rgba(0,0,0,0.8)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6,
             }} numberOfLines={1}>
               {trip.destination}
             </Text>
@@ -259,7 +259,7 @@ function FeedCard({ item, onPress }: { item: MockTripCard; onPress: () => void }
     <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.95 : 1 })}>
       <View style={{ borderRadius: 18, overflow: 'hidden', backgroundColor: colors.cardBackground }}>
         <View style={{ height: 280 }}>
-          <Image source={{ uri: item.image }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+          <Image source={{ uri: item.image, headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
           <LinearGradient
             colors={['rgba(0,0,0,0.2)', 'transparent', 'rgba(0,0,0,0.8)']}
             locations={[0, 0.3, 1]}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -86,8 +86,8 @@ function RootLayoutNav() {
   return (
     <ThemeProvider value={DefaultTheme}>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="trip/[id]" options={{ headerShown: false, gestureEnabled: false }} />
+        <Stack.Screen name="(tabs)" options={{ headerShown: false, freezeOnBlur: false }} />
+        <Stack.Screen name="trip/[id]" options={{ headerShown: false, gestureEnabled: true, animation: 'slide_from_right' }} />
         <Stack.Screen name="login" options={{ presentation: 'modal', headerShown: false }} />
         <Stack.Screen name="login-callback" options={{ headerShown: false }} />
         <Stack.Screen name="signup" options={{ presentation: 'modal', headerShown: false }} />

--- a/apps/mobile/app/trip/[id]/_layout.tsx
+++ b/apps/mobile/app/trip/[id]/_layout.tsx
@@ -450,7 +450,7 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
         {/* Collapsible essentials */}
         {essentialsOpen && trip && (
           <View>
-            {/* Date + travelers + currency + timezone */}
+            {/* Date + travelers + currency + timezone + safety */}
             <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}>
               {[
                 formatDateRange(trip.start_date, trip.end_date),
@@ -468,6 +468,20 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
                   }}>{text}</Text>
                 </View>
               ))}
+              {(() => {
+                const safety = trip?.trip_context?.safety as { score: number; message: string } | undefined;
+                if (!safety || safety.score <= 0) return null;
+                const color = safety.score <= 2 ? '#4ade80' : safety.score <= 3 ? '#facc15' : '#f87171';
+                const bg = safety.score <= 2 ? 'rgba(34,197,94,0.25)' : safety.score <= 3 ? 'rgba(234,179,8,0.25)' : 'rgba(239,68,68,0.25)';
+                const border = safety.score <= 2 ? 'rgba(34,197,94,0.5)' : safety.score <= 3 ? 'rgba(234,179,8,0.5)' : 'rgba(239,68,68,0.5)';
+                const label = safety.score <= 2 ? 'Safe' : safety.score <= 3 ? 'Caution' : 'Danger';
+                return (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: bg, borderWidth: 1, borderColor: border, borderRadius: 12, paddingHorizontal: 8, paddingVertical: 2 }}>
+                    <FontAwesome name="shield" size={9} color={color} />
+                    <Text style={{ fontSize: 10, fontWeight: '600', color }}>{label} ({safety.score})</Text>
+                  </View>
+                );
+              })()}
             </View>
 
             {/* Weather + forecast */}
@@ -525,26 +539,7 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
               );
             })()}
 
-            {/* Safety badge + Wiki excerpt */}
-            {(() => {
-              const safety = trip?.trip_context?.safety as { score: number; message: string; level?: string } | undefined;
-              return (safety && safety.score > 0) ? (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 8 }}>
-                  <View style={{
-                    flexDirection: 'row', alignItems: 'center', gap: 4,
-                    backgroundColor: safety.score <= 2 ? 'rgba(34,197,94,0.25)' : safety.score <= 3 ? 'rgba(234,179,8,0.25)' : 'rgba(239,68,68,0.25)',
-                    borderWidth: 1,
-                    borderColor: safety.score <= 2 ? 'rgba(34,197,94,0.5)' : safety.score <= 3 ? 'rgba(234,179,8,0.5)' : 'rgba(239,68,68,0.5)',
-                    borderRadius: 12, paddingHorizontal: 10, paddingVertical: 3,
-                  }}>
-                    <FontAwesome name="shield" size={10} color={safety.score <= 2 ? '#4ade80' : safety.score <= 3 ? '#facc15' : '#f87171'} />
-                    <Text style={{ fontSize: 10, fontWeight: '600', color: safety.score <= 2 ? '#4ade80' : safety.score <= 3 ? '#facc15' : '#f87171' }}>
-                      {safety.score <= 2 ? 'Safe' : safety.score <= 3 ? 'Caution' : 'Danger'} ({safety.score})
-                    </Text>
-                  </View>
-                </View>
-              ) : null;
-            })()}
+            {/* Wiki excerpt */}
 
             {wikiText ? (
               <View style={{

--- a/apps/mobile/app/trip/[id]/_layout.tsx
+++ b/apps/mobile/app/trip/[id]/_layout.tsx
@@ -424,7 +424,7 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
         <Text style={{ ...TextStyles.xs, fontWeight: '700', letterSpacing: 3, textTransform: 'uppercase', color: '#c8a96a', marginBottom: 4 }}>
           {countryName || 'Your Trip Guide'}
         </Text>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 6 }}>
           <Text style={{
             ...TextStyles.display, color: '#fff',
             textShadowColor: 'rgba(0,0,0,0.5)', textShadowOffset: { width: 0, height: 2 }, textShadowRadius: 12,
@@ -433,55 +433,72 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
           </Text>
           <Pressable
             onPress={() => setEssentialsOpen(!essentialsOpen)}
+            hitSlop={8}
             style={({ pressed }) => ({
               flexDirection: 'row', alignItems: 'center', gap: 5,
-              backgroundColor: 'rgba(255,255,255,0.12)', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 16,
-              borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)',
+              backgroundColor: 'rgba(255,255,255,0.15)', paddingHorizontal: 14, paddingVertical: 8, borderRadius: 20,
+              borderWidth: 1, borderColor: 'rgba(255,255,255,0.2)',
               opacity: pressed ? 0.7 : 1,
             })}
           >
-            <FontAwesome name={essentialsOpen ? 'eye-slash' : 'eye'} size={10} color="rgba(255,255,255,0.7)" />
-            <Text style={{ ...TextStyles.xs, fontWeight: '600', letterSpacing: 0.5, color: 'rgba(255,255,255,0.85)' }}>
-              {essentialsOpen ? 'Hide' : 'Info'}
+            <FontAwesome name={essentialsOpen ? 'chevron-up' : 'chevron-down'} size={10} color="rgba(255,255,255,0.8)" />
+            <Text style={{ fontSize: 12, fontWeight: '600', letterSpacing: 0.5, color: '#fff' }}>
+              {essentialsOpen ? 'Hide' : 'Show'}
             </Text>
           </Pressable>
         </View>
 
-        {/* Collapsible essentials */}
+        {/* Date + travelers + safety — always visible */}
+        {trip && (
+          <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6, marginBottom: 6 }}>
+            {[
+              formatDateRange(trip.start_date, trip.end_date),
+              `${trip.travelers} ${trip.travelers === 1 ? 'traveler' : 'travelers'}`,
+              qf?.timezone ? (qf.timezone as string).split(' · ')[0] : null,
+            ].filter(Boolean).map((text, i) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center' }}>
+                {i > 0 && <Text style={{ color: 'rgba(255,255,255,0.35)', marginRight: 6 }}>·</Text>}
+                <Text style={{
+                  ...TextStyles.bodyLg, fontWeight: '600', color: '#fff',
+                  textShadowColor: 'rgba(0,0,0,0.8)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6,
+                }}>{text}</Text>
+              </View>
+            ))}
+            {(() => {
+              const safety = trip?.trip_context?.safety as { score: number; message: string } | undefined;
+              if (!safety || safety.score <= 0) return null;
+              const color = safety.score <= 2 ? '#4ade80' : safety.score <= 3 ? '#facc15' : '#f87171';
+              const bg = safety.score <= 2 ? 'rgba(34,197,94,0.25)' : safety.score <= 3 ? 'rgba(234,179,8,0.25)' : 'rgba(239,68,68,0.25)';
+              const border = safety.score <= 2 ? 'rgba(34,197,94,0.5)' : safety.score <= 3 ? 'rgba(234,179,8,0.5)' : 'rgba(239,68,68,0.5)';
+              const label = safety.score <= 2 ? 'Safe' : safety.score <= 3 ? 'Caution' : 'Danger';
+              return (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: bg, borderWidth: 1, borderColor: border, borderRadius: 12, paddingHorizontal: 8, paddingVertical: 2 }}>
+                  <FontAwesome name="shield" size={9} color={color} />
+                  <Text style={{ fontSize: 10, fontWeight: '600', color }}>{label} ({safety.score})</Text>
+                </View>
+              );
+            })()}
+          </View>
+        )}
+
+        {/* Collapsible essentials — extra details */}
         {essentialsOpen && trip && (
           <View>
-            {/* Date + travelers + currency + timezone + safety */}
+            {/* Currency + timezone — expanded details */}
             <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}>
               {[
-                formatDateRange(trip.start_date, trip.end_date),
-                `${trip.travelers} ${trip.travelers === 1 ? 'traveler' : 'travelers'}`,
                 qf?.currency ? (qf.currency as string).split(' · ')[0] : null,
                 qf?.language ? (qf.language as string).split(' · ')[0] : null,
-                qf?.timezone ? (qf.timezone as string).split(' · ')[0] : null,
               ].filter(Boolean).map((text, i) => (
                 <View key={i} style={{ flexDirection: 'row', alignItems: 'center' }}>
                   {i > 0 && <Text style={{ color: 'rgba(255,255,255,0.35)', marginRight: 6 }}>·</Text>}
                   <Text style={{
-                    ...TextStyles.bodyLg, fontWeight: i >= 2 ? '700' : '600',
+                    ...TextStyles.bodyLg, fontWeight: '700',
                     color: '#fff',
                     textShadowColor: 'rgba(0,0,0,0.8)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6,
                   }}>{text}</Text>
                 </View>
               ))}
-              {(() => {
-                const safety = trip?.trip_context?.safety as { score: number; message: string } | undefined;
-                if (!safety || safety.score <= 0) return null;
-                const color = safety.score <= 2 ? '#4ade80' : safety.score <= 3 ? '#facc15' : '#f87171';
-                const bg = safety.score <= 2 ? 'rgba(34,197,94,0.25)' : safety.score <= 3 ? 'rgba(234,179,8,0.25)' : 'rgba(239,68,68,0.25)';
-                const border = safety.score <= 2 ? 'rgba(34,197,94,0.5)' : safety.score <= 3 ? 'rgba(234,179,8,0.5)' : 'rgba(239,68,68,0.5)';
-                const label = safety.score <= 2 ? 'Safe' : safety.score <= 3 ? 'Caution' : 'Danger';
-                return (
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, backgroundColor: bg, borderWidth: 1, borderColor: border, borderRadius: 12, paddingHorizontal: 8, paddingVertical: 2 }}>
-                    <FontAwesome name="shield" size={9} color={color} />
-                    <Text style={{ fontSize: 10, fontWeight: '600', color }}>{label} ({safety.score})</Text>
-                  </View>
-                );
-              })()}
             </View>
 
             {/* Weather + forecast */}

--- a/apps/mobile/app/trip/[id]/_layout.tsx
+++ b/apps/mobile/app/trip/[id]/_layout.tsx
@@ -374,7 +374,7 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
       {/* Background image — fills entire hero, content determines height */}
       <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
         {coverImage ? (
-          <Image source={{ uri: coverImage }} style={{ width: '100%', height: '100%' }} contentFit="cover" transition={600} cachePolicy="memory-disk" />
+          <Image source={{ uri: coverImage, headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} contentFit="cover" transition={600} cachePolicy="memory-disk" />
         ) : (
           <View style={{ flex: 1, backgroundColor: theme.base, alignItems: 'center', justifyContent: 'center' }}>
             <FontAwesome name="picture-o" size={32} color="rgba(255,255,255,0.3)" />
@@ -392,7 +392,7 @@ function TripHero({ trip, refetch }: { trip: Trip | null; refetch: () => void })
 
       {/* Back button */}
       <Pressable
-        onPress={() => router.back()}
+        onPress={() => router.canDismiss() ? router.dismiss() : router.back()}
         style={{
           position: 'absolute', top: 50, left: 14, zIndex: 10,
           width: 34, height: 34, borderRadius: 17,

--- a/apps/mobile/app/trip/[id]/activities.tsx
+++ b/apps/mobile/app/trip/[id]/activities.tsx
@@ -120,7 +120,7 @@ function ActivityCard({
         {/* Full-bleed image */}
         {hasImage ? (
           <Image
-            source={{ uri: item.images[0] }}
+            source={{ uri: item.images[0], headers: { Referer: '' } }}
             style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
             resizeMode="cover"
             onError={() => setImgError(true)}
@@ -328,7 +328,7 @@ function ActivityDetailSheet({
                 {/* Image */}
                 {hasImage ? (
                   <Image
-                    source={{ uri: item.images[0] }}
+                    source={{ uri: item.images[0], headers: { Referer: '' } }}
                     style={{ width: '100%', height: 200 }}
                     resizeMode="cover"
                     onError={() => setImgError(true)}
@@ -525,7 +525,7 @@ function ActivityDetailSheet({
                           >
                             {sim.images.length > 0 ? (
                               <Image
-                                source={{ uri: sim.images[0] }}
+                                source={{ uri: sim.images[0], headers: { Referer: '' } }}
                                 style={{ width: 150, height: 90 }}
                                 resizeMode="cover"
                               />
@@ -687,9 +687,9 @@ function ActivityDetailFooter({
                 })}
               >
                 {sim.images?.length ? (
-                  <Image source={{ uri: sim.images[0] }} style={{ width: 150, height: 90 }} resizeMode="cover" />
+                  <Image source={{ uri: sim.images[0], headers: { Referer: '' } }} style={{ width: 150, height: 90 }} resizeMode="cover" />
                 ) : sim.image ? (
-                  <Image source={{ uri: sim.image }} style={{ width: 150, height: 90 }} resizeMode="cover" />
+                  <Image source={{ uri: sim.image, headers: { Referer: '' } }} style={{ width: 150, height: 90 }} resizeMode="cover" />
                 ) : (
                   <View style={{ width: 150, height: 90, backgroundColor: colors.borderLight, alignItems: 'center', justifyContent: 'center' }}>
                     <FontAwesome name="image" size={20} color={colors.border} />

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -170,7 +170,7 @@ function ImageCarousel({ images, height = 220 }: { images: string[]; height?: nu
 
   return (
     <View style={{ width: '100%', height, backgroundColor: colors.skeleton, position: 'relative' }}>
-      <Image source={{ uri: images[idx] }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+      <Image source={{ uri: images[idx], headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
       {images.length > 1 && (
         <>
           <Pressable
@@ -253,7 +253,7 @@ function RoomSelection({
                 }}
               >
                 <Image
-                  source={{ uri: room.image }}
+                  source={{ uri: room.image, headers: { Referer: '' } }}
                   style={{ width: 80, height: 90 }}
                   resizeMode="cover"
                 />
@@ -553,7 +553,7 @@ function OtherHotelCard({ hotel }: { hotel: { id: string; name: string; stars: n
         borderWidth: 1, borderColor: colors.border, overflow: 'hidden', marginBottom: 10,
       }}
     >
-      <Image source={{ uri: hotel.image }} style={{ width: 90, height: 100 }} resizeMode="cover" />
+      <Image source={{ uri: hotel.image, headers: { Referer: '' } }} style={{ width: 90, height: 100 }} resizeMode="cover" />
       <View style={{ flex: 1, padding: 10, justifyContent: 'space-between' }}>
         <View>
           <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -754,7 +754,7 @@ function BrowseHotelCard({ hotel }: { hotel: { id: string; name: string; stars: 
         borderWidth: 1, borderColor: colors.border, overflow: 'hidden', marginBottom: 10,
       }}
     >
-      <Image source={{ uri: hotel.image }} style={{ width: 110, height: 120 }} resizeMode="cover" />
+      <Image source={{ uri: hotel.image, headers: { Referer: '' } }} style={{ width: 110, height: 120 }} resizeMode="cover" />
       <View style={{ flex: 1, padding: 10, justifyContent: 'space-between' }}>
         <View>
           <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/apps/mobile/app/trip/[id]/index.tsx
+++ b/apps/mobile/app/trip/[id]/index.tsx
@@ -161,11 +161,10 @@ export default function OverviewScreen() {
         showsVerticalScrollIndicator={false}
       >
 
-      {/* Gradient fade from hero into content */}
+      {/* Smooth fade from hero into content */}
       <LinearGradient
-        colors={['transparent', isDark ? 'rgba(13,13,13,0.6)' : 'rgba(248,247,245,0.6)', isDark ? '#0d0d0d' : '#f8f7f5']}
-        locations={[0, 0.4, 1]}
-        style={{ height: 40 }}
+        colors={['transparent', isDark ? '#0d0d0d' : '#f8f7f5']}
+        style={{ height: 20 }}
       />
 
       {/* Opaque content area */}

--- a/apps/mobile/app/trip/[id]/index.tsx
+++ b/apps/mobile/app/trip/[id]/index.tsx
@@ -17,23 +17,25 @@ import { PageTransition } from './_layout';
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const SIDEBAR_W = 30; // matches SIDE_TAB_W in _layout
 const CONTENT_WIDTH = SCREEN_WIDTH - SIDEBAR_W;
-const ACCENT_COLOR = '#c8a96a';
+const ACCENT_COLOR = '#d4b57a';
 const WEB_API = process.env.EXPO_PUBLIC_RECOMMENDATION_API_URL || 'https://api.dev.gotravyl.com';
 
 // ─── Accent label + serif heading ────────────────────────
 const TEXT_SHADOW = { textShadowColor: 'rgba(0,0,0,0.7)', textShadowOffset: { width: 0, height: 1 }, textShadowRadius: 6 } as const;
 
-function SectionHeader({ accent, title }: { accent: string; title: string }) {
+function SectionHeader({ accent, title, dark }: { accent: string; title: string; dark?: boolean }) {
   return (
-    <View style={{ marginBottom: 12 }}>
+    <View style={{ marginBottom: 14 }}>
       <Text style={{
-        ...TextStyles.xs, fontWeight: '700', letterSpacing: 3,
-        textTransform: 'uppercase', color: ACCENT_COLOR, marginBottom: 4,
-        ...TEXT_SHADOW,
+        fontSize: 11, fontWeight: '800', letterSpacing: 3,
+        textTransform: 'uppercase', marginBottom: 4,
+        fontFamily: 'Satoshi-Bold',
+        color: dark ? ACCENT_COLOR : '#6b5a3e',
       }}>{accent}</Text>
       <Text style={{
-        ...TextStyles.headline, fontSize: 22, color: '#fff',
-        ...TEXT_SHADOW,
+        fontSize: 26, lineHeight: 32,
+        fontFamily: 'Satoshi-Light',
+        color: dark ? ACCENT_COLOR : '#1e3a5f',
       }}>{title}</Text>
     </View>
   );
@@ -161,18 +163,18 @@ export default function OverviewScreen() {
 
       {/* Gradient fade from hero into content */}
       <LinearGradient
-        colors={['transparent', isDark ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)', isDark ? 'rgba(0,0,0,0.88)' : 'rgba(255,255,255,0.92)']}
+        colors={['transparent', isDark ? 'rgba(13,13,13,0.6)' : 'rgba(248,247,245,0.6)', isDark ? '#0d0d0d' : '#f8f7f5']}
         locations={[0, 0.4, 1]}
-        style={{ height: 80 }}
+        style={{ height: 40 }}
       />
 
-      {/* Opaque content area — prevents hero bleed between sections */}
-      <View style={{ backgroundColor: isDark ? 'rgba(0,0,0,0.88)' : 'rgba(255,255,255,0.92)' }}>
+      {/* Opaque content area */}
+      <View style={{ backgroundColor: isDark ? '#0d0d0d' : '#f8f7f5' }}>
 
       {/* ─── Things to Do — horizontal scroll cards ───────── */}
       <View>
         <View style={{ paddingHorizontal: 20 }}>
-          <SectionHeader accent="Explore" title="Things to Do" />
+          <SectionHeader dark={isDark} accent="Explore" title="Things to Do" />
         </View>
         {exploreItems.length > 0 ? (
           <ScrollView
@@ -188,7 +190,7 @@ export default function OverviewScreen() {
                 width: CONTENT_WIDTH - 40, height: 240, borderRadius: 14, overflow: 'hidden',
               }}>
                 {item.image ? (
-                  <Image source={{ uri: item.image }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
+                  <Image source={{ uri: item.image, headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
                 ) : (
                   <View style={{ flex: 1, backgroundColor: '#1e3a5f', alignItems: 'center', justifyContent: 'center' }}>
                     <FontAwesome name="compass" size={32} color="rgba(255,255,255,0.3)" />
@@ -215,7 +217,7 @@ export default function OverviewScreen() {
                   <Text style={{
                     ...TextStyles.title, fontSize: 17, color: '#fff', marginBottom: 4,
                   }}>{item.title}</Text>
-                  <Text style={{ ...TextStyles.caption, color: 'rgba(255,255,255,0.6)', lineHeight: 16 }} numberOfLines={2}>
+                  <Text style={{ ...TextStyles.caption, color: 'rgba(255,255,255,0.75)', lineHeight: 16 }} numberOfLines={2}>
                     {item.description}
                   </Text>
                 </View>
@@ -225,7 +227,7 @@ export default function OverviewScreen() {
         ) : (
           <View style={{ paddingHorizontal: 20, paddingVertical: 24, alignItems: 'center' }}>
             <FontAwesome name="compass" size={28} color={isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)'} />
-            <Text style={{ ...TextStyles.caption, color: isDark ? '#7a7268' : '#a39688', marginTop: 8, textAlign: 'center' }}>
+            <Text style={{ ...TextStyles.caption, color: isDark ? '#a09488' : '#8a7e72', marginTop: 8, textAlign: 'center' }}>
               Explore items will appear here once your trip is enriched
             </Text>
           </View>
@@ -237,7 +239,7 @@ export default function OverviewScreen() {
       {/* ─── What's Going On — dark gradient news cards ───── */}
       {news.length > 0 && (
         <View style={{ paddingHorizontal: 20, marginTop: 8 }}>
-          <SectionHeader accent="What's Happening" title="What's Going On" />
+          <SectionHeader dark={isDark} accent="What's Happening" title="What's Going On" />
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -271,12 +273,12 @@ export default function OverviewScreen() {
                       {item.source ? <Text style={{ opacity: 0.5 }}> · {item.source}</Text> : null}
                     </Text>
                     <Text style={{
-                      ...TextStyles.subhead, fontSize: 15, fontFamily: FontFamily.serif,
+                      ...TextStyles.subhead, fontSize: 16, fontFamily: FontFamily.serif,
                       fontWeight: '700',
-                      color: 'rgba(255,255,255,0.9)', lineHeight: 20, marginBottom: 6,
+                      color: '#fff', lineHeight: 21, marginBottom: 6,
                     }} numberOfLines={2}>{item.title}</Text>
                     <Text style={{
-                      ...TextStyles.caption, color: 'rgba(255,255,255,0.5)', lineHeight: 16,
+                      ...TextStyles.caption, color: 'rgba(255,255,255,0.65)', lineHeight: 17,
                     }} numberOfLines={2}>{item.snippet}</Text>
                   </LinearGradient>
                 </Pressable>
@@ -290,7 +292,7 @@ export default function OverviewScreen() {
       {(ctx?.cuisine ?? []).length > 0 && (
         <View style={{ marginTop: 24 }}>
           <View style={{ paddingHorizontal: 20 }}>
-            <SectionHeader accent="Local Cuisine" title="Must-Try Dishes" />
+            <SectionHeader dark={isDark} accent="Local Cuisine" title="Must-Try Dishes" />
           </View>
           <ScrollView
             horizontal
@@ -305,7 +307,7 @@ export default function OverviewScreen() {
                 width: CONTENT_WIDTH - 40, height: 240, borderRadius: 14, overflow: 'hidden',
               }}>
                 {dish.image ? (
-                  <Image source={{ uri: dish.image }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
+                  <Image source={{ uri: dish.image, headers: { Referer: '' } }} style={{ width: '100%', height: '100%' }} contentFit="cover" />
                 ) : (
                   <View style={{ flex: 1, backgroundColor: '#1e3a5f', alignItems: 'center', justifyContent: 'center' }}>
                     <FontAwesome name="cutlery" size={28} color="rgba(255,255,255,0.3)" />
@@ -327,7 +329,7 @@ export default function OverviewScreen() {
       {/* ─── Essential Phrases — vertical scroll, 2 per row ── */}
       {phrases.length > 0 && (
         <View style={{ marginTop: 24, paddingHorizontal: 20 }}>
-          <SectionHeader accent={ctx?.country?.language || 'Local Language'} title="Essential Phrases" />
+          <SectionHeader dark={isDark} accent={ctx?.country?.language || 'Local Language'} title="Essential Phrases" />
           <View style={{
             height: 52 * 2 + 8, // 2 visible rows + gap
             borderRadius: 12, overflow: 'hidden',
@@ -349,12 +351,12 @@ export default function OverviewScreen() {
                     return (
                       <View key={colIdx} style={{
                         flex: 1,
-                        backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.03)',
+                        backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
                         borderRadius: 10, paddingHorizontal: 12, paddingVertical: 10,
-                        borderWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+                        borderWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
                       }}>
-                        <Text style={{ ...TextStyles.xs, color: isDark ? '#9e9689' : '#7a6e63', marginBottom: 2 }}>{en}</Text>
-                        <Text style={{ ...TextStyles.bodyEm, fontWeight: '700', color: ACCENT_COLOR, fontFamily: FontFamily.serif }} numberOfLines={1}>{local}</Text>
+                        <Text style={{ fontSize: 11, color: isDark ? 'rgba(255,255,255,0.5)' : '#8a7e72', marginBottom: 2 }}>{en}</Text>
+                        <Text style={{ fontSize: 15, fontWeight: '600', color: isDark ? ACCENT_COLOR : '#1e3a5f', fontFamily: FontFamily.serif }} numberOfLines={1}>{local}</Text>
                       </View>
                     );
                   })}
@@ -368,19 +370,20 @@ export default function OverviewScreen() {
       {/* ─── Cost of Living ────────────────────────────────── */}
       {costItems.length > 0 && (
         <View style={{ marginTop: 24, paddingHorizontal: 20 }}>
-          <SectionHeader accent="Budget" title="Cost of Living" />
+          <SectionHeader dark={isDark} accent="Budget" title="Cost of Living" />
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {costItems.map((item, idx) => (
               <View key={idx} style={{
                 width: '31%', alignItems: 'center',
-                backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
-                borderRadius: 10, paddingVertical: 10, paddingHorizontal: 4,
+                backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
+                borderRadius: 10, paddingVertical: 12, paddingHorizontal: 4,
+                borderWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
               }}>
-                <FontAwesome name={item.icon} size={14} color={ACCENT_COLOR} style={{ marginBottom: 4 }} />
-                <Text style={{ ...TextStyles.body, fontWeight: '700', color: '#fff', fontSize: 13 }} numberOfLines={1}>
+                <FontAwesome name={item.icon} size={14} color={isDark ? ACCENT_COLOR : '#8b7355'} style={{ marginBottom: 6 }} />
+                <Text style={{ fontFamily: 'Satoshi-Bold', fontSize: 15, color: isDark ? '#fff' : '#1e3a5f' }} numberOfLines={1}>
                   {currencySymbol}{typeof item.value === 'number' ? item.value.toFixed(2) : item.value}
                 </Text>
-                <Text style={{ ...TextStyles.xs, color: isDark ? '#7a7268' : '#a39688', textAlign: 'center', marginTop: 2, fontSize: 10 }}>{item.label}</Text>
+                <Text style={{ fontSize: 10, color: isDark ? 'rgba(255,255,255,0.45)' : '#8a7e72', textAlign: 'center', marginTop: 2 }}>{item.label}</Text>
               </View>
             ))}
           </View>
@@ -390,19 +393,20 @@ export default function OverviewScreen() {
       {/* ─── Nearby Cities / Day Trips ─────────────────────── */}
       {(ctx?.nearby_cities ?? []).length > 0 && (
         <View style={{ marginTop: 24, paddingHorizontal: 20 }}>
-          <SectionHeader accent="Day Trips" title="Also Consider Visiting" />
+          <SectionHeader dark={isDark} accent="Day Trips" title="Also Consider Visiting" />
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 10 }}>
             {(ctx.nearby_cities as any[]).map((city: any) => (
               <View key={city.id || city.name} style={{
                 width: (SCREEN_WIDTH - 50) / 2,
-                backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
+                backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
                 borderRadius: 12, padding: 14,
+                borderWidth: 1, borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
               }}>
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-                  <FontAwesome name="map-marker" size={12} color={ACCENT_COLOR} />
-                  <Text style={{ ...TextStyles.bodyLg, fontWeight: '700', color: '#fff' }}>{city.name}</Text>
+                  <FontAwesome name="map-marker" size={12} color={isDark ? ACCENT_COLOR : '#8b7355'} />
+                  <Text style={{ ...TextStyles.bodyLg, fontWeight: '700', color: isDark ? '#fff' : '#1e3a5f' }}>{city.name}</Text>
                 </View>
-                {city.country && <Text style={{ ...TextStyles.xs, color: isDark ? '#7a7268' : '#a39688' }}>{city.country}</Text>}
+                {city.country && <Text style={{ ...TextStyles.xs, color: isDark ? 'rgba(255,255,255,0.45)' : '#8a7e72' }}>{city.country}</Text>}
                 {city.distance && <Text style={{ ...TextStyles.xs, fontWeight: '600', color: ACCENT_COLOR, marginTop: 4 }}>{Math.round(city.distance)} km away</Text>}
               </View>
             ))}
@@ -419,14 +423,14 @@ export default function OverviewScreen() {
         return (
           <View style={{ height: 360, overflow: 'hidden' }}>
             <Image
-              source={{ uri: heroUrl.includes?.('googleusercontent.com') ? heroUrl.replace(/=w\d+-h\d+[^&]*/, '=w1200-h800-k-no') : heroUrl }}
+              source={{ uri: heroUrl.includes?.('googleusercontent.com') ? heroUrl.replace(/=w\d+-h\d+[^&]*/, '=w1200-h800-k-no') : heroUrl, headers: { Referer: '' } }}
               style={{ width: '100%', height: '100%' }}
               contentFit="cover"
               contentPosition="bottom"
               cachePolicy="memory-disk"
             />
             <LinearGradient
-              colors={[isDark ? 'rgba(0,0,0,0.88)' : 'rgba(255,255,255,0.92)', 'rgba(0,0,0,0.3)', 'transparent']}
+              colors={[isDark ? '#0d0d0d' : '#f8f7f5', 'rgba(0,0,0,0.3)', 'transparent']}
               locations={[0, 0.35, 0.7]}
               style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '100%' }}
               pointerEvents="none"

--- a/apps/mobile/components/PlaceCard.tsx
+++ b/apps/mobile/components/PlaceCard.tsx
@@ -107,14 +107,14 @@ function CardFrontInternal({
         images.length > 1 ? (
           <>
             <Animated.View style={[{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }, animStyleA]}>
-              <Image source={{ uri: imgA ?? undefined }} style={{ width, height }} resizeMode="cover" />
+              <Image source={{ uri: imgA ?? undefined, headers: { Referer: '' } }} style={{ width, height }} resizeMode="cover" />
             </Animated.View>
             <Animated.View style={[{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }, animStyleB]}>
-              <Image source={{ uri: imgB ?? undefined }} style={{ width, height }} resizeMode="cover" />
+              <Image source={{ uri: imgB ?? undefined, headers: { Referer: '' } }} style={{ width, height }} resizeMode="cover" />
             </Animated.View>
           </>
         ) : (
-          <Image source={{ uri: images[0] ?? undefined }} style={{ position: 'absolute', width, height }} resizeMode="cover" />
+          <Image source={{ uri: images[0] ?? undefined, headers: { Referer: '' } }} style={{ position: 'absolute', width, height }} resizeMode="cover" />
         )
       ) : (
         /* Placeholder gradient when no image is available */

--- a/apps/mobile/components/itinerary/ActivityCard.tsx
+++ b/apps/mobile/components/itinerary/ActivityCard.tsx
@@ -24,7 +24,7 @@ export function ActivityCard({ activity, onPress, imageUrl }: ActivityCardProps)
         {/* Image area */}
         <View style={{ height: 140, position: 'relative' }}>
           {imageUrl ? (
-            <Image source={{ uri: imageUrl }} style={{ width: '100%', height: 140 }} resizeMode="cover" />
+            <Image source={{ uri: imageUrl, headers: { Referer: '' } }} style={{ width: '100%', height: 140 }} resizeMode="cover" />
           ) : (
             <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: typeColor.bg }}>
               <FontAwesome name="picture-o" size={24} color={typeColor.primary + '30'} />

--- a/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/activities/page.tsx
@@ -9,6 +9,8 @@ import { useItineraryScreen } from '@travyl/shared';
 import { useQuery } from '@tanstack/react-query';
 import type { PlaceItem } from '@travyl/shared';
 import { PinCard, getCardRowSpan } from '@/components/PinCard';
+import { AnimatePresence } from 'motion/react';
+import { PlaceDetailOverlay } from '@/components/PlaceDetailOverlay';
 
 // ─── Config ─────────────────────────────────────────────────
 
@@ -287,6 +289,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
   );
   const [searchQuery, setSearchQuery] = useState('');
   const [favorites, setFavorites] = useState<string[]>([]);
+  const [selectedPlace, setSelectedPlace] = useState<PlaceItem | null>(null);
   const [sortBy, setSortBy] = useState<SortKey>('default');
   const [activeSubcategory, setActiveSubcategory] = useState('');
   const [columnCount, setColumnCount] = useState(3);
@@ -610,6 +613,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
                             index={i}
                             isFavorited={favorites.includes(place.id)}
                             onFavorite={toggleFavorite}
+                            onClick={() => setSelectedPlace(place)}
                             flush
                           />
                         </div>
@@ -633,6 +637,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
                             index={i}
                             isFavorited={favorites.includes(place.id)}
                             onFavorite={toggleFavorite}
+                            onClick={() => setSelectedPlace(place)}
                           />
                         </div>
                       ))}
@@ -689,6 +694,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
                   index={i}
                   isFavorited={favorites.includes(place.id)}
                   onFavorite={toggleFavorite}
+                  onClick={() => setSelectedPlace(place)}
                   flush
                 />
               </div>
@@ -713,6 +719,7 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
                   index={i}
                   isFavorited={favorites.includes(place.id)}
                   onFavorite={toggleFavorite}
+                  onClick={() => setSelectedPlace(place)}
                 />
               </div>
             ))}
@@ -727,6 +734,19 @@ export default function ExplorePage({ params, searchParams }: { params: Promise<
           </div>
         )}
       </div>
+
+      {/* Place detail overlay — same as Places page */}
+      <AnimatePresence>
+        {selectedPlace && (
+          <PlaceDetailOverlay
+            place={selectedPlace}
+            isFavorited={favorites.includes(selectedPlace.id)}
+            onToggleFavorite={() => toggleFavorite(selectedPlace.id)}
+            onClose={() => setSelectedPlace(null)}
+            minimal
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -122,6 +122,10 @@ interface FlightSearchParams {
   date: string;
   passengers: number;
   cabinClass: string;
+  originCity?: string;
+  originCountry?: string;
+  destCity?: string;
+  destCountry?: string;
 }
 
 function useFlightSearch(tripId: string, searchParams?: FlightSearchParams) {
@@ -140,13 +144,19 @@ function useFlightSearch(tripId: string, searchParams?: FlightSearchParams) {
     queryKey: ['flights-search', originAirport, destAirport, departDate, passengers, cabinClass],
     queryFn: async (): Promise<ComparisonFlight[]> => {
       if (!originAirport || (!destAirport && !destination)) return [];
+      // Backend resolves airports from city names, not IATA codes
+      const originCity = searchParams?.originCity || originAirport;
+      const destCity = searchParams?.destCity || destAirport || destination || '';
+      const originCtry = searchParams?.originCountry || 'US';
+      const destCtry = searchParams?.destCountry || destCountry || '';
       const params = new URLSearchParams({
-        origin: originAirport,
-        destination: destAirport || destination || '',
+        origin: originCity,
+        destination: destCity,
         date: departDate,
         passengers: String(passengers),
       });
-      if (destCountry) params.set('destination_country', destCountry);
+      if (originCtry) params.set('origin_country', originCtry);
+      if (destCtry) params.set('destination_country', destCtry);
       if (cabinClass) params.set('cabin', cabinClass);
 
       const res = await fetch(`/api/flights/search?${params}`);
@@ -205,7 +215,9 @@ const collapseVariants = {
    AIRPORT AUTOCOMPLETE INPUT
    ================================================================ */
 
-function AirportInput({ label, value, onChange }: { label: string; value: string; onChange: (code: string) => void }) {
+interface AirportInfo { iata: string; city: string; country: string }
+
+function AirportInput({ label, value, onChange, onSelect }: { label: string; value: string; onChange: (code: string) => void; onSelect?: (info: AirportInfo) => void }) {
   const [query, setQuery] = useState(value || '');
   const [editing, setEditing] = useState(false);
   const [results, setResults] = useState<{ iata: string; name: string; city: string; country: string }[]>([]);
@@ -237,10 +249,64 @@ function AirportInput({ label, value, onChange }: { label: string; value: string
     }, 250);
   }, [query, editing]);
 
+  const [highlightIdx, setHighlightIdx] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  // Reset highlight when results change
+  useEffect(() => { setHighlightIdx(results.length > 0 ? 0 : -1); }, [results]);
+
+  // Position dropdown relative to viewport (escapes overflow:hidden parents)
+  useEffect(() => {
+    if (open && inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setDropdownPos({ top: rect.bottom + 4, left: rect.left, width: Math.max(rect.width, 300) });
+    }
+  }, [open]);
+
+  const selectResult = (r: { iata: string; city?: string; country?: string }) => {
+    onChange(r.iata);
+    setQuery(r.iata);
+    setOpen(false);
+    setEditing(false);
+    selectingRef.current = false;
+    prevValueRef.current = r.iata;
+    if (onSelect && r.city) onSelect({ iata: r.iata, city: r.city, country: r.country || '' });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || results.length === 0) {
+      // Enter with no dropdown → treat typed text as IATA code directly
+      if (e.key === 'Enter' && query.trim()) {
+        onChange(query.trim().toUpperCase());
+        setEditing(false);
+        setOpen(false);
+        (e.target as HTMLInputElement).blur();
+      }
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightIdx(i => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightIdx(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const idx = highlightIdx >= 0 ? highlightIdx : 0;
+      selectResult(results[idx]);
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setEditing(false);
+    }
+  };
+
   return (
     <div className="flex-1 min-w-0 px-4 py-2.5 hover:bg-blue-50/30 dark:hover:bg-white/[0.04] transition-colors relative">
       <p className="text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500">{label}</p>
       <input
+        ref={inputRef}
         type="text"
         value={query}
         onChange={(e) => { setQuery(e.target.value); setEditing(true); }}
@@ -249,27 +315,21 @@ function AirportInput({ label, value, onChange }: { label: string; value: string
           if (selectingRef.current) return;
           setOpen(false);
           setEditing(false);
-          // Restore to last selected value if user cleared without picking
           if (!query.trim()) setQuery(value || '');
         }}
+        onKeyDown={handleKeyDown}
         placeholder="Search airport..."
         className="text-sm font-semibold text-[#2563eb] bg-transparent border-none p-0 w-full focus:outline-none placeholder:text-gray-300 dark:placeholder:text-gray-600"
       />
-      {open && results.length > 0 && (
-        <div className="absolute left-0 right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-white/[0.08] rounded-lg shadow-lg z-50 max-h-48 overflow-auto">
+      {open && results.length > 0 && dropdownPos && (
+        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-white/[0.08] rounded-lg shadow-xl max-h-48 overflow-auto"
+          style={{ position: 'fixed', top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width, zIndex: 9999 }}>
           {results.map((r, i) => (
             <button
               key={`${r.iata}-${i}`}
               onMouseDown={(e) => { e.preventDefault(); selectingRef.current = true; }}
-              onClick={() => {
-                onChange(r.iata);
-                setQuery(r.iata);
-                setOpen(false);
-                setEditing(false);
-                selectingRef.current = false;
-                prevValueRef.current = r.iata;
-              }}
-              className="w-full text-left px-3 py-2 hover:bg-blue-50 dark:hover:bg-white/[0.06] transition-colors flex items-center gap-2"
+              onClick={() => selectResult(r)}
+              className={`w-full text-left px-3 py-2 transition-colors flex items-center gap-2 ${i === highlightIdx ? 'bg-blue-50 dark:bg-white/[0.08]' : 'hover:bg-blue-50 dark:hover:bg-white/[0.06]'}`}
             >
               <span className="text-xs font-bold text-[#2563eb] w-8">{r.iata}</span>
               <span className="text-xs text-gray-600 dark:text-gray-400 truncate">{r.name}</span>
@@ -289,13 +349,15 @@ function AirportInput({ label, value, onChange }: { label: string; value: string
 
 function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearch, defaultOpen }: {
   defaultFrom?: string; defaultTo?: string; defaultTravelers?: number;
-  onSearch?: (params: { origin: string; destination: string; passengers: number; cabinClass: string }) => void;
+  onSearch?: (params: { origin: string; destination: string; passengers: number; cabinClass: string; originCity?: string; originCountry?: string; destCity?: string; destCountry?: string }) => void;
   defaultOpen?: boolean;
 }) {
   const [collapsed, setCollapsed] = useState(!defaultOpen);
   const [showFilters, setShowFilters] = useState(false);
   const [from, setFrom] = useState(defaultFrom || '');
   const [to, setTo] = useState(defaultTo || '');
+  const [fromInfo, setFromInfo] = useState<AirportInfo | null>(null);
+  const [toInfo, setToInfo] = useState<AirportInfo | null>(null);
   const [travelers, setTravelers] = useState(defaultTravelers || 2);
   const [cabinClass, setCabinClass] = useState('economy');
 
@@ -357,7 +419,7 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
               {/* Search strip */}
               <div className="flex flex-col sm:flex-row items-stretch border border-gray-200 dark:border-white/[0.08] rounded-xl overflow-visible bg-white dark:bg-white/[0.03] divide-y sm:divide-y-0 sm:divide-x divide-gray-200 dark:divide-white/[0.08]">
                 {/* From */}
-                <AirportInput label="From" value={from} onChange={setFrom} />
+                <AirportInput label="From" value={from} onChange={setFrom} onSelect={setFromInfo} />
 
                 {/* Swap */}
                 <div className="hidden sm:flex items-center -mx-3 z-10">
@@ -367,7 +429,7 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
                 </div>
 
                 {/* To */}
-                <AirportInput label="To" value={to} onChange={setTo} />
+                <AirportInput label="To" value={to} onChange={setTo} onSelect={setToInfo} />
 
                 {/* Travelers */}
                 <div className="shrink-0 px-4 py-2.5 hover:bg-blue-50/30 dark:hover:bg-white/[0.04] transition-colors">
@@ -394,7 +456,7 @@ function FlightSearchSection({ defaultFrom, defaultTo, defaultTravelers, onSearc
 
                 {/* Search button */}
                 <button
-                  onClick={(e) => { e.stopPropagation(); onSearch?.({ origin: from, destination: to, passengers: travelers, cabinClass }); }}
+                  onClick={(e) => { e.stopPropagation(); onSearch?.({ origin: from, destination: to, passengers: travelers, cabinClass, originCity: fromInfo?.city, originCountry: fromInfo?.country, destCity: toInfo?.city, destCountry: toInfo?.country }); }}
                   className="px-5 py-2.5 text-xs text-white bg-[#2563eb] hover:bg-[#1d4ed8] transition-colors shrink-0 flex items-center gap-1.5 justify-center sm:rounded-r-xl font-medium"
                 >
                   <Search size={13} />
@@ -794,7 +856,9 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
   const [searchParams, setSearchParams] = useState<FlightSearchParams | undefined>(undefined);
   const { flights: searchedFlights, isLoading: searchingFlights } = useFlightSearch(id, searchParams);
 
-  const destination = trip?.destination?.split(',')[0]?.trim();
+  const destParts = (trip?.destination || '').split(',');
+  const destination = destParts[0]?.trim();
+  const tripDestCountry = destParts.slice(1).join(',').trim() || '';
   const [defaultTo, setDefaultTo] = useState<string | undefined>(undefined);
   const [defaultFrom, setDefaultFrom] = useState<string>('');
   const defaultTravelers = trip?.travelers || 1;
@@ -836,13 +900,17 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
     return () => { cancelled = true; };
   }, []);
 
-  const handleSearch = (params: { origin: string; destination: string; passengers: number; cabinClass: string }) => {
+  const handleSearch = (params: { origin: string; destination: string; passengers: number; cabinClass: string; originCity?: string; originCountry?: string; destCity?: string; destCountry?: string }) => {
     setSearchParams({
       origin: params.origin,
       destination: params.destination,
       date: trip?.start_date || new Date(Date.now() + 14 * 86400000).toISOString().slice(0, 10),
       passengers: params.passengers,
       cabinClass: params.cabinClass,
+      originCity: params.originCity,
+      originCountry: params.originCountry,
+      destCity: params.destCity || destination,
+      destCountry: params.destCountry || tripDestCountry,
     });
   };
 

--- a/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/itinerary/page.tsx
@@ -207,17 +207,23 @@ function GlanceView({
   // Fetch destination-specific images from Unsplash/Pexels
   const destImages = useDestinationImages(destination, Math.max(days.length, 3));
 
-  // Sync scroll position when selectedDayIndex changes from external source (day pills)
-  useEffect(() => {
-    scrollTo(selectedDayIndex);
-  }, [selectedDayIndex]);
+  // Prevent scroll→onSelectDay feedback loop when programmatically scrolling
+  const isScrollingRef = useRef(false);
 
-  const scrollTo = (idx: number) => {
+  const scrollTo = useCallback((idx: number) => {
     const el = scrollRef.current;
     if (!el) return;
     const card = el.children[idx] as HTMLElement;
-    if (card) card.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
-  };
+    if (!card) return;
+    isScrollingRef.current = true;
+    card.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
+    setTimeout(() => { isScrollingRef.current = false; }, 400);
+  }, []);
+
+  // Sync scroll position when selectedDayIndex changes from external source (day pills)
+  useEffect(() => {
+    scrollTo(selectedDayIndex);
+  }, [selectedDayIndex, scrollTo]);
 
   const onMouseDown = (e: React.MouseEvent) => {
     const el = scrollRef.current;
@@ -245,6 +251,7 @@ function GlanceView({
       <div ref={scrollRef}
         className="flex gap-0 overflow-x-auto scrollbar-hide snap-x snap-mandatory cursor-grab select-none"
         onScroll={(e) => {
+          if (isScrollingRef.current) return;
           const el = e.currentTarget;
           const idx = Math.round(el.scrollLeft / ((el.firstElementChild as HTMLElement)?.offsetWidth || 1));
           onSelectDay(Math.min(idx, days.length - 1));
@@ -1251,14 +1258,14 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
                 dragOverIdx === i ? 'ring-2 ring-gray-400 dark:ring-white/40 scale-105' : ''
               } ${
                 i === selectedDayIndex
-                  ? 'bg-gray-100 dark:bg-white/[0.15] border-gray-300 dark:border-white/[0.25]'
+                  ? 'bg-gray-800 dark:bg-white/[0.15] border-gray-700 dark:border-white/[0.25] shadow-sm'
                   : dragOverIdx === i
-                    ? 'bg-gray-50 dark:bg-white/[0.08] border-transparent'
-                    : 'bg-transparent border-transparent'
+                    ? 'bg-gray-100 dark:bg-white/[0.08] border-transparent'
+                    : 'bg-white/60 dark:bg-transparent border-gray-200 dark:border-transparent hover:bg-white/80 dark:hover:bg-white/[0.06]'
               }`}
             >
-              <span className="block text-[10px] font-bold text-gray-500 dark:text-white/50">{d.dayLabel.replace('Day ', 'D')}</span>
-              <span className="block text-[11px] font-medium text-gray-800 dark:text-white/80">{d.dateLabel.replace(/,.*/, '')}</span>
+              <span className={`block text-[10px] font-bold ${i === selectedDayIndex ? 'text-gray-300 dark:text-white/50' : 'text-gray-500 dark:text-white/50'}`}>{d.dayLabel.replace('Day ', 'D')}</span>
+              <span className={`block text-[11px] font-medium ${i === selectedDayIndex ? 'text-white dark:text-white/80' : 'text-gray-700 dark:text-white/80'}`}>{d.dateLabel.replace(/,.*/, '')}</span>
             </button>
           ))}
         </div>
@@ -1266,14 +1273,13 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
         {/* ── AT A GLANCE section ── */}
         <section>
           <div className="mb-4 flex items-end justify-between">
-            <div className="flex items-center gap-3">
-              <div>
-                <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-white/70">Your Itinerary</p>
-                <h2 className="text-2xl sm:text-3xl font-normal text-gray-900 dark:text-white tracking-wide font-serif">At a Glance</h2>
-              </div>
-              <TripHistoryToggle tripId={id} variant="pill" dark />
+            <div>
+              <p className="text-[10px] tracking-[0.3em] uppercase font-semibold mb-1 text-gray-500 dark:text-white/70">Your Itinerary</p>
+              <h2 className="text-2xl sm:text-3xl font-normal text-gray-800 dark:text-white tracking-wide font-serif">At a Glance</h2>
             </div>
-            <div className="relative shrink-0 mr-2" ref={regenMenuRef}>
+            <div className="flex items-center gap-2 shrink-0">
+              <TripHistoryToggle tripId={id} variant="pill" />
+              <div className="relative shrink-0" ref={regenMenuRef}>
               <button
                 onClick={() => !regenerating && setRegenMenuOpen(v => !v)}
                 disabled={regenerating}
@@ -1373,6 +1379,7 @@ export default function Itinerary({ params }: { params: Promise<{ id: string }> 
               >
                 <Map size={13} />
               </button>
+            </div>
             </div>
           </div>
 

--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -8,7 +8,6 @@ import type { TripContextData, PlaceItem } from '@travyl/shared';
 import { AnimatePresence } from 'motion/react';
 import { PlaceDetailOverlay } from '@/components/PlaceDetailOverlay';
 import { TripExploreSection } from './trip-layout-inner';
-import { PlaceDetailModal } from '@/components/trip/PlaceDetailModal';
 
 // Hide broken images — no misleading fallback photos
 const handleImgError = (e: React.SyntheticEvent<HTMLImageElement>) => {
@@ -127,7 +126,7 @@ function ThingsToDoSection({ items, addedItems, onToggleAdd, onItemClick }: {
             {items.map((item) => (
               <div key={item.id} onClick={() => onItemClick?.(item)} className="relative flex-shrink-0 w-full rounded-xl overflow-hidden snap-start cursor-pointer" style={{ height: 360 }}>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={item.image || undefined} alt={item.title} className="absolute inset-0 w-full h-full object-cover" onError={handleImgError} />
+                <img src={item.image || undefined} alt={item.title} className="absolute inset-0 w-full h-full object-cover" onError={handleImgError} referrerPolicy="no-referrer" />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                 <div className="absolute top-3 left-3">
                   <span className="text-[9px] uppercase tracking-wider font-semibold px-2.5 py-1 rounded-full backdrop-blur-md bg-black/30 text-white border border-white/20">
@@ -271,7 +270,7 @@ function WhatsGoingOnSection({ addedItems, onToggleAdd, exploreItems, heroImages
               {bgImage ? (
                 <>
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={bgImage} alt={item.title} className="absolute inset-0 w-full h-full object-cover" style={{ objectPosition: 'center 30%' }} onError={handleImgError} />
+                  <img src={bgImage} alt={item.title} className="absolute inset-0 w-full h-full object-cover" style={{ objectPosition: 'center 30%' }} onError={handleImgError} referrerPolicy="no-referrer" />
                   <div className="absolute inset-0" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.95) 0%, rgba(0,0,0,0.7) 35%, rgba(0,0,0,0.15) 60%, transparent 100%)' }} />
                 </>
               ) : (
@@ -792,7 +791,7 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
                           phone: r.phone, hours: r.hours, priceLevel: r.priceLevel,
                         })}>
                         {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src={r.image} alt={r.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" onError={handleImgError} />
+                        <img src={r.image} alt={r.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" onError={handleImgError} referrerPolicy="no-referrer" />
                         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
                         {/* Add to trip button */}
                         <div className="absolute top-3 right-3 z-10" onClick={(e) => e.stopPropagation()}>

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -12,7 +12,7 @@ import { ItineraryProvider, useItineraryContext } from '@/components/itinerary/I
 import { TripThemeProvider } from '@/components/trip/TripThemeContext';
 import { CompactTripHeader } from '@/components/trip/CompactTripHeader';
 import { TripMagazineHero } from '@/components/trip/TripMagazineHero';
-import { PlaceDetailModal } from '@/components/trip/PlaceDetailModal';
+import { PlaceDetailOverlay } from '@/components/PlaceDetailOverlay';
 import { TripOnboardingBanner } from '@/components/trip/TripOnboardingBanner';
 import { useTripSettingsRegistration } from '@/stores/tripSettingsStore';
 import { useQuery } from '@tanstack/react-query';
@@ -112,35 +112,48 @@ export function TripExploreSection({ trip, embedded }: { trip: Trip | null; embe
     reviewCount: p.reviewCount, priceLevel: p.priceLevel,
   });
 
-  // Fetch places across all categories the API supports — uses lat/lng + category param
+  // Fetch places across Foursquare categories + SerpAPI text search for diversity
   const { data: liveCategories, isLoading: liveFetching } = useQuery({
     queryKey: ['explore-section', trip?.id, city, lat, lng],
     queryFn: async () => {
       if (!city && !lat) return [];
       // Wait a tick so overview sections render first — then we can scan their names
       await new Promise(r => setTimeout(r, 500));
-      // First: discover available categories by fetching with text query
-      const discoveryRes = await fetch(`/api/places?q=${encodeURIComponent(city)}&limit=30${coordParams}`);
-      const discoveryPlaces: any[] = discoveryRes.ok ? await discoveryRes.json() : [];
 
-      // Extract unique category params from what came back, plus use nearby endpoint
-      const seenCats = new Set(discoveryPlaces.map((p: any) => p.type || '').filter(Boolean));
-      // Also fetch from the nearby endpoint which returns different (Foursquare) results
-      const nearbyCats = lat && lng ? ['sightseeing', 'restaurant', 'nightlife', 'shopping', 'park', 'museum'] : [];
-      const nearbyResults = await Promise.all(
-        nearbyCats.map(async (cat) => {
+      // Categories that produce distinct Foursquare results → display label
+      const catLabel: Record<string, string> = {
+        sightseeing: 'Landmark', restaurant: 'Culinary', nightlife: 'Nightlife',
+        shopping: 'Shopping', cafe: 'Cafes', entertainment: 'Entertainment',
+      };
+
+      // Nearby Foursquare fetches — reliable, category-specific results
+      const nearbyResults = lat && lng ? await Promise.all(
+        Object.entries(catLabel).map(async ([api, label]) => {
           try {
-            const res = await fetch(`/api/places?lat=${lat}&lng=${lng}&category=${cat}&limit=15`);
+            const res = await fetch(`/api/places?lat=${lat}&lng=${lng}&category=${api}&limit=20`);
             if (!res.ok) return [];
-            return res.json();
+            const places = await res.json();
+            return (places as any[]).map((p: any) => ({ ...p, category: label }));
+          } catch { return []; }
+        })
+      ) : [];
+
+      // Text search supplements with SerpAPI results (different source when available)
+      // Uses category-specific queries for diversity; falls back to Foursquare if SerpAPI unavailable
+      const textCats = ['sightseeing', 'dining', 'nightlife', 'cultural', 'shopping', 'museum', 'cafe'];
+      const textResults = await Promise.all(
+        textCats.map(async (cat) => {
+          try {
+            const res = await fetch(`/api/places?q=${encodeURIComponent(city)}&category=${cat}&limit=15${coordParams}`);
+            if (!res.ok) return [];
+            return (await res.json()) as any[];
           } catch { return []; }
         })
       );
 
       // Merge all results, deduplicate by normalized name, group by display category
-      const allPlaces = [...discoveryPlaces, ...nearbyResults.flat()];
+      const allPlaces = [...nearbyResults.flat(), ...textResults.flat()];
       const normalize = (n: string) => n.toLowerCase().replace(/[®™''""·\-–—]/g, '').replace(/\s+/g, ' ').trim();
-      // Start with names already shown in overview sections above (scan DOM at fetch time)
       const seen = getAboveNames();
       const grouped: Record<string, ExploreItem[]> = {};
       for (const p of allPlaces) {
@@ -156,7 +169,8 @@ export function TripExploreSection({ trip, embedded }: { trip: Trip | null; embe
       }
 
       return Object.entries(grouped)
-        .filter(([, items]) => items.length >= 3)
+        .filter(([, items]) => items.length >= 2)
+        .sort(([, a], [, b]) => b.length - a.length)
         .map(([key, items]) => ({ key, label: `${key} in ${city}`, items }));
     },
     enabled: !!(city || lat),
@@ -273,7 +287,7 @@ export function TripExploreSection({ trip, embedded }: { trip: Trip | null; embe
                 <div key={`${item.id}-${idx}`} onClick={() => setSelectedPlace(toPlaceItem(item))}
                   className="relative flex-shrink-0 w-[220px] rounded-2xl overflow-hidden shadow-lg group cursor-pointer hover:shadow-xl transition-shadow" style={{ height: 280 }}>
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={item.image!} alt={item.title || item.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" onError={() => onImgError(item.id)} />
+                  <img src={item.image!} alt={item.title || item.name} className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" onError={() => onImgError(item.id)} referrerPolicy="no-referrer" />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                   <button onClick={(e) => { e.stopPropagation(); setFavorites((prev) => prev.includes(item.id) ? prev.filter((f) => f !== item.id) : [...prev, item.id]); }}
                     className={`absolute top-2.5 right-2.5 w-8 h-8 rounded-full backdrop-blur-sm flex items-center justify-center shadow-sm hover:scale-110 transition-transform z-10 ${favorites.includes(item.id) ? 'bg-red-500' : 'bg-black/30'}`}>
@@ -302,9 +316,9 @@ export function TripExploreSection({ trip, embedded }: { trip: Trip | null; embe
         })}
       </div>
       {selectedPlace && (
-        <PlaceDetailModal place={selectedPlace} isFavorited={favorites.includes(selectedPlace.id)}
+        <PlaceDetailOverlay place={selectedPlace} isFavorited={favorites.includes(selectedPlace.id)}
           onToggleFavorite={() => setFavorites((prev) => prev.includes(selectedPlace.id) ? prev.filter((f) => f !== selectedPlace.id) : [...prev, selectedPlace.id])}
-          onClose={() => setSelectedPlace(null)} />
+          onClose={() => setSelectedPlace(null)} minimal />
       )}
     </div>
   );
@@ -439,42 +453,21 @@ function TripLayoutContent({
   const hasMarkers = mapMarkers.length > 0;
   const dir = directionRef.current;
 
-  // Skip fancy animation when coming from/going to calendar — it causes a jarring flash
+  // Track if we just came from/going to calendar to suppress the inner tab animation
+  // (the outer layout crossfade already handles the transition)
   const wasCalendarRef = useRef(isCalendar);
   useEffect(() => { wasCalendarRef.current = isCalendar; }, [isCalendar]);
-  const skipAnimation = isCalendar || wasCalendarRef.current;
+  const fromCalendar = wasCalendarRef.current && !isCalendar;
 
-  const pageVariants = skipAnimation ? {
-    initial: { opacity: 1 },
-    animate: { opacity: 1 },
-    exit: { opacity: 0 },
-  } : {
-    initial: { opacity: 0, y: dir > 0 ? 20 : -20 },
+  const pageVariants = fromCalendar ? {
+    initial: { opacity: 1, y: 0 },
     animate: { opacity: 1, y: 0 },
     exit: { opacity: 0 },
+  } : {
+    initial: { opacity: 0, y: dir > 0 ? 14 : -14 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: dir > 0 ? -8 : 8 },
   };
-
-  // Calendar gets full-screen layout with hover-reveal sidebar
-  if (isCalendar) {
-    return (
-      <TripThemeProvider trip={trip}>
-        <ItineraryProvider tripId={tripId}>
-          <div className="w-screen overflow-hidden relative" style={{ height: 'calc(100vh - 48px)', marginTop: 48 }}>
-            {/* Hover-reveal sidebar — invisible strip on the left, expands on hover */}
-            <div className="fixed left-0 top-0 bottom-0 z-50 w-3 hover:w-auto group">
-              {/* Thin hover trigger strip */}
-              <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-16 rounded-r-full bg-white/10 group-hover:opacity-0 transition-opacity" />
-              {/* Sidebar — slides in on hover */}
-              <div className="h-full opacity-0 -translate-x-full group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 ease-out pointer-events-none group-hover:pointer-events-auto">
-                <TripTabs tripId={tripId} position="left" dark />
-              </div>
-            </div>
-            {children}
-          </div>
-        </ItineraryProvider>
-      </TripThemeProvider>
-    );
-  }
 
   // Layout toggle button (floating, bottom-right)
   const layoutToggle = (
@@ -501,9 +494,34 @@ function TripLayoutContent({
   );
 
   return (
-    <div
+    <AnimatePresence mode="sync">
+    {isCalendar ? (
+      <motion.div
+        key="calendar-layout"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3, ease: 'easeInOut' }}
+        className="w-screen overflow-hidden relative"
+        style={{ height: 'calc(100vh - 48px)', marginTop: 48, position: 'fixed', inset: 0, top: 48, zIndex: 40 }}
+      >
+        {/* Hover-reveal sidebar — invisible strip on the left, expands on hover */}
+        <div className="fixed left-0 top-0 bottom-0 z-50 w-3 hover:w-auto group">
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-16 rounded-r-full bg-white/10 group-hover:opacity-0 transition-opacity" />
+          <div className="h-full opacity-0 -translate-x-full group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 ease-out pointer-events-none group-hover:pointer-events-auto">
+            <TripTabs tripId={tripId} position="left" dark />
+          </div>
+        </div>
+        {children}
+      </motion.div>
+    ) : (
+    <motion.div
+      key="standard-layout"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
       className={`pb-14 md:pb-0 ${isMagazine ? 'relative' : 'bg-white dark:bg-[var(--background)]'}`}
-      style={{ transition: 'background-color 0.3s ease' }}
     >
       {layoutToggle}
 
@@ -540,9 +558,8 @@ function TripLayoutContent({
                   initial={pageVariants.initial}
                   animate={pageVariants.animate}
                   exit={pageVariants.exit}
-                  transition={{ duration: 0.18, ease: 'easeOut' }}
-                  className={isMagazine && isOverview ? 'pt-2' : ''}
-                  style={undefined}
+                  transition={{ duration: 0.22, ease: [0.25, 0.1, 0.25, 1] }}
+                  className={isMagazine ? (isOverview ? 'pt-2' : 'bg-white/85 backdrop-blur-xl rounded-2xl p-5 sm:p-6 mt-4 mb-8') : ''}
                 >
                   {children}
                 </motion.div>
@@ -639,6 +656,8 @@ function TripLayoutContent({
         <div className="relative z-10 h-40 pointer-events-none"
           style={{ background: 'linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 50%, rgba(0,0,0,0.85) 100%)' }} />
       )}
-    </div>
+    </motion.div>
+    )}
+    </AnimatePresence>
   );
 }

--- a/apps/web/app/api/flights/search/route.ts
+++ b/apps/web/app/api/flights/search/route.ts
@@ -15,8 +15,9 @@ export async function GET(req: NextRequest) {
   const originCountry = getOptionalParam(req, 'origin_country', 'US')
   const destCountry = getOptionalParam(req, 'destination_country', '')
   extra.origin_country = originCountry
-  // If destination_country not provided, use destination as-is (backend can resolve)
-  extra.destination_country = destCountry || params.destination
+  // destination_country is required by backend; use provided value, fall back to empty
+  // (backend resolves IATA codes directly when destination is a 3-letter code)
+  extra.destination_country = destCountry
 
   const returnDate = getOptionalParam(req, 'return', '')
   if (returnDate) extra.return_date = returnDate

--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -5,9 +5,20 @@ import {
   isValidImageUrl,
 } from '@travyl/shared'
 import { filterByRadius } from '@/lib/haversine'
+import { createServerClient } from '@supabase/ssr'
 
 const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const SUPABASE_KEY = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)!
 
+// Map category names that Foursquare doesn't recognise to ones it does
+const FOURSQUARE_CAT_MAP: Record<string, string> = {
+  dining: 'restaurant',
+  cultural: 'museum',
+  outdoor: 'park',
+  tour: 'attraction',
+  all: 'sightseeing',
+}
 
 export async function GET(req: NextRequest) {
   const lat = req.nextUrl.searchParams.get('lat') ?? ''
@@ -25,6 +36,16 @@ export async function GET(req: NextRequest) {
     return NextResponse.json([])
   }
 
+  // Extract auth from Supabase cookies so backend Lambdas can validate the user
+  let authHeader: string | undefined
+  try {
+    const supabase = createServerClient(SUPABASE_URL, SUPABASE_KEY, {
+      cookies: { getAll() { return req.cookies.getAll() }, setAll() {} },
+    })
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session?.access_token) authHeader = `Bearer ${session.access_token}`
+  } catch { /* continue without auth */ }
+
   try {
     let data: BackendPlace[] = []
 
@@ -33,7 +54,7 @@ export async function GET(req: NextRequest) {
     if (q) {
       const nlpRes = await fetch(
         `${API_URL}/places/search?q=${encodeURIComponent(q)}&category=${category}&limit=${limit}&lat=${lat}&lng=${lng}`,
-        { headers: { Accept: 'application/json' } }
+        { headers: { Accept: 'application/json', ...(authHeader ? { Authorization: authHeader } : {}) } }
       )
       if (nlpRes.ok) {
         const nlpData = await nlpRes.json()
@@ -56,7 +77,7 @@ export async function GET(req: NextRequest) {
       if (!data || data.length === 0) {
         // Extract a category hint from the NLP query text for better nearby results
         const qLower = q.toLowerCase()
-        let nearbyCategory = category
+        let nearbyCategory = FOURSQUARE_CAT_MAP[category] ?? category
         if (/restaurant|food|dining|eat/.test(qLower)) nearbyCategory = 'restaurant'
         else if (/nightlife|bar|club|lounge|pub/.test(qLower)) nearbyCategory = 'nightlife'
         else if (/shop|market|mall/.test(qLower)) nearbyCategory = 'shopping'

--- a/apps/web/components/calendar/CalendarDashboard.tsx
+++ b/apps/web/components/calendar/CalendarDashboard.tsx
@@ -583,9 +583,9 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
   }, [moveActivity, updateActivity, queryClient])
 
   // Early returns for loading / error states (must come after all hooks)
-  if (isLoading) return <CalendarSkeleton />
+  if (isLoading) return <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15 }}><CalendarSkeleton /></motion.div>
   if (error) return <CalendarError message={error} />
-  if (!trip) return <CalendarSkeleton />
+  if (!trip) return <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15 }}><CalendarSkeleton /></motion.div>
 
   // Event handlers
   const handleSelectEvent = (id: string, anchorEl?: HTMLElement) => {
@@ -710,7 +710,11 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
     <CalendarThemeContext.Provider value={{ isDark: theme === 'dark' }}>
     <TripPermissionProvider trip={trip!} collaborators={tripCollaborators} isSharedView={isSharedView}>
     <div className={theme === 'dark' ? 'dark' : ''}>
-    <div className={`flex h-full overflow-hidden bg-[var(--cal-bg)] text-[var(--cal-text)]${isResizingPanel ? ' select-none' : ''}`}>
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className={`flex h-full overflow-hidden bg-[var(--cal-bg)] text-[var(--cal-text)]${isResizingPanel ? ' select-none' : ''}`}>
       {/* Main column */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
         {/* Header */}
@@ -964,7 +968,7 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
           )}
         </DndContext>
       </div>
-    </div>
+    </motion.div>
     </div>
     <CardPopover
       anchorEl={popoverAnchor}

--- a/apps/web/components/calendar/providers/YjsTripProvider.tsx
+++ b/apps/web/components/calendar/providers/YjsTripProvider.tsx
@@ -53,28 +53,42 @@ export function YjsTripProvider({ tripId, children }: YjsTripProviderProps) {
   }, [])
 
   useEffect(() => {
-    const provider = new SupabaseProvider(`trip:${tripId}`, doc, supabase, {
-      awareness: true,
-      persistence: {
-        table: 'yjs_documents',
-        roomColumn: 'room',
-        stateColumn: 'state',
-        storeTimeout: 1000,
-      },
-    })
+    let provider: SupabaseProvider | null = null
+    let destroyed = false
 
-    provider.on('status', (status) => {
-      if (status === 'connected') setConnectionStatus('connected')
-      else if (status === 'connecting') setConnectionStatus('reconnecting')
-      else if (status === 'disconnected') setConnectionStatus('disconnected')
-    })
+    try {
+      provider = new SupabaseProvider(`trip:${tripId}`, doc, supabase, {
+        awareness: true,
+        persistence: {
+          table: 'yjs_documents',
+          roomColumn: 'room',
+          stateColumn: 'state',
+          storeTimeout: 1000,
+        },
+      })
 
-    provider.on('error', (err) => {
-      console.error('[YjsTripProvider]', err.message)
-    })
+      provider.on('status', (status) => {
+        if (destroyed) return
+        if (status === 'connected') setConnectionStatus('connected')
+        else if (status === 'connecting') setConnectionStatus('reconnecting')
+        else if (status === 'disconnected') setConnectionStatus('disconnected')
+      })
+
+      provider.on('error', (err) => {
+        // Log once and destroy — prevents infinite reconnect loop when channel is unavailable
+        console.warn('[YjsTripProvider] sync unavailable:', err.message)
+        if (!destroyed && provider) {
+          provider.destroy()
+          provider = null
+        }
+      })
+    } catch (err) {
+      console.warn('[YjsTripProvider] failed to initialise:', err)
+    }
 
     return () => {
-      provider.destroy()
+      destroyed = true
+      provider?.destroy()
     }
   }, [tripId, doc])
 

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -99,8 +99,8 @@ export function CompactTripHeader({
 
   return (
     <div className="relative w-full">
-      {/* Fixed-height hero */}
-      <div className="relative w-full overflow-hidden" style={{ height: 300 }}>
+      {/* Hero — grows when expanded to keep content on the image */}
+      <div className="relative w-full overflow-hidden" style={{ minHeight: 300 }}>
         {/* Background image */}
         {coverImage ? (
           <Image
@@ -118,11 +118,11 @@ export function CompactTripHeader({
 
         {/* Gradient overlay */}
         <div className="absolute inset-0" style={{
-          background: 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.15) 40%, rgba(0,0,0,0.7) 85%, rgba(0,0,0,0.8) 100%)',
+          background: 'linear-gradient(to bottom, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.15) 40%, rgba(0,0,0,0.55) 70%, rgba(0,0,0,0.8) 100%)',
         }} />
 
-        {/* Content */}
-        <div className="relative z-10 h-full flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-[100px] pb-5">
+        {/* Content — all on the hero image */}
+        <div className="relative z-10 flex flex-col justify-end max-w-7xl mx-auto px-6 sm:px-10 md:pl-[100px] pb-5" style={{ minHeight: 300 }}>
           {/* Country tag */}
           <p className="flex items-center gap-2 text-[10px] tracking-[0.3em] uppercase font-semibold mb-1.5 text-white/70">
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -181,6 +181,37 @@ export function CompactTripHeader({
             </div>
           )}
 
+          {/* Expanded details — on the hero image, matching magazine style */}
+          {hasExpandContent && (
+            <div className={`overflow-hidden transition-all duration-300 ease-out ${expanded ? 'max-h-[400px] opacity-100 mt-4' : 'max-h-0 opacity-0'}`}>
+              <div className="flex flex-col gap-2.5">
+                {/* Forecast row */}
+                {forecast && forecast.length > 0 && !isNaN(forecast[0]?.high) && (
+                  <div className="flex flex-wrap items-center gap-3 text-white" style={{ textShadow: '0 2px 10px rgba(0,0,0,0.5)' }}>
+                    {temp != null && (
+                      <span className="text-xl font-semibold tabular-nums">{Math.round(temp)}°</span>
+                    )}
+                    <span className="text-white/20">|</span>
+                    {forecast.slice(0, 5).map((day) => (
+                      <span key={day.date} className="text-[12px] tabular-nums">
+                        <span className="text-white/60">{new Date(day.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' })}</span>{' '}
+                        <span className="font-semibold text-white">{Math.round(day.high)}°</span>
+                        <span className="text-white/50">/{Math.round(day.low)}°</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {/* Wiki */}
+                {wiki && (
+                  <p className="text-[13px] leading-relaxed text-white/80 font-serif line-clamp-4 backdrop-blur-sm bg-black/25 rounded-lg px-4 py-3"
+                    style={{ textShadow: '0 1px 6px rgba(0,0,0,0.4)' }}>
+                    {wiki}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Inline editor */}
           {editing && (
             <div className="flex flex-wrap items-end gap-2.5 mt-2">
@@ -204,36 +235,6 @@ export function CompactTripHeader({
           )}
         </div>
       </div>
-
-      {/* Expanded details — dropdown below header */}
-      {hasExpandContent && (
-        <div className={`relative z-20 px-6 sm:px-10 md:pl-[100px] overflow-hidden transition-all duration-300 ease-out ${expanded ? 'max-h-[400px] opacity-100 py-4' : 'max-h-0 opacity-0'}`}>
-          <div className="max-w-3xl flex flex-col gap-2.5">
-            {/* Forecast row */}
-            {forecast && forecast.length > 0 && !isNaN(forecast[0]?.high) && (
-              <div className="flex items-center gap-3 text-gray-800">
-                {temp != null && (
-                  <span className="text-xl font-semibold tabular-nums">{Math.round(temp)}°</span>
-                )}
-                <span className="text-gray-300">|</span>
-                {forecast.slice(0, 5).map((day) => (
-                  <span key={day.date} className="text-[11px] tabular-nums">
-                    <span className="text-gray-500">{new Date(day.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short' })}</span>{' '}
-                    <span className="font-medium">{Math.round(day.high)}°</span>
-                    <span className="text-gray-400">/{Math.round(day.low)}°</span>
-                  </span>
-                ))}
-              </div>
-            )}
-            {/* Wiki */}
-            {wiki && (
-              <p className="text-[12px] leading-relaxed text-gray-500 font-serif line-clamp-2">
-                {wiki}
-              </p>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/components/trip/PlaceDetailModal.tsx
+++ b/apps/web/components/trip/PlaceDetailModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Heart, MapPin, Star, ExternalLink, Phone, Globe } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import type { PlaceItem } from '@travyl/shared';
@@ -40,7 +41,7 @@ export function PlaceDetailModal({ place, isFavorited = false, onToggleFavorite,
 
   const hasCoords = enrichedPlace.latitude && enrichedPlace.longitude && (enrichedPlace.latitude !== 0 || enrichedPlace.longitude !== 0);
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center" onClick={onClose}>
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
@@ -177,6 +178,7 @@ export function PlaceDetailModal({ place, isFavorited = false, onToggleFavorite,
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/web/components/trip/TripHistoryPanel.tsx
+++ b/apps/web/components/trip/TripHistoryPanel.tsx
@@ -299,10 +299,14 @@ export function TripHistoryToggle({ tripId, variant = 'pill', dark = false }: { 
       <button
         onClick={() => setOpen(!open)}
         className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[11px] font-semibold transition-all duration-200"
-        style={{
+        style={dark ? {
           color: 'rgba(255,255,255,0.85)',
           backgroundColor: open ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.1)',
           border: `1px solid ${open ? 'rgba(255,255,255,0.25)' : 'rgba(255,255,255,0.15)'}`,
+        } : {
+          color: open ? '#1e3a5f' : '#475569',
+          backgroundColor: open ? 'rgba(30,58,95,0.1)' : 'rgba(0,0,0,0.05)',
+          border: `1px solid ${open ? 'rgba(30,58,95,0.25)' : 'rgba(0,0,0,0.12)'}`,
         }}
         title="View trip history"
       >

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -714,6 +714,7 @@ export async function savePlanToSupabase(
   // Save itinerary activities to activity table (powers the calendar)
   onProgress?.('Saving activities...', 90)
   const activityRows: Record<string, unknown>[] = []
+  let sortOrder = 0
   for (const day of cappedItinerary) {
     const dayDate = day.date || ext.dates.start
     for (const slot of day.slots ?? []) {
@@ -730,6 +731,7 @@ export async function savePlanToSupabase(
         latitude: poi.lat || null,
         longitude: poi.lng || null,
         notes: poi.description || null,
+        sort_order: sortOrder++,
         activity_data: {
           category: poi.category,
           location_name: poi.name,

--- a/packages/shared/src/utils/places.ts
+++ b/packages/shared/src/utils/places.ts
@@ -73,13 +73,16 @@ export function mapCategory(cat: string, sub?: string): string {
   const c = (sub ?? cat).toLowerCase();
   if (['restaurant', 'dining'].includes(c)) return 'Culinary';
   if (c === 'cafe') return 'Culinary';
-  if (c === 'bar' || c === 'nightlife') return 'Music Festival';
-  if (c === 'museum') return 'Historical';
+  if (c === 'bar' || c === 'nightlife' || c === 'club') return 'Nightlife';
+  if (c === 'museum' || c === 'gallery') return 'Museum';
+  if (c === 'cultural' || c === 'culture') return 'Arts & Culture';
   if (['attraction', 'landmark', 'monument', 'sightseeing'].includes(c)) return 'Landmark';
-  if (['park', 'garden'].includes(c)) return 'Nature';
+  if (['park', 'garden', 'outdoor'].includes(c)) return 'Nature';
   if (c === 'beach') return 'Coastal';
-  if (c === 'shopping') return 'Market';
-  return 'Cultural';
+  if (c === 'shopping' || c === 'market') return 'Shopping';
+  if (c === 'entertainment' || c === 'theater' || c === 'show') return 'Entertainment';
+  if (c === 'tour' || c === 'experience') return 'Tours';
+  return 'Attraction';
 }
 
 export function mapTags(cat: string, backendTags?: string[], cuisine?: string | null): string[] {
@@ -119,7 +122,7 @@ export function getFallbackImage(_name: string, _idx: number): string {
 
 // ─── Canonical mapper ───────────────────────────────────────
 
-export function mapBackendToPlaceItem(p: BackendPlace, idx = 0, requestedCategory?: string): PlaceItem {
+export function mapBackendToPlaceItem(p: BackendPlace, _idx = 0, requestedCategory?: string): PlaceItem {
   const img = upscaleGoogleImage(p.photo_url);
   return {
     id: p.id,


### PR DESCRIPTION
## Summary
- Web explore section expanded from 19→117 places across 6 categories
- Calendar crossfade animation, Yjs reconnect fix
- Flight search: keyboard nav, city names to backend, dropdown z-index
- Mobile: fixed blank screen after trip back-navigation
- Mobile: Places feed with multi-city discovery, high-res images
- Mobile: trip generation sort_order fix, takeoff animation timing
- Image loading: referrerPolicy/Referer header fix across all components
- Dark/light mode support for trip overview sections

## Test plan
- [ ] Web: explore section shows 6+ categories on trip overview
- [ ] Web: calendar tab transition is smooth crossfade
- [ ] Web: flight search dropdown visible, Enter key works
- [ ] Mobile: navigate to trip detail and back — no blank screen
- [ ] Mobile: Places tab shows 40+ places with images
- [ ] Mobile: generate trip from search — no sort_order error
- [ ] Mobile: trip overview readable in both light and dark mode