### PR TITLE
fix: calendar book/status route type error (TRA-479)

### DIFF
--- a/apps/web/app/api/calendar/book/status/route.ts
+++ b/apps/web/app/api/calendar/book/status/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 import { proxyToBackend } from '@/lib/api-utils'
 
-export async function GET(req: NextRequest, { params }: { params: Promise<{ tripId: string }> }) {
-  const { tripId } = await params
+export async function GET(req: NextRequest) {
+  const tripId = req.nextUrl.searchParams.get('tripId') ?? ''
   return proxyToBackend(`/book/status/${tripId}`, req)
 }


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in `/api/calendar/book/status/route.ts` introduced by PR #509
- Route handler declared `params: Promise<{ tripId: string }>` but the route path has no `[tripId]` dynamic segment, blocking `next build`
- Changed to read `tripId` from query params instead

## Test plan
- [x] `npm run typecheck` passes
- [x] `next build` completes successfully