### PR TITLE
feat: SerpAPI Google Flights search + animation speed (TRA-485)

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -111,10 +111,6 @@ function formatDuration(iso: string): string {
   return `${h}h ${m}m`;
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
-}
 
 interface FlightSearchParams {
   origin: string;
@@ -163,32 +159,50 @@ function useFlightSearch(tripId: string, searchParams?: FlightSearchParams) {
       if (!res.ok) return [];
       const json = await res.json();
 
-      // Backend returns a flat array of flights from SerpAPI
+      // API returns { flights: [...], priceInsights, total }
       const flights = Array.isArray(json) ? json : (json.flights ?? json.results ?? []);
       return flights.map((f: any, i: number): ComparisonFlight => {
-        const depTime = f.departure_time ? formatTime(f.departure_time) : '?';
-        const arrTime = f.arrival_time ? formatTime(f.arrival_time) : '?';
-        const depDate = f.departure_time ? new Date(f.departure_time).getDate() : 0;
-        const arrDate = f.arrival_time ? new Date(f.arrival_time).getDate() : 0;
-        const durationH = Math.floor((f.duration_min || 0) / 60);
-        const durationM = (f.duration_min || 0) % 60;
-        const airlineCode = (f.airline || '??').slice(0, 2).toUpperCase();
+        const legs = f.legs ?? [];
+        const firstLeg = legs[0] ?? {};
+        const lastLeg = legs[legs.length - 1] ?? {};
+        // SerpAPI time format: "2026-05-01 10:28" — extract HH:MM
+        const extractTime = (t: string) => { const m = t?.match(/(\d{1,2}:\d{2})/); return m ? m[1] : '?'; };
+        const depTime = extractTime(firstLeg.departure?.time ?? '');
+        const arrTime = extractTime(lastLeg.arrival?.time ?? '');
+        const depDay = firstLeg.departure?.time ? new Date(firstLeg.departure.time.replace(' ', 'T')).getDate() : 0;
+        const arrDay = lastLeg.arrival?.time ? new Date(lastLeg.arrival.time.replace(' ', 'T')).getDate() : 0;
+        const totalMin = f.totalDuration ?? 0;
+        const durationH = Math.floor(totalMin / 60);
+        const durationM = totalMin % 60;
+        const airline = firstLeg.airline ?? f.airline ?? 'Unknown';
+        const extensions = legs.flatMap((l: any) => l.extensions ?? []);
+        const hasWifi = extensions.some((e: string) => /wi-?fi/i.test(e));
+        const hasPower = extensions.some((e: string) => /power|usb|outlet/i.test(e));
+        const hasMeals = extensions.some((e: string) => /meal|food|dining/i.test(e));
+        const hasEntertainment = extensions.some((e: string) => /stream|video|entertainment/i.test(e));
+        const co2kg = f.carbonEmissions?.this_flight ? Math.round(f.carbonEmissions.this_flight / 1000) : 0;
+        const layoverStr = (f.layovers ?? []).map((l: any) => {
+          const h = Math.floor(l.duration / 60);
+          const m = l.duration % 60;
+          return `${h}h${m > 0 ? ` ${m}m` : ''} ${l.id}`;
+        }).join(', ');
+
         return {
-          id: f.flight_number || `flight-${i}`,
-          airline: f.airline ?? 'Unknown',
-          airlineLogo: airlineCode,
-          flightNumber: f.flight_number ?? '',
-          departure: { time: depTime, airport: f.departure_airport ?? originAirport },
-          arrival: { time: arrTime, airport: f.arrival_airport ?? destAirport ?? '', nextDay: arrDate !== depDate },
+          id: f.id ?? firstLeg.flightNumber ?? `flight-${i}`,
+          airline,
+          airlineLogo: f.airlineLogo ?? firstLeg.airlineLogo ?? '',
+          flightNumber: firstLeg.flightNumber ?? '',
+          departure: { time: depTime, airport: firstLeg.departure?.id ?? originAirport },
+          arrival: { time: arrTime, airport: lastLeg.arrival?.id ?? destAirport ?? '', nextDay: arrDay !== depDay },
           duration: `${durationH}h ${durationM}m`,
           stops: f.stops ?? 0,
-          layover: f.stops > 0 && f.layovers?.length ? `${f.layovers[0]} layover` : null,
+          layover: layoverStr || null,
           price: Math.round(f.price ?? 0),
-          fareClass: cabinClass || 'Economy',
-          amenities: { wifi: false, power: false, meals: false, entertainment: false },
+          fareClass: firstLeg.travelClass ?? (cabinClass || 'Economy'),
+          amenities: { wifi: hasWifi, power: hasPower, meals: hasMeals, entertainment: hasEntertainment },
           onTime: 0,
-          co2: 0,
-          badge: i === 0 ? 'Lowest Price' : f.stops === 0 && i < 3 ? 'Direct' : null,
+          co2: co2kg,
+          badge: f.tier === 'best' && i === 0 ? 'Best' : f.stops === 0 ? 'Direct' : null,
         };
       });
     },

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -670,7 +670,7 @@ export default function Home() {
               loading={i === 0 ? "eager" : "lazy"}
               fetchPriority={i === 0 ? "high" : "low"}
               decoding={i === 0 ? "sync" : "async"}
-              className="absolute inset-0 w-full h-full object-cover transition-opacity duration-[1500ms] ease-in-out"
+              className="absolute inset-0 w-full h-full object-cover transition-opacity duration-700 ease-in-out"
               style={{ opacity: heroSlide % heroSlides.length === i ? 1 : 0 }}
             />
           ))}

--- a/apps/web/app/api/flights/search/route.ts
+++ b/apps/web/app/api/flights/search/route.ts
@@ -1,32 +1,116 @@
-import { NextRequest } from 'next/server'
-import { getRequiredParams, getOptionalParam, proxyToBackend } from '@/lib/api-utils'
+import { NextRequest, NextResponse } from 'next/server'
+import { checkOrigin, rateLimit, CACHE_1H } from '@/lib/api-utils'
+
+const SERPAPI_KEY = process.env.SERPAPI_KEY
+
+const CABIN_MAP: Record<string, number> = {
+  economy: 1,
+  premium_economy: 2,
+  business: 3,
+  first: 4,
+}
 
 export async function GET(req: NextRequest) {
-  const params = getRequiredParams(req, 'origin', 'destination', 'date')
-  if (params instanceof Response) return params
+  const blocked = checkOrigin(req) || rateLimit(req, 'flights-search', 10, 60_000)
+  if (blocked) return blocked
 
-  const extra: Record<string, string> = {
-    origin: params.origin,
-    destination: params.destination,
-    departure_date: params.date,
+  if (!SERPAPI_KEY) {
+    return NextResponse.json({ error: 'Flight search not configured' }, { status: 503 })
   }
 
-  // Backend requires country params — pass through or default
-  const originCountry = getOptionalParam(req, 'origin_country', 'US')
-  const destCountry = getOptionalParam(req, 'destination_country', '')
-  extra.origin_country = originCountry
-  // destination_country is required by backend; use provided value, fall back to empty
-  // (backend resolves IATA codes directly when destination is a 3-letter code)
-  extra.destination_country = destCountry
+  const p = req.nextUrl.searchParams
+  const origin = p.get('origin')
+  const destination = p.get('destination')
+  const date = p.get('date')
 
-  const returnDate = getOptionalParam(req, 'return', '')
-  if (returnDate) extra.return_date = returnDate
+  if (!origin || !destination || !date) {
+    return NextResponse.json({ error: 'Missing origin, destination, or date' }, { status: 400 })
+  }
 
-  const passengers = getOptionalParam(req, 'passengers', '1')
-  extra.passengers = passengers
+  const returnDate = p.get('return') || ''
+  const passengers = p.get('passengers') || '1'
+  const cabin = p.get('class') || p.get('cabin') || 'economy'
 
-  const cabin = getOptionalParam(req, 'cabin', '')
-  if (cabin) extra.travel_class = cabin
+  // Build SerpAPI Google Flights URL
+  const url = new URL('https://serpapi.com/search.json')
+  url.searchParams.set('engine', 'google_flights')
+  url.searchParams.set('departure_id', origin)
+  url.searchParams.set('arrival_id', destination)
+  url.searchParams.set('outbound_date', date)
+  if (returnDate) url.searchParams.set('return_date', returnDate)
+  url.searchParams.set('adults', passengers)
+  url.searchParams.set('travel_class', String(CABIN_MAP[cabin] || 1))
+  url.searchParams.set('currency', 'USD')
+  url.searchParams.set('hl', 'en')
+  url.searchParams.set('api_key', SERPAPI_KEY)
 
-  return proxyToBackend('/api/flights/search', req, { params: extra })
+  try {
+    const res = await fetch(url.toString(), CACHE_1H)
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Flight search failed' }, { status: res.status })
+    }
+
+    const data = await res.json()
+    const bestFlights = data.best_flights ?? []
+    const otherFlights = data.other_flights ?? []
+    const priceInsights = data.price_insights ?? {}
+
+    // Normalize flights into a consistent shape
+    const normalize = (flights: any[], tier: string) =>
+      flights.map((f: any, i: number) => {
+        const legs = f.flights ?? []
+        const firstLeg = legs[0] ?? {}
+
+        return {
+          id: `${tier}-${i}`,
+          tier,
+          price: f.price ?? null,
+          type: f.type ?? 'Round trip',
+          totalDuration: f.total_duration ?? 0,
+          stops: Math.max(0, legs.length - 1),
+          airlineLogo: f.airline_logo ?? firstLeg.airline_logo ?? '',
+          carbonEmissions: f.carbon_emissions ?? null,
+          legs: legs.map((leg: any) => ({
+            flightNumber: leg.flight_number ?? '',
+            airline: leg.airline ?? '',
+            airlineLogo: leg.airline_logo ?? '',
+            airplane: leg.airplane ?? '',
+            travelClass: leg.travel_class ?? 'Economy',
+            legroom: leg.legroom ?? '',
+            duration: leg.duration ?? 0,
+            overnight: leg.overnight ?? false,
+            departure: {
+              airport: leg.departure_airport?.name ?? '',
+              id: leg.departure_airport?.id ?? '',
+              time: leg.departure_airport?.time ?? '',
+            },
+            arrival: {
+              airport: leg.arrival_airport?.name ?? '',
+              id: leg.arrival_airport?.id ?? '',
+              time: leg.arrival_airport?.time ?? '',
+            },
+            extensions: leg.extensions ?? [],
+          })),
+          layovers: (f.layovers ?? []).map((l: any) => ({
+            duration: l.duration ?? 0,
+            airport: l.name ?? '',
+            id: l.id ?? '',
+          })),
+        }
+      })
+
+    const results = [
+      ...normalize(bestFlights, 'best'),
+      ...normalize(otherFlights, 'other'),
+    ]
+
+    return NextResponse.json({
+      flights: results,
+      priceInsights,
+      total: results.length,
+    })
+  } catch (err) {
+    console.error('[flights/search] error:', err)
+    return NextResponse.json({ error: 'Flight search failed' }, { status: 500 })
+  }
 }

--- a/apps/web/components/AnimatedCounter.tsx
+++ b/apps/web/components/AnimatedCounter.tsx
@@ -19,7 +19,7 @@ export function AnimatedCounter({ value, suffix, decimals = 0 }: { value: number
         setHasAnimated(true);
         prevValueRef.current = value;
 
-        const duration = 2000;
+        const duration = 1200;
         const start = performance.now();
 
         const tick = (now: number) => {

--- a/packages/shared/src/hooks/useFlightSearch.ts
+++ b/packages/shared/src/hooks/useFlightSearch.ts
@@ -63,9 +63,9 @@ export function useFlightSearch(params: FlightSearchParams) {
       const qs = new URLSearchParams({
         origin: origin!,
         destination: destination!,
-        depart_date: departDate!,
+        date: departDate!,
       });
-      if (returnDate) qs.set('return_date', returnDate);
+      if (returnDate) qs.set('return', returnDate);
       if (passengers) qs.set('passengers', String(passengers));
       const res = await fetch(`${base}/api/flights/search?${qs}`);
       if (!res.ok) throw new Error('Flight search failed');


### PR DESCRIPTION
## Summary
- **Flight search**: replaced broken Duffel backend proxy with direct SerpAPI Google Flights — returns airline logos, legroom, Wi-Fi, prices, layover details, carbon emissions
- **Animation speed**: hero crossfade 1500ms→700ms, stats counter 2000ms→1200ms
- Merged latest develop

## Test plan
- [ ] Go to a trip → Flights tab → enter origin airport → click Search
- [ ] Verify flight results show with prices, airlines, stops, duration
- [ ] Homepage hero image crossfade feels snappier
- [ ] Stats counter animates faster