### PR TITLE
fix(mobile): add restaurants tab to ALL_TABS and DEFAULT_ENABLED_TABS

### DIFF
--- a/apps/mobile/app/trip/[id]/_layout.tsx
+++ b/apps/mobile/app/trip/[id]/_layout.tsx
@@ -30,6 +30,7 @@ const ALL_TABS = [
   { name: 'itinerary',   title: 'Itinerary',   icon: 'calendar'    },
   { name: 'hotels',      title: 'Hotels',      icon: 'building-o'  },
   { name: 'flights',     title: 'Flights',     icon: 'plane'       },
+  { name: 'restaurants', title: 'Restaurants', icon: 'cutlery'     },
   { name: 'activities',  title: 'Explore',     icon: 'compass'     },
   { name: 'packing',     title: 'Packing',     icon: 'suitcase'    },
   { name: 'budget',      title: 'Budget',      icon: 'pie-chart'   },
@@ -40,7 +41,7 @@ const ALL_TABS = [
 
 const PERMANENT_TAB_NAMES = new Set(['index', 'itinerary']);
 const ADDABLE_TABS = ALL_TABS.filter(t => !PERMANENT_TAB_NAMES.has(t.name));
-const DEFAULT_ENABLED_TABS = ['index', 'itinerary', 'hotels', 'flights', 'activities', 'packing', 'budget', 'cars', 'favorites', 'settings'];
+const DEFAULT_ENABLED_TABS = ['index', 'itinerary', 'hotels', 'flights', 'restaurants', 'activities', 'packing', 'budget', 'cars', 'favorites', 'settings'];
 
 // ─── Types ──────────────────────────────────────────────
 type SpinePosition = 'top' | 'bottom' | 'left' | 'right';


### PR DESCRIPTION
## Summary

The restaurants screen was registered in TopTabs but missing from ALL_TABS, making it unreachable via the custom tab bar.

## Changes
- Added `{ name: 'restaurants', title: 'Restaurants', icon: 'cutlery' }` to ALL_TABS
- Added 'restaurants' to DEFAULT_ENABLED_TABS

## Testing
- Typecheck passed

Fixes #650 item 2 (Restaurants tab is unreachable)