### PR TITLE
fix(calendar): fix For You panel masonry layout with overlapping images

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -193,6 +193,18 @@ body::-webkit-scrollbar {
   50% { opacity: 0; }
 }
 
+/* Masonry layout for For You panel suggestions */
+.masonry-grid {
+  column-count: 2;
+  column-gap: 0.5rem;
+}
+
+.masonry-item {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+}
+
 /* Reveal animations for overview page */
 .reveal-on-scroll {
   opacity: 0;

--- a/apps/web/components/calendar/ForYouPanel.tsx
+++ b/apps/web/components/calendar/ForYouPanel.tsx
@@ -147,11 +147,11 @@ export function ForYouPanel({
       {/* Content area */}
       <div className="h-0 grow overflow-y-auto px-2 pb-3 scrollbar-thin">
         {isLoading ? (
-          <div className="columns-2 gap-2">
+          <div className="masonry-grid">
             {Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="break-inside-avoid mb-2 rounded-[10px] bg-[var(--cal-border)] animate-pulse"
+                className="masonry-item mb-2 rounded-[10px] bg-[var(--cal-border)] animate-pulse"
                 style={{ height: 120 + i * 20 }}
               />
             ))}
@@ -180,7 +180,7 @@ export function ForYouPanel({
           </div>
         ) : (
           <>
-            <div className="columns-2 gap-2">
+            <div className="masonry-grid">
               {enrichedSuggestions.map((suggestion) => (
                 <SuggestionCard
                   key={suggestion.id}

--- a/apps/web/components/calendar/SuggestionCard.tsx
+++ b/apps/web/components/calendar/SuggestionCard.tsx
@@ -105,7 +105,7 @@ export function SuggestionCard({ suggestion, onVisible, onSelect }: SuggestionCa
       onMouseLeave={() => setIsHovered(false)}
       onClick={handleClick}
       className={[
-        'group break-inside-avoid mb-2 rounded-[10px] overflow-hidden cursor-grab active:cursor-grabbing',
+        'group masonry-item mb-2 rounded-[10px] overflow-hidden cursor-grab active:cursor-grabbing',
         'relative transition-all duration-200',
         isDragging ? '' : 'hover:-translate-y-0.5 hover:shadow-[0_6px_24px_rgba(0,0,0,0.4)]',
       ].join(' ')}


### PR DESCRIPTION
## Summary
Fix CSS masonry layout in calendar For You panel where suggestion card images were overlapping and appearing cut off.

## Changes
- Add custom `.masonry-grid` CSS class with `column-count: 2` and proper `column-gap`
- Add `.masonry-item` CSS class with proper vendor prefixes for `break-inside: avoid`
- Update `ForYouPanel.tsx` to use new CSS classes
- Update `SuggestionCard.tsx` to use `masonry-item` class

## Testing
- [ ] Verify For You panel displays cards in 2-column masonry layout
- [ ] Verify images no longer overlap or appear cut off
- [ ] Test in both light and dark mode

🤖 Generated with Claude Code