### PR TITLE
fix: require auth for trips, remove anon code, fix trips page + card drag

### DIFF
--- a/apps/mobile/app/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/(tabs)/(home)/index.tsx
@@ -36,7 +36,7 @@ import {
   FontSize,
   FontFamily,
 } from '@travyl/shared';
-import { savePlanToSupabase, saveAnonTripId } from '@travyl/shared';
+import { savePlanToSupabase } from '@travyl/shared';
 import type { PlaceItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useAddToTrip } from '@/hooks/useAddToTrip';
@@ -376,7 +376,6 @@ export default function HomeScreen() {
       (async () => {
         try {
           const tripId = await savePlanToSupabase(s.plan as any);
-          await saveAnonTripId(tripId);
           // Navigate FIRST while takeoff animation is still covering the screen
           router.push(`/trip/${tripId}` as any);
           // Then clean up after navigation transition starts

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -11,7 +11,9 @@ import { useEffect, useRef } from 'react';
 import 'react-native-reanimated';
 
 import { Text, TextInput } from 'react-native';
-import { useAuthStore } from '@travyl/shared';
+import { useAuthStore, configureSupabase } from '@travyl/shared';
+import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // Set Satoshi as the default font for all Text and TextInput components
 const originalTextRender = (Text as any).render;
@@ -38,6 +40,21 @@ export {
 export const unstable_settings = {
   initialRouteName: '(tabs)',
 };
+
+// Configure Supabase with AsyncStorage for session persistence on mobile
+const mobileSupabase = createClient(
+  process.env.EXPO_PUBLIC_SUPABASE_URL!,
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY || '',
+  {
+    auth: {
+      storage: AsyncStorage,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: false,
+    },
+  }
+);
+configureSupabase(mobileSupabase);
 
 SplashScreen.preventAutoHideAsync();
 

--- a/apps/mobile/components/places/CardStackCarousel.tsx
+++ b/apps/mobile/components/places/CardStackCarousel.tsx
@@ -418,11 +418,12 @@ export function CardStackCarousel({
     PanResponder.create({
       onStartShouldSetPanResponderCapture: () => false,
       onMoveShouldSetPanResponderCapture: (_, gs) => {
-        if (Math.abs(gs.dy) > 10 && Math.abs(gs.dy) > Math.abs(gs.dx) * 1.2) {
+        // Lower threshold for easier vertical dragging
+        if (Math.abs(gs.dy) > 6 && Math.abs(gs.dy) > Math.abs(gs.dx)) {
           gestureDirRef.current = 'v';
           return true;
         }
-        if (Math.abs(gs.dx) > 15 && Math.abs(gs.dx) > Math.abs(gs.dy) * 1.2) {
+        if (Math.abs(gs.dx) > 12 && Math.abs(gs.dx) > Math.abs(gs.dy)) {
           gestureDirRef.current = 'h';
           return true;
         }
@@ -439,8 +440,8 @@ export function CardStackCarousel({
         if (gestureDirRef.current === 'v') {
           const newY = Math.max(SHEET_TOP, sheetYRef.current + gs.dy);
 
-          // Dismiss: dragged past 75% of screen or fast flick down
-          if (newY > SCREEN_H * 0.75 || (gs.vy > 1.5 && newY > SHEET_BOTTOM)) {
+          // Dismiss: dragged past 60% of screen or moderate flick down
+          if (newY > SCREEN_H * 0.6 || (gs.vy > 0.8 && newY > SHEET_BOTTOM)) {
             RNAnimated.timing(sheetY, {
               toValue: SCREEN_H, duration: 200, useNativeDriver: false,
             }).start(() => onCloseRef.current?.());
@@ -515,11 +516,11 @@ export function CardStackCarousel({
             backgroundColor: 'transparent',
           }}
         >
-          {/* Drag handle */}
+          {/* Drag handle — large touch area for easy grabbing */}
           <View style={{
-            alignItems: 'center', paddingTop: 10, paddingBottom: 6,
+            alignItems: 'center', paddingTop: 12, paddingBottom: 10,
           }}>
-            <View style={{ width: 40, height: 5, borderRadius: 3, backgroundColor: 'rgba(255,255,255,0.6)' }} />
+            <View style={{ width: 48, height: 6, borderRadius: 3, backgroundColor: 'rgba(255,255,255,0.7)' }} />
           </View>
 
           {/* Card fills remaining space below handle */}

--- a/apps/mobile/components/trips/CreateTripModal.tsx
+++ b/apps/mobile/components/trips/CreateTripModal.tsx
@@ -11,7 +11,6 @@ import {
   TextStyles, FontSize, FontFamily, Navy,
   useTripPlanner, savePlanToSupabase,
 } from '@travyl/shared';
-import { saveAnonTripId } from '@travyl/shared/src/hooks/useTrips';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PaperPlane } from '@/components/icons/PaperPlane';
 
@@ -92,7 +91,6 @@ export function CreateTripModal({ visible, onClose, prefillPrompt }: CreateTripM
       setSaving(true);
       try {
         const tripId = await savePlanToSupabase(plan as any, () => {});
-        await saveAnonTripId(tripId);
         await queryClient.invalidateQueries({ queryKey: ['trips'] });
         // Pre-fetch the trip data so it's cached before we navigate
         await queryClient.prefetchQuery({

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -21,7 +21,7 @@
 
 'use client';
 
-export { useTrips, saveAnonTripId } from './useTrips';
+export { useTrips } from './useTrips';
 export { useHomeScreen } from './useHomeScreen';
 export { useExploreRows } from './useExploreRows';
 export { useExploreData } from './useExploreData';

--- a/packages/shared/src/hooks/useTrips.ts
+++ b/packages/shared/src/hooks/useTrips.ts
@@ -1,79 +1,19 @@
 /**
  * @module useTrips
- * Fetches all trips accessible to the current user from Supabase.
- * Handles both authenticated users (owned trips + collaborated trips) and
- * anonymous users (trips stored by ID in localStorage/AsyncStorage).
- * Used by the web TripsPage and mobile TripsTab.
+ * Fetches all trips for the current authenticated user from Supabase.
+ * Includes both owned trips and collaborated trips.
  */
 
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
 import { fetchTrips, fetchCollaboratorTrips } from '../services/api';
-import { supabase } from '../services/supabase';
 import { useAuthStore } from '../stores/authStore';
 import type { Trip } from '../types';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-/**
- * Retrieves stored anonymous trip IDs from localStorage (web) or AsyncStorage (mobile).
- * Tries localStorage/sessionStorage first, then falls back to React Native AsyncStorage.
- * @returns Array of trip UUID strings saved locally for anonymous users
- */
-async function getAnonTripIds(): Promise<string[]> {
-  try {
-    const g = globalThis as any;
-    // Web: localStorage/sessionStorage
-    const stored = g.localStorage?.getItem('my-trip-ids')
-      ?? g.sessionStorage?.getItem('my-trip-ids');
-    if (stored) return JSON.parse(stored);
-  } catch {}
-
-  // Mobile: AsyncStorage
-  try {
-    const AsyncStorage = require('@react-native-async-storage/async-storage')?.default;
-    if (AsyncStorage) {
-      const stored = await AsyncStorage.getItem('my-trip-ids');
-      if (stored) return JSON.parse(stored);
-    }
-  } catch {}
-
-  return [];
-}
-
-/**
- * Persists a trip ID for an anonymous (unauthenticated) user so it can be
- * retrieved across page refreshes. Writes to localStorage on web and to
- * AsyncStorage on React Native. Deduplicates before saving.
- * @param tripId - UUID of the trip to save locally
- * @returns Promise that resolves once the ID has been written to all available stores
- * @example
- * ```ts
- * await saveAnonTripId(newTrip.id);
- * ```
- */
-export async function saveAnonTripId(tripId: string): Promise<void> {
-  const ids = await getAnonTripIds();
-  if (!ids.includes(tripId)) ids.push(tripId);
-  const json = JSON.stringify(ids);
-
-  try {
-    const g = globalThis as any;
-    g.localStorage?.setItem('my-trip-ids', json);
-  } catch {}
-
-  try {
-    const AsyncStorage = require('@react-native-async-storage/async-storage')?.default;
-    if (AsyncStorage) await AsyncStorage.setItem('my-trip-ids', json);
-  } catch {}
-}
 
 /**
  * Fetches all trips for a given authenticated user by combining owned trips
  * and collaborated trips, deduplicating by trip ID.
- * @param userId - Supabase auth UUID of the logged-in user
- * @returns Merged, deduplicated array of Trip objects
  */
 async function fetchTripsForUser(userId: string): Promise<Trip[]> {
   const [owned, collaborated] = await Promise.all([
@@ -81,7 +21,6 @@ async function fetchTripsForUser(userId: string): Promise<Trip[]> {
     fetchCollaboratorTrips(userId),
   ]);
 
-  // Merge and deduplicate by id
   const seen = new Set<string>();
   const merged: Trip[] = [];
   for (const trip of [...owned, ...collaborated]) {
@@ -94,62 +33,17 @@ async function fetchTripsForUser(userId: string): Promise<Trip[]> {
 }
 
 /**
- * Resolves the correct trip list depending on whether the user is authenticated.
- * - Anonymous: reads stored trip IDs and fetches via `/api/trips` (web) or
- *   directly from Supabase (mobile/fallback).
- * - Authenticated: delegates to {@link fetchTripsForUser} for owned + collaborated trips.
- * @param userId - Supabase auth UUID, or `null` for anonymous users
- * @returns Array of Trip objects the current session can access
- */
-async function fetchTripsWithAnonymous(userId: string | null): Promise<Trip[]> {
-  // Anonymous users: fetch by stored trip IDs via API route (service key)
-  if (!userId) {
-    const anonIds = await getAnonTripIds();
-
-    // Web: use API route for anonymous trips
-    if (anonIds.length > 0 && typeof (globalThis as any).document !== 'undefined') {
-      try {
-        const res = await fetch(`/api/trips?ids=${anonIds.join(',')}`);
-        if (res.ok) return res.json() as Promise<Trip[]>;
-      } catch {}
-    }
-
-    // Mobile/fallback: fetch specific trip IDs directly from Supabase
-    if (anonIds.length > 0) {
-      try {
-        const { data, error } = await supabase
-          .from('trips')
-          .select('*')
-          .in('id', anonIds)
-          .order('created_at', { ascending: false });
-        if (!error && data?.length) return data as Trip[];
-      } catch {}
-    }
-
-    return [];
-  }
-
-  // Logged-in users: only show their own + collaborated trips
-  return fetchTripsForUser(userId);
-}
-
-/**
- * Fetches all trips the current user can access (owned, collaborated, or anonymous).
- * The query key is scoped to the user ID (or `'anon'`) so it refetches automatically
- * when the auth state changes.
- * @returns React Query result with `data: Trip[]`, `isLoading`, and `error`
- * @example
- * ```tsx
- * const { data: trips, isLoading } = useTrips();
- * if (isLoading) return <Spinner />;
- * return trips?.map(t => <TripCard key={t.id} trip={t} />);
- * ```
+ * Fetches all trips the current user can access (owned + collaborated).
+ * Requires authentication — returns empty array if not logged in.
  */
 export function useTrips() {
   const user = useAuthStore((s) => s.user);
   return useQuery({
-    queryKey: ['trips', user?.id ?? 'anon'],
-    queryFn: () => fetchTripsWithAnonymous(user?.id ?? null),
-    enabled: true,
+    queryKey: ['trips', user?.id],
+    queryFn: () => fetchTripsForUser(user!.id),
+    enabled: !!user?.id,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: 'always',
   });
 }


### PR DESCRIPTION
## Summary
- Removed all anonymous trip code (saveAnonTripId, getAnonTripIds, fetchTripsWithAnonymous)
- useTrips only fetches for authenticated users, always refetches on mount
- Mobile Supabase configured with AsyncStorage for session persistence
- Card drag: lower thresholds, bigger handle, easier dismiss

## Test plan
- [ ] Generate trip while logged in → shows on trips page
- [ ] Card overlay drags down easily
- [ ] Stats show real numbers