### PR TITLE
fix: trips page shows newly created trips

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -6,7 +6,7 @@ import { motion, useScroll, useTransform } from "motion/react";
 import { Search, Sparkles, MapPin } from "lucide-react";
 import { useHomeScreen, useHeroConfig, usePlaceImages, useTripPlanner, useAuthStore, EASE_OUT_EXPO } from "@travyl/shared";
 import type { FollowUpQuestion } from "@travyl/shared";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { savePlanToSupabase } from "@travyl/shared/src/services/api";
 import { PaperPlane } from "@/components/icons/PaperPlane";
 import { AnimatedCounter } from "@/components/AnimatedCounter";
@@ -258,6 +258,7 @@ function OptionCard({ label, index, selected, onSelect }: {
 
 export default function Home() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const {
     tripQuery,
     setTripQuery,
@@ -535,6 +536,7 @@ export default function Home() {
         // Logged in — save to Supabase via shared helper, then redirect
         try {
           const tripId = await savePlanToSupabase(plan as any);
+          queryClient.invalidateQueries({ queryKey: ['trips'] });
           setTakeoffCompleted(true);
           await new Promise((r) => setTimeout(r, 800));
           setShowTakeoff(false);

--- a/apps/web/components/spotlight/SpotlightTripCreator.tsx
+++ b/apps/web/components/spotlight/SpotlightTripCreator.tsx
@@ -7,6 +7,7 @@ import { Sparkles, Loader2, AlertCircle, ArrowLeft } from 'lucide-react'
 import { useTripPlanner, useAuthStore } from '@travyl/shared'
 import type { FollowUpQuestion, PlanResponse } from '@travyl/shared'
 import { savePlanToSupabase } from '@travyl/shared/src/services/api'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface Props {
   prefillDestination: string
@@ -20,6 +21,7 @@ const LETTERS = ['A', 'B', 'C', 'D', 'E']
 
 export function SpotlightTripCreator({ prefillDestination, query, onClose, onBack, onPhaseChange }: Props) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const user = useAuthStore((s) => s.user)
   const planner = useTripPlanner()
   const [currentQIdx, setCurrentQIdx] = useState(0)
@@ -107,6 +109,7 @@ export function SpotlightTripCreator({ prefillDestination, query, onClose, onBac
 
       try {
         const tripId = await savePlanToSupabase(plan as any)
+        queryClient.invalidateQueries({ queryKey: ['trips'] })
         onClose()
         router.push(`/trip/${tripId}`)
       } catch {


### PR DESCRIPTION
## Summary
Web homepage and Spotlight trip creator now invalidate the trips React Query cache after saving a trip. Previously, generating a trip then navigating to /trips would show stale (empty) data because the cache wasn't refreshed.

## Test plan
- [ ] Generate trip on homepage → go to /trips → trip appears
- [ ] Generate trip via Spotlight → go to /trips → trip appears