### PR TITLE
fix: trips page shows user trips, supabase module-scope config, hi-res maps

### DIFF
--- a/apps/web/app/(main)/places/page.tsx
+++ b/apps/web/app/(main)/places/page.tsx
@@ -74,13 +74,10 @@ async function fetchSearchPlaces(query: string): Promise<PlaceItemType[]> {
   const lat = probeData[0]?.latitude
   const lng = probeData[0]?.longitude
   if (lat == null || lng == null) {
-    // Fallback: use q param for places + events search in parallel
-    const categories = BROWSE_CATEGORIES
-    const placesFetches = categories.map(async (cat) => {
-      const res = await fetch(`/api/places?q=${encodeURIComponent(query)}&category=${cat}&limit=20`)
-      if (!res.ok) return []
-      return res.json() as Promise<PlaceItemType[]>
-    })
+    // Fallback: Google Maps search + events in parallel
+    const mapsFetch = fetch(`/api/search/maps?q=${encodeURIComponent(query)}`)
+      .then(r => r.ok ? r.json() as Promise<PlaceItemType[]> : [])
+      .catch(() => [] as PlaceItemType[])
     const eventsFetch = fetch(`/api/events/search?city=${encodeURIComponent(query)}`)
       .then(async r => {
         if (!r.ok) return []
@@ -100,15 +97,22 @@ async function fetchSearchPlaces(query: string): Promise<PlaceItemType[]> {
         })) as PlaceItemType[]
       })
       .catch(() => [] as PlaceItemType[])
-    const [placesResults, events] = await Promise.all([Promise.all(placesFetches), eventsFetch])
+    const [mapsResults, events] = await Promise.all([mapsFetch, eventsFetch])
     const seen = new Set<string>()
-    return [...placesResults.flat(), ...events].filter((p) => { if (seen.has(p.id)) return false; seen.add(p.id); return true })
+    return [...mapsResults, ...events].filter((p) => { if (seen.has(p.id)) return false; seen.add(p.id); return true })
   }
 
-  // Step 2: fetch key categories from center + one offset neighborhood
+  // Step 2: Google Maps search + categories from center + offset neighborhood
   const categories = BROWSE_CATEGORIES
 
   const fetches: Promise<PlaceItemType[]>[] = []
+
+  // Google Maps search — finds the exact place/business by name
+  fetches.push(
+    fetch(`/api/search/maps?q=${encodeURIComponent(query)}`)
+      .then(r => r.ok ? r.json() as Promise<PlaceItemType[]> : [])
+      .catch(() => [])
+  )
 
   // Center: key categories, limit 15
   for (const cat of categories) {

--- a/apps/web/app/api/search/maps/route.ts
+++ b/apps/web/app/api/search/maps/route.ts
@@ -24,13 +24,37 @@ export async function GET(req: NextRequest) {
     const data = await res.json()
     const results: any[] = []
 
-    // Single place result (exact match — e.g. "Yum Yum Donuts Porterville")
+    // Single place result (exact match)
     if (data.place_results) {
       const p = data.place_results
-      results.push(mapPlace(p, 0))
+      const mapped = mapPlace(p, 0)
+
+      // Fetch hi-res image via Google Images if thumbnail is low quality
+      if (!mapped.image || mapped.image.includes('gps-cs-s')) {
+        try {
+          const imgUrl = new URL('https://serpapi.com/search.json')
+          imgUrl.searchParams.set('engine', 'google_images')
+          imgUrl.searchParams.set('q', mapped.name)
+          imgUrl.searchParams.set('num', '3')
+          imgUrl.searchParams.set('api_key', SERPAPI_KEY)
+          const imgRes = await fetch(imgUrl.toString(), CACHE_1H)
+          if (imgRes.ok) {
+            const imgData = await imgRes.json()
+            const imgs = (imgData.images_results ?? [])
+              .filter((r: any) => r.original && !r.original.includes('encrypted-tbn'))
+              .slice(0, 5)
+            if (imgs.length > 0) {
+              mapped.image = imgs[0].original
+              mapped.images = imgs.map((r: any) => r.original)
+            }
+          }
+        } catch {}
+      }
+
+      results.push(mapped)
     }
 
-    // Multiple local results (e.g. "donuts near porterville")
+    // Multiple local results
     if (data.local_results) {
       for (const [i, p] of data.local_results.entries()) {
         results.push(mapPlace(p, i + 1))

--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -4,6 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
 import { useAuthStore, useSettingsStore, configureSupabase } from '@travyl/shared';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
+
+// Configure supabase at module load — before any component renders or auth initializes
+configureSupabase(getSupabaseBrowser());
 import { SpotlightSearch } from './spotlight/SpotlightSearch';
 import GlobalNavbar from './GlobalNavbar';
 import { Toaster } from './ui/sonner';
@@ -22,10 +25,6 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   }));
 
   const initialize = useAuthStore((s) => s.initialize);
-
-  // Configure synchronously during render so child component effects see the
-  // cookie-based client. useEffect fires after child effects, which is too late.
-  configureSupabase(getSupabaseBrowser());
 
   useEffect(() => {
     const unsubscribe = initialize();

--- a/packages/shared/src/hooks/useTrips.ts
+++ b/packages/shared/src/hooks/useTrips.ts
@@ -16,10 +16,16 @@ import type { Trip } from '../types';
  * and collaborated trips, deduplicating by trip ID.
  */
 async function fetchTripsForUser(userId: string): Promise<Trip[]> {
-  const [owned, collaborated] = await Promise.all([
-    fetchTrips(userId),
-    fetchCollaboratorTrips(userId),
-  ]);
+  // Fetch owned trips — this must succeed
+  const owned = await fetchTrips(userId);
+
+  // Collaborator trips — best effort, don't block owned trips if this fails
+  let collaborated: Trip[] = [];
+  try {
+    collaborated = await fetchCollaboratorTrips(userId);
+  } catch {
+    // RLS or join error on trip_collaborators — non-fatal
+  }
 
   const seen = new Set<string>();
   const merged: Trip[] = [];


### PR DESCRIPTION
## Summary
- **Trips page fixed** — `fetchCollaboratorTrips` 500 error no longer kills the entire trips query. Owned trips always show.
- **Supabase configured at module scope** — guarantees cookie-based browser client is used before any auth or query runs
- **Google Maps search** — hi-res images via Google Images for exact place matches
- **Web Places page** — uses /api/search/maps for all searches (finds Yosemite, restaurants, etc.)

## Verified via Playwright
User jpompa1@csub.edu sees 8 trips (Miami, Tokyo, Santorini, Barcelona, Bora Bora) on localhost:3000/trips.

## Test plan
- [ ] Log in → /trips shows user's trips
- [ ] Search "Yosemite" on Places → shows hi-res image + details
- [ ] Generate new trip → appears on trips page