### PR TITLE
fix: unbreak Amplify build + mobile audit fixes (search, Expo Go, dark mode, RLS)

### DIFF
--- a/apps/mobile/app/(tabs)/favorites/index.tsx
+++ b/apps/mobile/app/(tabs)/favorites/index.tsx
@@ -382,10 +382,20 @@ export default function FavoritesScreen() {
     return dedupPlaces(searchData.pages.flatMap(p => p.items));
   }, [searchData]);
 
-  // Merge: search results when searching, discover feed otherwise
+  // When searching, merge API results with locally-filtered nearby places.
+  // The /api/search/maps backend ignores location, so local matches surface
+  // relevant nearby places (e.g. "park" hits Tilden, Marina Park, etc).
   const PLACES = useMemo(() => {
-    if (searchCity) return searchResults;
-    return discoveredPlaces;
+    if (!searchCity) return discoveredPlaces;
+    const q = searchCity.toLowerCase();
+    const localMatches = discoveredPlaces.filter((p) =>
+      p.name?.toLowerCase().includes(q) ||
+      p.tagline?.toLowerCase().includes(q) ||
+      p.category?.toLowerCase().includes(q) ||
+      p.description?.toLowerCase().includes(q) ||
+      p.tags?.some((t) => t.toLowerCase().includes(q))
+    );
+    return dedupPlaces([...localMatches, ...searchResults]);
   }, [discoveredPlaces, searchCity, searchResults]);
 
   // Active pagination state — depends on whether searching or browsing
@@ -443,14 +453,15 @@ export default function FavoritesScreen() {
   const filteredPlaces = useMemo(() => {
     let result = [...tabFiltered];
     if (activeSubcategory) result = result.filter((p) => p.category === activeSubcategory);
-    // Only apply local text filter when NOT in API search mode
-    if (searchQuery.trim() && !searchCity) {
+    // Local text filter — narrows the merged set further while user types
+    if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
       result = result.filter(
         (p) =>
           p.name?.toLowerCase().includes(q) ||
           p.tagline?.toLowerCase().includes(q) ||
           p.category?.toLowerCase().includes(q) ||
+          p.description?.toLowerCase().includes(q) ||
           p.tags?.some((t) => t.toLowerCase().includes(q))
       );
     }

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -4,11 +4,12 @@ import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as WebBrowser from 'expo-web-browser';
+import Constants from 'expo-constants';
 import { PageTransition, useTabAccent, TabCtx } from './_layout';
-// Conditionally import react-native-maps (crashes on web)
+// Conditionally import react-native-maps — skip on web AND in Expo Go (no native module)
 let MapView: any = View;
 let Marker: any = View;
-if (Platform.OS !== 'web') {
+if (Platform.OS !== 'web' && Constants.appOwnership !== 'expo') {
   try {
     const maps = require('react-native-maps');
     MapView = maps.default;

--- a/apps/mobile/app/trip/[id]/itinerary.tsx
+++ b/apps/mobile/app/trip/[id]/itinerary.tsx
@@ -26,10 +26,11 @@ import {
   supabase,
 } from '@travyl/shared';
 import type { FlightDetail, HotelDetail, DiscoverItem, ActivityViewModel, ItineraryDayViewModel } from '@travyl/shared';
-// Conditionally import react-native-maps (crashes on web)
+import Constants from 'expo-constants';
+// Conditionally import react-native-maps — skip on web AND in Expo Go (no native module)
 let MapView: any = View;
 let Marker: any = View;
-if (Platform.OS !== 'web') {
+if (Platform.OS !== 'web' && Constants.appOwnership !== 'expo') {
   try {
     const maps = require('react-native-maps');
     MapView = maps.default;
@@ -286,7 +287,7 @@ function DayMap({ todayActivities, allActivities, onClose, centerLat, centerLng,
   const focusStop = useCallback((index: number) => {
     setSelectedStop((prev) => {
       if (prev === index) {
-        mapRef.current?.animateToRegion({
+        typeof mapRef.current?.animateToRegion === 'function' && mapRef.current.animateToRegion({
           latitude: centerLat,
           longitude: centerLng,
           latitudeDelta: 0.05,
@@ -296,7 +297,7 @@ function DayMap({ todayActivities, allActivities, onClose, centerLat, centerLng,
       }
       const m = markers[index];
       if (m) {
-        mapRef.current?.animateToRegion({
+        typeof mapRef.current?.animateToRegion === 'function' && mapRef.current.animateToRegion({
           latitude: m.lat,
           longitude: m.lng,
           latitudeDelta: 0.01,
@@ -391,12 +392,14 @@ function DayMap({ todayActivities, allActivities, onClose, centerLat, centerLng,
           </Pressable>
           {/* Recenter button */}
           <Pressable
-            onPress={() => mapRef.current?.animateToRegion({
-              latitude: centerLat,
-              longitude: centerLng,
-              latitudeDelta: 0.05,
-              longitudeDelta: 0.05,
-            }, 400)}
+            onPress={() => {
+              if (typeof mapRef.current?.animateToRegion === 'function') {
+                mapRef.current.animateToRegion({
+                  latitude: centerLat, longitude: centerLng,
+                  latitudeDelta: 0.05, longitudeDelta: 0.05,
+                }, 400);
+              }
+            }}
             style={{
               position: 'absolute', top: 52, left: 16,
               width: 32, height: 32, borderRadius: 16,

--- a/apps/mobile/components/places/CardStackCarousel.tsx
+++ b/apps/mobile/components/places/CardStackCarousel.tsx
@@ -13,10 +13,11 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-// Conditionally import react-native-maps (crashes on web)
+import Constants from 'expo-constants';
+// Conditionally import react-native-maps — skip on web AND in Expo Go (no native module)
 let MapView: any = View;
 let Marker: any = View;
-if (Platform.OS !== 'web') {
+if (Platform.OS !== 'web' && Constants.appOwnership !== 'expo') {
   try {
     const maps = require('react-native-maps');
     MapView = maps.default;
@@ -154,10 +155,12 @@ export function CardStackCarousel({
     const id = setTimeout(() => {
       // Offset center south so pin appears in top 25% (above the card)
       const latDelta = 0.025;
-      mapRef.current?.animateToRegion({
-        latitude: p!.latitude! - latDelta * 0.35, longitude: p!.longitude!,
-        latitudeDelta: latDelta, longitudeDelta: latDelta,
-      }, 400);
+      if (typeof mapRef.current?.animateToRegion === 'function') {
+        mapRef.current.animateToRegion({
+          latitude: p!.latitude! - latDelta * 0.35, longitude: p!.longitude!,
+          latitudeDelta: latDelta, longitudeDelta: latDelta,
+        }, 400);
+      }
     }, delay);
     return () => clearTimeout(id);
   }, [currentIdx, showMap, overlay]);

--- a/apps/mobile/components/places/PlaceDetailModal.tsx
+++ b/apps/mobile/components/places/PlaceDetailModal.tsx
@@ -13,11 +13,12 @@ import {
   Platform,
 } from 'react-native';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Constants from 'expo-constants';
 
-// Conditionally import react-native-maps (crashes on web)
+// Conditionally import react-native-maps — skip on web AND in Expo Go (no native module)
 let MapView: any = View;
 let Marker: any = View;
-if (Platform.OS !== 'web') {
+if (Platform.OS !== 'web' && Constants.appOwnership !== 'expo') {
   try {
     const maps = require('react-native-maps');
     MapView = maps.default;
@@ -111,7 +112,7 @@ const PlaceDetailModal = memo(function PlaceDetailModal({
   const mapRef = useRef<any>(null);
   useEffect(() => {
     if (currentPlace?.latitude != null && currentPlace?.longitude != null) {
-      mapRef.current?.animateToRegion({
+      typeof mapRef.current?.animateToRegion === 'function' && mapRef.current.animateToRegion({
         latitude: currentPlace.latitude,
         longitude: currentPlace.longitude,
         latitudeDelta: 0.02,
@@ -177,7 +178,7 @@ const PlaceDetailModal = memo(function PlaceDetailModal({
     }).start();
     if (opening && currentPlace?.latitude != null && currentPlace?.longitude != null) {
       setTimeout(() => {
-        mapRef.current?.animateToRegion({
+        typeof mapRef.current?.animateToRegion === 'function' && mapRef.current.animateToRegion({
           latitude: currentPlace.latitude!,
           longitude: currentPlace.longitude!,
           latitudeDelta: 0.02,
@@ -242,7 +243,7 @@ const PlaceDetailModal = memo(function PlaceDetailModal({
             <Pressable
               onPress={() => {
                 if (currentPlace?.latitude != null && currentPlace?.longitude != null) {
-                  mapRef.current?.animateToRegion({
+                  typeof mapRef.current?.animateToRegion === 'function' && mapRef.current.animateToRegion({
                     latitude: currentPlace.latitude,
                     longitude: currentPlace.longitude,
                     latitudeDelta: 0.02,

--- a/apps/web/app/(dashboard)/trips/page.tsx
+++ b/apps/web/app/(dashboard)/trips/page.tsx
@@ -79,7 +79,7 @@ export default function MyTripsPage() {
     <Suspense fallback={
       <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-serif font-normal text-gray-900 tracking-wide">My Trips</h1>
+          <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <SkeletonCard />
@@ -236,7 +236,7 @@ function TripsContent() {
       <div className="flex flex-col min-h-screen">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4 flex-1 w-full">
           <div className="flex items-center justify-between mb-6">
-            <h1 className="text-2xl font-serif font-normal text-gray-900 tracking-wide">My Trips</h1>
+            <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <SkeletonCard />
@@ -255,7 +255,7 @@ function TripsContent() {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4 flex-1 w-full">
         {/* Header Row: Title | View Toggle | Button */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
-          <h1 className="text-2xl font-serif font-normal text-gray-900 tracking-wide">My Trips</h1>
+          <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
 
           <div className="flex items-center gap-3 flex-wrap">
             {/* View Toggle */}

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -13,7 +13,6 @@ import { AnimatedCounter } from "@/components/AnimatedCounter";
 import { TypeWriter } from "@/components/TypeWriter";
 import { useCyclingPlaceholder, useCyclingPlaceholderRef } from "@/hooks/useCyclingPlaceholder";
 import dynamic from "next/dynamic";
-import { getSupabaseBrowser } from "@/lib/supabase-browser";
 
 const HowItWorks = dynamic(
   () => import("@/components/home/HowItWorks").then((m) => ({ default: m.HowItWorks })),
@@ -462,6 +461,19 @@ export default function Home() {
     setTimeout(() => inputRef.current?.focus(), 50);
   }, [planner, setTripQuery]);
 
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+  const [takeoffCompleted, setTakeoffCompleted] = useState(false);
+  const [showAuthGate, setShowAuthGate] = useState(false);
+  const isSaving = useRef(false);
+  const user = useAuthStore((s) => s.user);
+
+  const requireAuth = (prompt: string) => {
+    if (user) return false;
+    try { sessionStorage.setItem('pending-trip-prompt', prompt); } catch {}
+    setShowAuthGate(true);
+    return true;
+  };
+
   const onSearch = () => {
     const val = tripQuery.trim();
     if (!val) return;
@@ -473,6 +485,7 @@ export default function Home() {
     const prompt = words <= 3 && !val.match(/\d/)
       ? `Plan a 5-day trip to ${val}`
       : val;
+    if (requireAuth(prompt)) return;
     planner.submitPrompt(prompt);
     setTripQuery("");
   };
@@ -480,16 +493,26 @@ export default function Home() {
   const onRefine = () => {
     const val = tripQuery.trim();
     if (!val) return;
+    if (requireAuth(val)) return;
     skipQuestionsRef.current = false;
     setShowQuestions(true);
     planner.submitPrompt(val);
     setTripQuery("");
   };
 
-  const [loadingError, setLoadingError] = useState<string | null>(null);
-  const [takeoffCompleted, setTakeoffCompleted] = useState(false);
-  const isSaving = useRef(false);
-  const user = useAuthStore((s) => s.user);
+  // Resume a pending trip prompt after the user signs in
+  useEffect(() => {
+    if (!user) return;
+    let pending: string | null = null;
+    try { pending = sessionStorage.getItem('pending-trip-prompt'); } catch {}
+    if (!pending) return;
+    try { sessionStorage.removeItem('pending-trip-prompt'); } catch {}
+    setShowAuthGate(false);
+    skipQuestionsRef.current = true;
+    skipRetryCountRef.current = 0;
+    clarifyRoundRef.current = 0;
+    planner.submitPrompt(pending);
+  }, [user]);
 
   // Show takeoff when planning starts
   useEffect(() => {
@@ -549,96 +572,11 @@ export default function Home() {
           isSaving.current = false;
         }
       } else {
-        // Not logged in:
-        // 1. Tiny create through CloudFront (~500 bytes, no trip_context)
-        // 2. Update trip_context via direct Supabase (bypasses CloudFront WAF)
-        //    Secured by time-limited RLS policy (1hr window after creation)
-        try {
-          const ext = plan.extracted;
-          if (!ext?.destination) throw new Error('No destination extracted');
-          const dest = ext.destination;
-          const totalBudget = ext.daily_estimate_usd ? ext.daily_estimate_usd * ext.duration_days : null;
-
-          // Step 1 — tiny create (no trip_context, bypasses WAF)
-          const createRes = await fetch('/api/trips/create', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              destination: `${dest.city}, ${dest.country}`,
-              start_date: ext.dates.start,
-              end_date: ext.dates.end,
-              travelers: ext.travelers.count,
-              budget: totalBudget,
-              currency: 'USD',
-            }),
-          });
-          if (!createRes.ok) {
-            const errBody = await createRes.text().catch(() => '');
-            throw new Error(`Create failed: ${createRes.status}`);
-          }
-          const trip = await createRes.json();
-          const tripId = trip.id;
-
-          // Track in localStorage for anonymous persistence
-          try {
-            const stored = localStorage.getItem('my-trip-ids');
-            const ids: string[] = stored ? JSON.parse(stored) : [];
-            if (!ids.includes(tripId)) ids.push(tripId);
-            localStorage.setItem('my-trip-ids', JSON.stringify(ids));
-          } catch {}
-
-          // Step 2 — update trip_context direct to Supabase (no CloudFront)
-          // RLS: anon can only update public trips created in last 1 hour
-          const sb = getSupabaseBrowser();
-          sb.from('trips').update({
-            trip_context: {
-              lat: dest.lat, lng: dest.lng,
-              hero_image_url: plan.destination_photo_url || null,
-              hero_images: plan.destination_photo_url ? [plan.destination_photo_url] : [],
-              lede_text: `A ${ext.duration_days}-day trip to ${dest.city}.`,
-              quick_facts: {
-                budget_level: ext.budget_level,
-                daily_budget: ext.daily_estimate_usd,
-                interests: ext.interests,
-                timezone: (plan as any).timezone,
-              },
-              hotels: (plan.hotels ?? []).slice(0, 5).map((h: any) => ({
-                id: `hotel-${h.name?.replace(/\s+/g, '-').toLowerCase()}`,
-                name: h.name, rating: h.rating, price: h.price_per_night, stars: h.stars,
-              })),
-              flights: (plan.flights ?? []).slice(0, 5).map((f: any) => ({
-                airline: f.airline, price: f.price,
-                departure_time: f.departure_time, arrival_time: f.arrival_time,
-              })),
-              itinerary: (plan.itinerary ?? []).map((day: any) => ({
-                day: day.day, date: day.date,
-                slots: (day.slots ?? []).map((slot: any) => ({
-                  start_time: slot.start_time, end_time: slot.end_time,
-                  poi: { id: slot.poi.id, name: slot.poi.name, category: slot.poi.category, lat: slot.poi.lat, lng: slot.poi.lng },
-                })),
-              })),
-            },
-          }).eq('id', tripId).then(({ error }) => {
-          });
-
-          // Enrich in background
-          fetch('/api/trips/enrich', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tripId }),
-          }).catch(() => {});
-
-          setTakeoffCompleted(true);
-          await new Promise((r) => setTimeout(r, 800));
-          setShowTakeoff(false);
-          planner.reset();
-          isSaving.current = false;
-          router.push(`/trip/${tripId}`);
-        } catch (saveErr) {
-          setLoadingError(saveErr instanceof Error ? saveErr.message : 'Failed to save trip');
-          setShowTakeoff(false);
-          isSaving.current = false;
-        }
+        // Not logged in — show clean auth gate (should have been caught earlier,
+        // but guard here in case a plan completed before user signed in)
+        setShowTakeoff(false);
+        isSaving.current = false;
+        setShowAuthGate(true);
       }
     })();
   }, [planner.state.phase]);
@@ -869,9 +807,11 @@ export default function Home() {
                     <button
                       key={s.id}
                       onClick={() => {
+                        const prompt = `Plan a trip to ${s.label}`;
+                        if (requireAuth(prompt)) return;
                         skipQuestionsRef.current = true;
                         skipRetryCountRef.current = 0;
-                        planner.submitPrompt(`Plan a trip to ${s.label}`);
+                        planner.submitPrompt(prompt);
                       }}
                       className="text-[10px] sm:text-xs text-white font-semibold border border-white/50 rounded-full px-2.5 sm:px-3.5 py-1 sm:py-1.5 hover:bg-white/30 transition-colors backdrop-blur-md bg-white/20 shadow-md drop-shadow-md whitespace-nowrap"
                     >
@@ -921,6 +861,44 @@ export default function Home() {
         }}
         onComplete={() => {}}
       />
+
+      {/* ─── Auth gate for trip planning ─────────────────────────── */}
+      {showAuthGate && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={() => setShowAuthGate(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 p-6 sm:p-8 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-2xl font-serif text-slate-900 dark:text-white mb-2">Sign in to plan your trip</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">
+              We&apos;ll save your itinerary, hotels, and flights to your account so you can come back to it anytime.
+            </p>
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={() => router.push('/signup?next=/')}
+                className="w-full rounded-xl bg-[#1e3a5f] hover:bg-[#16314f] text-white font-semibold py-3 transition-colors"
+              >
+                Create free account
+              </button>
+              <button
+                onClick={() => router.push('/login?next=/')}
+                className="w-full rounded-xl border border-slate-300 dark:border-slate-600 text-slate-900 dark:text-white font-semibold py-3 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+              >
+                I already have an account
+              </button>
+              <button
+                onClick={() => setShowAuthGate(false)}
+                className="text-xs text-slate-500 dark:text-slate-400 hover:underline mt-1"
+              >
+                Maybe later
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/api/airports/nearest/route.ts
+++ b/apps/web/app/api/airports/nearest/route.ts
@@ -4,6 +4,8 @@ import { NextRequest, NextResponse } from 'next/server'
 const GEONAMES_USER = process.env.GEONAMES_USERNAME || 'demo'
 
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'airports-nearest', 60, 60000)
+  if (rl) return rl
   const sp = req.nextUrl.searchParams
   const lat = sp.get('lat')
   const lng = sp.get('lng')
@@ -53,8 +55,6 @@ export async function GET(req: NextRequest) {
           const duffelRes = await fetch(
             `https://api.duffel.com/places/suggestions?query=${encodeURIComponent(cityName)}&types[]=airport`,
             {
-  const rl = rateLimit(req, 'airports-nearest', 60, 60000)
-  if (rl) return rl
               headers: {
                 Authorization: `Bearer ${duffelToken}`,
                 'Duffel-Version': 'v2',

--- a/apps/web/app/api/airports/route.ts
+++ b/apps/web/app/api/airports/route.ts
@@ -4,6 +4,8 @@ import { NextRequest, NextResponse } from 'next/server'
 const DUFFEL_TOKEN = process.env.DUFFEL_API_TOKEN
 
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'airports', 60, 60000)
+  if (rl) return rl
   const q = req.nextUrl.searchParams.get('q')
   if (!q || q.length < 2) return NextResponse.json([])
 
@@ -15,8 +17,6 @@ export async function GET(req: NextRequest) {
     const res = await fetch(
       `https://api.duffel.com/places/suggestions?query=${encodeURIComponent(q)}&types[]=airport&types[]=city`,
       {
-  const rl = rateLimit(req, 'airports', 60, 60000)
-  if (rl) return rl
         headers: {
           Authorization: `Bearer ${DUFFEL_TOKEN}`,
           'Duffel-Version': 'v2',

--- a/apps/web/app/api/destinations/[name]/route.ts
+++ b/apps/web/app/api/destinations/[name]/route.ts
@@ -163,11 +163,11 @@ interface NominatimResult {
 // ─── Route handler ───────────────────────────────────────────────────────────
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ name: string }> }
+) {
   const rl = rateLimit(req, 'destinations-[name]', 60, 60000)
   if (rl) return rl
-) {
   const { name } = await params
   const slug = decodeURIComponent(name).toLowerCase().replace(/-/g, ' ').trim()
 

--- a/apps/web/app/api/events/artist/route.ts
+++ b/apps/web/app/api/events/artist/route.ts
@@ -9,6 +9,8 @@ const SERPAPI_KEY = process.env.SERPAPI_KEY || ''
  * Returns upcoming tour dates with venues, dates, ticket links, and coordinates.
  */
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'events-artist', 20, 60000)
+  if (rl) return rl
   const query = getOptionalParam(req, 'q', '')
   if (!query) return NextResponse.json([])
   if (!SERPAPI_KEY) return NextResponse.json({ error: 'SerpAPI key not configured' }, { status: 503 })
@@ -18,11 +20,11 @@ export async function GET(req: NextRequest) {
     const [eventsRes, organicRes] = await Promise.all([
       // Google Events: direct concert search
       fetch(`https://serpapi.com/search.json?engine=google_events&q=${encodeURIComponent(`${query} concert tour`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-        .then(r => r.ok ? r.json() : {})
+        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
         .catch(() => ({})),
       // Google organic: find tour pages on Ticketmaster/LiveNation/Songkick
       fetch(`https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(`${query} tour dates 2026 concert tickets`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-        .then(r => r.ok ? r.json() : {})
+        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
         .catch(() => ({})),
     ])
 
@@ -48,8 +50,6 @@ export async function GET(req: NextRequest) {
           const geoRes = await fetch(
             `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(address)}&format=json&limit=1`,
             { headers: { 'User-Agent': 'Travyl/1.0' } }
-  const rl = rateLimit(req, 'events-artist', 20, 60000)
-  if (rl) return rl
           )
           const geoData = await geoRes.json() as any[]
           if (geoData.length > 0) {

--- a/apps/web/app/api/events/search/route.ts
+++ b/apps/web/app/api/events/search/route.ts
@@ -22,6 +22,8 @@ interface SerpEvent {
  * ?pages=1 — number of pages to fetch (10 results each, default 2 = 20 results)
  */
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'events-search', 20, 60000)
+  if (rl) return rl
   const query = getOptionalParam(req, 'city', '') || getOptionalParam(req, 'q', '')
   if (!query) return NextResponse.json([])
 
@@ -85,8 +87,6 @@ export async function GET(req: NextRequest) {
         const geoRes = await fetch(
           `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(addr)}&format=json&limit=1`,
           { headers: { 'User-Agent': 'Travyl/1.0' } }
-  const rl = rateLimit(req, 'events-search', 20, 60000)
-  if (rl) return rl
         )
         const geoData = await geoRes.json() as any[]
         if (geoData.length > 0) {

--- a/apps/web/app/api/favorites/[id]/route.ts
+++ b/apps/web/app/api/favorites/[id]/route.ts
@@ -27,9 +27,9 @@ async function getAuthHeader(req: NextRequest): Promise<string | null> {
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
+) {
   const rl = rateLimit(req, 'favorites-[id]', 60, 60000)
   if (rl) return rl
-) {
   const { id } = await params
   if (!BACKEND_URL) return NextResponse.json({ error: 'Backend URL not configured' }, { status: 503 })
   const auth = await getAuthHeader(req)

--- a/apps/web/app/api/hotels/[id]/route.ts
+++ b/apps/web/app/api/hotels/[id]/route.ts
@@ -4,9 +4,9 @@ import { proxyToBackend, rateLimit } from '@/lib/api-utils'
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
+) {
   const rl = rateLimit(req, 'hotels-[id]', 30, 60000)
   if (rl) return rl
-) {
   const { id } = await params
   return proxyToBackend(`/api/places/${encodeURIComponent(id)}`, req)
 }

--- a/apps/web/app/api/places/[id]/route.ts
+++ b/apps/web/app/api/places/[id]/route.ts
@@ -8,11 +8,11 @@ import {
 const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
+) {
   const rl = rateLimit(req, 'places-[id]', 30, 60000)
   if (rl) return rl
-) {
   const { id } = await params
 
   if (!API_URL) {

--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -22,6 +22,8 @@ const FOURSQUARE_CAT_MAP: Record<string, string> = {
 }
 
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'places', 30, 60000)
+  if (rl) return rl
   const lat = req.nextUrl.searchParams.get('lat') ?? ''
   const lng = req.nextUrl.searchParams.get('lng') ?? ''
   const category = req.nextUrl.searchParams.get('category') ?? 'sightseeing'
@@ -56,8 +58,6 @@ export async function GET(req: NextRequest) {
       const nlpRes = await fetch(
         `${API_URL}/places/search?q=${encodeURIComponent(q)}&category=${category}&limit=${limit}&lat=${lat}&lng=${lng}`,
         { headers: { Accept: 'application/json', ...(authHeader ? { Authorization: authHeader } : {}) } }
-  const rl = rateLimit(req, 'places', 30, 60000)
-  if (rl) return rl
       )
       if (nlpRes.ok) {
         const nlpData = await nlpRes.json()

--- a/apps/web/app/api/search/place-detail/route.ts
+++ b/apps/web/app/api/search/place-detail/route.ts
@@ -72,10 +72,10 @@ export async function GET(req: NextRequest) {
     if (dataId) {
       const [reviewsRes, photosRes] = await Promise.all([
         fetch(`https://serpapi.com/search.json?engine=google_maps_reviews&data_id=${encodeURIComponent(dataId)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-          .then(r => r.ok ? r.json() : {})
+          .then(r => r.ok ? r.json() as Promise<any> : {} as any)
           .catch(() => ({})),
         fetch(`https://serpapi.com/search.json?engine=google_maps_photos&data_id=${encodeURIComponent(dataId)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-          .then(r => r.ok ? r.json() : {})
+          .then(r => r.ok ? r.json() as Promise<any> : {} as any)
           .catch(() => ({})),
       ])
 

--- a/apps/web/app/api/timezone/route.ts
+++ b/apps/web/app/api/timezone/route.ts
@@ -8,6 +8,8 @@ import { NextRequest, NextResponse } from 'next/server'
 const API_KEY = process.env.TIMEZONEDB_API_KEY || ''
 
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'timezone', 60, 60000)
+  if (rl) return rl
   const sp = req.nextUrl.searchParams
   const lat = sp.get('lat')
   const lng = sp.get('lng')
@@ -22,8 +24,6 @@ export async function GET(req: NextRequest) {
       const res = await fetch(
         `https://worldtimeapi.org/api/timezone`,
         { next: { revalidate: 3600 } }
-  const rl = rateLimit(req, 'timezone', 60, 60000)
-  if (rl) return rl
       )
 
       // Use Nominatim + timezone lookup via coordinates

--- a/apps/web/app/api/trips/create/route.ts
+++ b/apps/web/app/api/trips/create/route.ts
@@ -24,6 +24,10 @@ export async function POST(req: NextRequest) {
       } catch {}
     }
 
+    if (!user_id) {
+      return NextResponse.json({ error: 'Sign in to plan a trip', code: 'AUTH_REQUIRED' }, { status: 401 })
+    }
+
     if (!destination || typeof destination !== 'string' || destination.length > 200) {
       return NextResponse.json({ error: 'Missing or invalid destination' }, { status: 400 })
     }
@@ -40,12 +44,12 @@ export async function POST(req: NextRequest) {
         start_date: start_date || null,
         end_date: end_date || null,
         status: 'planning',
-        user_id: user_id || null,
+        user_id,
         travelers: safeTravelers,
         budget: safeBudget,
         currency: ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'INR', 'MXN', 'BRL'].includes(currency) ? currency : 'USD',
         trip_context: trip_context || {},
-        visibility: user_id ? 'private' : 'public',
+        visibility: 'private',
         is_generated: true,
       })
       .select()

--- a/apps/web/app/api/trips/route.ts
+++ b/apps/web/app/api/trips/route.ts
@@ -3,13 +3,13 @@ import { createServerClient } from '@supabase/ssr'
 import { getSupabase, supabaseUrl, supabaseKey, rateLimit } from '@/lib/api-utils'
 
 export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'trips', 60, 60000)
+  if (rl) return rl
   // Try to get user session from cookies
   const supabase = createServerClient(
     supabaseUrl,
     supabaseKey,
     {
-  const rl = rateLimit(req, 'trips', 60, 60000)
-  if (rl) return rl
       cookies: {
         getAll() {
           return req.cookies.getAll()

--- a/packages/shared/src/services/placesDiscovery.ts
+++ b/packages/shared/src/services/placesDiscovery.ts
@@ -85,18 +85,21 @@ function mapEvent(e: any, idPrefix: string, idx: number): PlaceItem {
 
 // ─── Dedup ───────────────────────────────────────────────────
 
-/** Dedup places by normalized name + approximate coordinates */
+/** Dedup places by normalized name within a coarse geo bucket (~11km).
+ * Same name in the same metro = duplicate (different API sources for the same POI).
+ * Same name in different metros = distinct (e.g., chains).
+ */
 export function dedupPlaces(places: PlaceItem[]): PlaceItem[] {
   const seen = new Set<string>();
   return places.filter((p) => {
     if (!p.name) return false;
     const normName = p.name.toLowerCase().replace(/[^a-z0-9]/g, '');
-    const locKey = p.latitude != null ? `${p.latitude.toFixed(3)}_${p.longitude?.toFixed(3)}` : '';
-    const key = `${normName}_${locKey}`;
+    const bucket = p.latitude != null && p.longitude != null
+      ? `${p.latitude.toFixed(1)}_${p.longitude.toFixed(1)}`
+      : 'no-geo';
+    const key = `${normName}@${bucket}`;
     if (seen.has(key)) return false;
-    if (!locKey && seen.has(normName)) return false;
     seen.add(key);
-    if (!locKey) seen.add(normName);
     return true;
   });
 }


### PR DESCRIPTION
## Summary

- **Unblock Amplify build** — fix 11 route handlers where the rate-limit
  script (commit `30b83fe`) inserted `const rl = rateLimit(...)` lines in
  syntactically invalid positions, causing SWC parse errors. Plus 2
  TypeScript narrowing fixes in `events/artist` and `search/place-detail`.
- **Mobile Expo Go stability** — gate `react-native-maps` behind
  `Constants.appOwnership !== 'expo'` in 4 files; guard 6
  `animateToRegion` calls with `typeof === 'function'`. Maps work in dev
  builds; Expo Go shows an empty View instead of crashing on
  PushNotificationIOS.
- **Mobile places search (frontend-only fix)** — `/api/search/maps` is
  broken (missing `ll` param to SerpAPI returns `[]`). Frontend now merges
  API results with locally-filtered discovered places by
  name/tagline/category/description/tags. Verified on dev build: "park" →
  Washington Square + Mission Bay Kids Park, "tower" → Coit Tower, "play" →
  parks matched by "play zones" in description.
- **Web auth gate + RLS** — anonymous trip creation hit RLS violations.
  Endpoint now returns 401 with `code: 'AUTH_REQUIRED'`, homepage shows a
  clean signup modal and stashes the prompt in sessionStorage so the trip
  auto-creates after signin.
- **Web dark mode** — "My Trips" h1 was invisible on dark background;
  added `dark:text-white`.
- **Shared dedup** — tightened `dedupPlaces` geo bucket from `toFixed(3)`
  (~100m) to `toFixed(1)` (~11km); same-name landmarks were duplicating
  when source coords drifted.

## Test plan

- [ ] Amplify build succeeds (was failing on `Unexpected token \`ident\``
      in 11 routes)
- [ ] `next build` locally passes (verified: 5.3s compile)
- [ ] Mobile dev build: open Places, switch to stack view → Apple Maps
      tiles render with pins
- [ ] Mobile Places search: type "park", "tower", "landmark", "play" →
      relevant local + API results merged
- [ ] Anonymous user on `/` types a prompt → signup modal appears (no
      500 RLS error)
- [ ] After signin, pending prompt resumes and trip generates
- [ ] Web `/trips` in dark mode shows "My Trips" heading visibly