### PR TITLE
fix(events/artist): exact-phrase SerpAPI + drop hardcoded stopwords

### DIFF
--- a/apps/web/app/api/events/artist/route.ts
+++ b/apps/web/app/api/events/artist/route.ts
@@ -2,49 +2,107 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getOptionalParam, CACHE_1H, rateLimit } from '@/lib/api-utils'
 
 const SERPAPI_KEY = process.env.SERPAPI_KEY || ''
+const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || 'travyl'
 
 /**
- * Artist tour search — combines Google Events + Google organic for tour dates.
- * ?q=Drake — artist name
- * Returns upcoming tour dates with venues, dates, ticket links, and coordinates.
+ * Artist tour search.
+ *
+ * Two sources, weighted in this order:
+ *   1. Bandsintown — canonical artist database. Disambiguates by artist ID
+ *      server-side ("Drake" the rapper, not "Drake Milligan" the country
+ *      singer), so its hits are trusted and surfaced first.
+ *   2. SerpAPI Google Events — broader coverage for artists Bandsintown
+ *      doesn't track. Filtered down to titles that contain the artist phrase.
+ *
+ * Results are deduped by `${date}|${venue}` so the same show doesn't appear
+ * twice when both sources see it.
  */
 export async function GET(req: NextRequest) {
   const rl = rateLimit(req, 'events-artist', 20, 60000)
   if (rl) return rl
-  const query = getOptionalParam(req, 'q', '')
+  const query = getOptionalParam(req, 'q', '').trim()
   if (!query) return NextResponse.json([])
-  if (!SERPAPI_KEY) return NextResponse.json({ error: 'SerpAPI key not configured' }, { status: 503 })
+
+  const queryLower = query.toLowerCase()
+  const quotedQuery = `"${query}"`
 
   try {
-    // Fire Google Events + Google organic in parallel
-    const [eventsRes, organicRes] = await Promise.all([
-      // Google Events: direct concert search
-      fetch(`https://serpapi.com/search.json?engine=google_events&q=${encodeURIComponent(`${query} concert tour`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
-        .catch(() => ({})),
-      // Google organic: find tour pages on Ticketmaster/LiveNation/Songkick
-      fetch(`https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(`${query} tour dates 2026 concert tickets`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
-        .catch(() => ({})),
+    const [bitEventsRaw, eventsRes, organicRes] = await Promise.all([
+      // Bandsintown: artist-disambiguated event list
+      fetch(
+        `https://rest.bandsintown.com/artists/${encodeURIComponent(query)}/events?app_id=${encodeURIComponent(BANDSINTOWN_APP_ID)}`,
+        { ...CACHE_1H, headers: { Accept: 'application/json' } },
+      )
+        .then(r => r.ok ? r.json() as Promise<any[]> : [] as any[])
+        .catch(() => [] as any[]),
+      // Google Events with quoted artist
+      SERPAPI_KEY
+        ? fetch(`https://serpapi.com/search.json?engine=google_events&q=${encodeURIComponent(`${quotedQuery} concert tour`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
+            .then(r => r.ok ? r.json() as Promise<any> : {} as any)
+            .catch(() => ({}))
+        : Promise.resolve({}),
+      // Google organic for ticket links
+      SERPAPI_KEY
+        ? fetch(`https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(`${quotedQuery} tour dates concert tickets`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
+            .then(r => r.ok ? r.json() as Promise<any> : {} as any)
+            .catch(() => ({}))
+        : Promise.resolve({}),
     ])
+
+    const seen = new Set<string>()
+    const dedupeKey = (date: string, venue: string) =>
+      `${(date || '').toLowerCase()}|${(venue || '').toLowerCase()}`
 
     const results: any[] = []
 
-    // Map Google Events results
+    // 1. Bandsintown — trusted, comes first
+    const bitEvents = Array.isArray(bitEventsRaw) ? bitEventsRaw : []
+    for (const e of bitEvents) {
+      const venue = e.venue || {}
+      const date = e.datetime || ''
+      const venueName = venue.name || ''
+      const key = dedupeKey(date, venueName)
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const lat = typeof venue.latitude === 'string' ? parseFloat(venue.latitude) : (venue.latitude ?? null)
+      const lng = typeof venue.longitude === 'string' ? parseFloat(venue.longitude) : (venue.longitude ?? null)
+      const address = [venue.name, venue.city, venue.region, venue.country].filter(Boolean).join(', ')
+      const ticket_links = (e.offers ?? [])
+        .filter((o: any) => o.type === 'Tickets' && o.url)
+        .map((o: any) => ({ source: o.status || 'Bandsintown', url: o.url }))
+
+      results.push({
+        id: `tour_${results.length}`,
+        name: e.lineup?.[0] || query,
+        date,
+        venue: venueName,
+        address,
+        lat: Number.isFinite(lat) ? lat : null,
+        lng: Number.isFinite(lng) ? lng : null,
+        image: e.artist?.image_url || '',
+        description: e.description || '',
+        link: e.url || '',
+        ticket_links,
+        source: 'bandsintown',
+      })
+    }
+
+    // 2. Google Events — fill gaps Bandsintown missed
     const events = eventsRes.events_results ?? []
     for (const e of events) {
-      // Skip events that don't seem related to the artist
       const title = (e.title || '').toLowerCase()
-      const queryLower = query.toLowerCase()
-      const words = queryLower.split(/\s+/)
-      const isRelevant = words.some((w: string) => title.includes(w))
-      if (!isRelevant) continue
+      if (!title.includes(queryLower)) continue
+
+      const date = e.date?.when || e.date?.start_date || ''
+      const venueName = e.venue?.name || (e.address?.[0]) || ''
+      const key = dedupeKey(date, venueName)
+      if (seen.has(key)) continue
+      seen.add(key)
 
       const address = (e.address || []).join(', ')
       let lat: number | null = null
       let lng: number | null = null
-
-      // Geocode the venue
       if (address) {
         try {
           const geoRes = await fetch(
@@ -60,12 +118,11 @@ export async function GET(req: NextRequest) {
       }
 
       const tickets = (e.ticket_info ?? []).filter((t: any) => t.link_type === 'tickets')
-
       results.push({
         id: `tour_${results.length}`,
         name: e.title,
-        date: e.date?.when || e.date?.start_date || '',
-        venue: e.venue?.name || (e.address?.[0]) || '',
+        date,
+        venue: venueName,
         address,
         lat,
         lng,
@@ -77,12 +134,13 @@ export async function GET(req: NextRequest) {
       })
     }
 
-    // Extract tour links from Google organic results
+    // Tour links from Google organic — title or snippet must mention the artist
     const tourLinks: any[] = []
     for (const r of (organicRes.organic_results ?? []).slice(0, 8)) {
       const link = r.link || ''
-      const isTicketSite = /ticketmaster|livenation|seatgeek|stubhub|axs\.com|bandsintown|songkick|spotify\.com\/concert/i.test(link)
-      if (!isTicketSite) continue
+      if (!link) continue
+      const haystack = `${r.title || ''} ${r.snippet || ''}`.toLowerCase()
+      if (!haystack.includes(queryLower)) continue
 
       tourLinks.push({
         source: new URL(link).hostname.replace('www.', ''),
@@ -92,11 +150,7 @@ export async function GET(req: NextRequest) {
       })
     }
 
-    return NextResponse.json({
-      artist: query,
-      events: results,
-      tourLinks,
-    })
+    return NextResponse.json({ artist: query, events: results, tourLinks })
   } catch (err) {
     return NextResponse.json({ artist: query, events: [], tourLinks: [] })
   }

--- a/apps/web/app/api/events/artist/route.ts
+++ b/apps/web/app/api/events/artist/route.ts
@@ -2,51 +2,38 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getOptionalParam, CACHE_1H, rateLimit } from '@/lib/api-utils'
 
 const SERPAPI_KEY = process.env.SERPAPI_KEY || ''
-const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || 'travyl'
 
 /**
- * Artist tour search.
+ * Artist tour search via SerpAPI Google Events + Google organic.
+ * ?q=Drake — artist name
  *
- * Two sources, weighted in this order:
- *   1. Bandsintown — canonical artist database. Disambiguates by artist ID
- *      server-side ("Drake" the rapper, not "Drake Milligan" the country
- *      singer), so its hits are trusted and surfaced first.
- *   2. SerpAPI Google Events — broader coverage for artists Bandsintown
- *      doesn't track. Filtered down to titles that contain the artist phrase.
+ * Disambiguation is delegated to Google: the artist name is sent quoted
+ * (`"Drake"`) so Google only returns results containing that exact phrase.
+ * A substring check on the title catches stragglers — no hardcoded
+ * stopwords or tokenization in our code.
  *
- * Results are deduped by `${date}|${venue}` so the same show doesn't appear
- * twice when both sources see it.
+ * Note: Bandsintown's free API is no longer available for third-party access
+ * (they've locked it down behind a paid integration partnership), so we rely
+ * solely on Google here.
  */
 export async function GET(req: NextRequest) {
   const rl = rateLimit(req, 'events-artist', 20, 60000)
   if (rl) return rl
   const query = getOptionalParam(req, 'q', '').trim()
   if (!query) return NextResponse.json([])
+  if (!SERPAPI_KEY) return NextResponse.json({ error: 'SerpAPI key not configured' }, { status: 503 })
 
   const queryLower = query.toLowerCase()
   const quotedQuery = `"${query}"`
 
   try {
-    const [bitEventsRaw, eventsRes, organicRes] = await Promise.all([
-      // Bandsintown: artist-disambiguated event list
-      fetch(
-        `https://rest.bandsintown.com/artists/${encodeURIComponent(query)}/events?app_id=${encodeURIComponent(BANDSINTOWN_APP_ID)}`,
-        { ...CACHE_1H, headers: { Accept: 'application/json' } },
-      )
-        .then(r => r.ok ? r.json() as Promise<any[]> : [] as any[])
-        .catch(() => [] as any[]),
-      // Google Events with quoted artist
-      SERPAPI_KEY
-        ? fetch(`https://serpapi.com/search.json?engine=google_events&q=${encodeURIComponent(`${quotedQuery} concert tour`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-            .then(r => r.ok ? r.json() as Promise<any> : {} as any)
-            .catch(() => ({}))
-        : Promise.resolve({}),
-      // Google organic for ticket links
-      SERPAPI_KEY
-        ? fetch(`https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(`${quotedQuery} tour dates concert tickets`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
-            .then(r => r.ok ? r.json() as Promise<any> : {} as any)
-            .catch(() => ({}))
-        : Promise.resolve({}),
+    const [eventsRes, organicRes] = await Promise.all([
+      fetch(`https://serpapi.com/search.json?engine=google_events&q=${encodeURIComponent(`${quotedQuery} concert tour`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
+        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
+        .catch(() => ({})),
+      fetch(`https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(`${quotedQuery} tour dates concert tickets`)}&api_key=${SERPAPI_KEY}`, CACHE_1H)
+        .then(r => r.ok ? r.json() as Promise<any> : {} as any)
+        .catch(() => ({})),
     ])
 
     const seen = new Set<string>()
@@ -54,44 +41,12 @@ export async function GET(req: NextRequest) {
       `${(date || '').toLowerCase()}|${(venue || '').toLowerCase()}`
 
     const results: any[] = []
-
-    // 1. Bandsintown — trusted, comes first
-    const bitEvents = Array.isArray(bitEventsRaw) ? bitEventsRaw : []
-    for (const e of bitEvents) {
-      const venue = e.venue || {}
-      const date = e.datetime || ''
-      const venueName = venue.name || ''
-      const key = dedupeKey(date, venueName)
-      if (seen.has(key)) continue
-      seen.add(key)
-
-      const lat = typeof venue.latitude === 'string' ? parseFloat(venue.latitude) : (venue.latitude ?? null)
-      const lng = typeof venue.longitude === 'string' ? parseFloat(venue.longitude) : (venue.longitude ?? null)
-      const address = [venue.name, venue.city, venue.region, venue.country].filter(Boolean).join(', ')
-      const ticket_links = (e.offers ?? [])
-        .filter((o: any) => o.type === 'Tickets' && o.url)
-        .map((o: any) => ({ source: o.status || 'Bandsintown', url: o.url }))
-
-      results.push({
-        id: `tour_${results.length}`,
-        name: e.lineup?.[0] || query,
-        date,
-        venue: venueName,
-        address,
-        lat: Number.isFinite(lat) ? lat : null,
-        lng: Number.isFinite(lng) ? lng : null,
-        image: e.artist?.image_url || '',
-        description: e.description || '',
-        link: e.url || '',
-        ticket_links,
-        source: 'bandsintown',
-      })
-    }
-
-    // 2. Google Events — fill gaps Bandsintown missed
     const events = eventsRes.events_results ?? []
+
     for (const e of events) {
       const title = (e.title || '').toLowerCase()
+      // Safety net: drop any event whose title doesn't contain the artist
+      // phrase. Google's exact-phrase search already does the heavy lifting.
       if (!title.includes(queryLower)) continue
 
       const date = e.date?.when || e.date?.start_date || ''


### PR DESCRIPTION
## Summary
- Bug: artist search returned wrong artist (e.g. \"Drake\" surfaced \"Drake Milligan\" the country singer) because the previous \`words.some()\` filter accepted any event whose title shared a single word with the query.
- Fix: use SerpAPI Google Events with **exact-phrase quoting** (\`\"Drake\"\`) and a substring safety net. Removed hardcoded stopword list and ticket-vendor regex per project guideline (everything dynamic).
- Bandsintown integration was attempted but **rolled back** — they denied API access (email 2026-04-28). Falling back to Google-only.

## What changed
- SerpAPI calls now wrap the artist name in quotes so Google filters unrelated artists upstream.
- Substring check on event titles + organic snippets as a safety net only.
- Cross-source dedupe scaffolding (kept simple now, useful when we add another source).
- Tour-link filter: dropped the hardcoded \`ticketmaster|livenation|...\` regex; we now keep any organic result whose title or snippet mentions the artist.

## Test plan
- [x] \`npm run build\` clean for apps/web
- [x] \`curl /api/events/artist?q=Drake\` returns events with no crash
- [x] \`curl /api/events/artist?q=Tame%20Impala\` returns ticketmaster/seatgeek/etc. links
- [ ] Manually verify on www that \"Drake\" returns rapper events more reliably than before (still leaks \"Drake Milligan\" for ambiguous names — long-term fix is a real artist-database integration)

## Notes
- Bandsintown's free \`app_id\` placeholder returns 403; their team confirmed via email they don't grant casual API access. Long-term we'll need MusicBrainz (free, no auth) or a paid partnership.