### PR TITLE
feat: AuthGuard + profile layout for auth redirect (TRA-439)

### DIFF
--- a/apps/web/app/(main)/profile/layout.tsx
+++ b/apps/web/app/(main)/profile/layout.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { AuthGuard } from '@/components/auth/AuthGuard'
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return <AuthGuard>{children}</AuthGuard>
+}

--- a/apps/web/app/(main)/profile/page.tsx
+++ b/apps/web/app/(main)/profile/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { useTrips, useAuthStore, useProfile } from '@travyl/shared'
 import type { Trip, TripCard as TripCardType } from '@travyl/shared'
 import { TripCard } from '@/components/trips/TripCard'
-import { Settings, LogOut, User, MapPin, Calendar, Heart } from 'lucide-react'
+import { Settings, LogOut, MapPin, Calendar, Heart } from 'lucide-react'
 import { toast } from 'sonner'
 
 // Transform Trip to TripCard for the component
@@ -22,7 +22,6 @@ function tripToCard(trip: Trip): TripCardType {
 export default function ProfilePage() {
   const router = useRouter()
   const user = useAuthStore((s) => s.user)
-  const loading = useAuthStore((s) => s.loading)
   const signOut = useAuthStore((s) => s.signOut)
   const { data: profile } = useProfile()
   const { data: trips, isLoading: tripsLoading } = useTrips()
@@ -37,35 +36,6 @@ export default function ProfilePage() {
     } catch (error) {
       toast.error('Failed to sign out')
     }
-  }
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-gray-600">Loading...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center">
-        <div className="text-center">
-          <User className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">Authentication Required</h1>
-          <p className="text-gray-600 mb-6">Please sign in to view your profile</p>
-          <Link
-            href="/login"
-            className="inline-block px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-          >
-            Sign In
-          </Link>
-        </div>
-      </div>
-    )
   }
 
   const displayName = profile?.display_name || user.email?.split('@')[0] || 'User'

--- a/apps/web/app/(main)/profile/settings/page.tsx
+++ b/apps/web/app/(main)/profile/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
-import { User, Compass, Bell, Settings, CheckCircle, Plane, Hotel, Loader2, AlertCircle, Plus, Eye, Check, Shield, Smartphone, LogOut, Star, HelpCircle, MessageSquare, Trash2, X, ChevronDown, Pencil, ClipboardList, Activity, Zap, ArrowLeft } from 'lucide-react';
+import { User, Compass, Bell, Settings, CheckCircle, Plane, Hotel, Loader2, Plus, Eye, Check, Shield, Smartphone, LogOut, Star, HelpCircle, MessageSquare, Trash2, X, ChevronDown, Pencil, ClipboardList, Activity, Zap, ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { AvatarUpload } from '@/components/AvatarUpload';
@@ -299,21 +299,9 @@ export default function ProfileSettings() {
   // ─── Load Profile Data ───────────────────────────────
   useEffect(() => {
     async function loadProfile() {
-      // Wait for auth to finish loading
-      if (authLoading) {
-        return;
-      }
-
       try {
         setIsLoading(true);
         setError(null);
-
-        // Check if user is authenticated
-        if (!user || !session) {
-          setError('Sign In to View');
-          setIsLoading(false);
-          return;
-        }
 
         // Check if Supabase is configured
         if (!supabase) {
@@ -673,43 +661,6 @@ export default function ProfileSettings() {
           </div>
         </div>
       </div>
-    );
-  }
-
-  if (error && !user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-[#f8fafc] to-[#e0f2fe]">
-        <div className="flex items-center justify-center p-6 pt-24">
-          <div className="max-w-md w-full text-center bg-white rounded-3xl shadow-2xl p-10">
-          {/* Travyl Logo */}
-          <div className="flex items-center justify-center gap-3 mb-8">
-            <span className="text-3xl font-black text-[#1e3a5f] tracking-wider">TRAVYL</span>
-            <svg
-              viewBox="0 0 64 64"
-              className="w-10 h-10"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M60 10 L20 36 L6 34 Z" fill="#ffffff" stroke="#1e3a5f" strokeWidth="2"/>
-              <path d="M48 48 L30 40 L26 38 L60 10 Z" fill="#ffffff" stroke="#1e3a5f" strokeWidth="2"/>
-              <path d="M52 16 L26 38 L24 50 L20 36 Z" fill="#ffffff" stroke="#1e3a5f" strokeWidth="2"/>
-            </svg>
-          </div>
-
-          <div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
-            <AlertCircle size={40} className="text-red-500" />
-          </div>
-          <h2 className="text-2xl font-bold text-[#1e3a5f] mb-1">Access Denied</h2>
-          <h3 className="text-2xl font-bold text-[#1e3a5f] mb-6">{error}</h3>
-          <a
-            href="/login"
-            className="inline-flex items-center gap-2 px-8 py-3 bg-[#1e3a5f] text-white rounded-xl hover:bg-[#2a4a6f] transition-all font-bold shadow-lg"
-          >
-            Sign In
-          </a>
-        </div>
-      </div>
-    </div>
     );
   }
 

--- a/apps/web/components/auth/AuthGuard.tsx
+++ b/apps/web/components/auth/AuthGuard.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+import { useAuthStore } from '@travyl/shared'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function AuthGuard({ children }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const user = useAuthStore((s) => s.user)
+  const loading = useAuthStore((s) => s.loading)
+
+  useEffect(() => {
+    if (loading) return
+    if (!user) {
+      router.replace(`/login?next=${encodeURIComponent(pathname)}`)
+    }
+  }, [loading, user, router, pathname])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-600">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return null
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Create reusable `AuthGuard` client component with spinner/redirect/render pattern
- Add `profile/layout.tsx` wrapping both `/profile` and `/profile/settings` in AuthGuard
- Remove inline auth checks from profile page and settings page
- Unauthenticated users now redirect to `/login?next=<path>` instead of seeing a banner

## Test plan
- [ ] Visit `/profile` unauthenticated → redirect to `/login?next=%2Fprofile`
- [ ] Visit `/profile/settings` unauthenticated → redirect to `/login?next=%2Fprofile%2Fsettings`
- [ ] Authenticated users can access profile pages normally
- [ ] Other `(main)` routes (/, /places, /trips, /login) unaffected