### PR TITLE
feat: trip history restore-to-point + shared history service (TRA-429)

### DIFF
--- a/apps/web/components/calendar/HistoryDrawer.tsx
+++ b/apps/web/components/calendar/HistoryDrawer.tsx
@@ -1,11 +1,11 @@
 'use client'
-import { useEffect, useState } from 'react'
-import { Xmark, Undo } from 'iconoir-react'
+import { useEffect, useState, useMemo } from 'react'
+import { Xmark, Undo, ClockRotateLeft } from 'iconoir-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useActivityHistory, type AuditEntry } from './hooks/useActivityHistory'
 import { formatDistanceToNow } from 'date-fns'
 import type { CalendarActivity } from './types'
-import { toCalendarActivity, supabase, type ActivityRow } from '@travyl/shared'
+import { toCalendarActivity, supabase, type ActivityRow, groupAuditEntries, buildRestorePlan } from '@travyl/shared'
 
 interface Props {
   tripId: string
@@ -39,8 +39,12 @@ export function HistoryDrawer({
   tripId, isOpen, onClose, onMove, onEdit, onDelete, onAdd, tripStartDate, userId,
 }: Props) {
   const [isVisible, setIsVisible] = useState(false)
+  const [restoring, setRestoring] = useState(false)
+  const [confirmGroupId, setConfirmGroupId] = useState<string | null>(null)
   const queryClient = useQueryClient()
   const { data: entries = [], isLoading } = useActivityHistory(tripId, isOpen)
+
+  const groups = useMemo(() => groupAuditEntries(entries, 3), [entries])
 
   useEffect(() => {
     if (isOpen) {
@@ -86,27 +90,67 @@ export function HistoryDrawer({
       user_id: userId,
     })
 
-
     queryClient.invalidateQueries({ queryKey: ['activity-history', tripId] })
+  }
+
+  async function handleRestoreToPoint(groupTimestamp: string) {
+    setRestoring(true)
+    try {
+      const plan = buildRestorePlan(entries, groupTimestamp)
+      for (const entry of plan) {
+        const activityId = entry.activity_id
+        switch (entry.edit_type) {
+          case 'move': {
+            const orig = entry.original_data as any
+            onMove(activityId, orig.day, orig.startHour)
+            break
+          }
+          case 'edit':
+            onEdit(activityId, entry.original_data as Partial<CalendarActivity>)
+            break
+          case 'create':
+            await onDelete(activityId)
+            break
+          case 'delete': {
+            const activity = toCalendarActivity(entry.original_data as unknown as ActivityRow, tripStartDate)
+            await onAdd(activity)
+            break
+          }
+        }
+
+        await supabase.from('itinerary_edits').insert({
+          trip_id: tripId,
+          activity_id: activityId,
+          edit_type: 'revert',
+          original_data: entry.new_data,
+          new_data: entry.original_data,
+          user_id: userId,
+        })
+      }
+      queryClient.invalidateQueries({ queryKey: ['activity-history', tripId] })
+    } finally {
+      setRestoring(false)
+      setConfirmGroupId(null)
+    }
   }
 
   return (
     <div className="fixed inset-0 z-40 pointer-events-none">
       <div
         className={[
-          'absolute right-0 top-0 h-full w-80 bg-white dark:bg-[#0f1a28] border-l border-gray-200 dark:border-[#1e3a5f]/40 shadow-xl pointer-events-auto flex flex-col transition-transform duration-300',
+          'absolute right-0 top-0 h-full w-80 bg-white dark:bg-cal-surface-elevated border-l border-gray-200 dark:border-cal-border shadow-xl pointer-events-auto flex flex-col transition-transform duration-300',
           isVisible ? 'translate-x-0' : 'translate-x-full',
         ].join(' ')}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-[#1e3a5f]/30">
-          <h2 className="text-sm font-semibold text-gray-900 dark:text-[#f5efe8]">Change history</h2>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-cal-border">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-cal-text">Change history</h2>
           <button
             onClick={onClose}
             aria-label="Close history"
-            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30"
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-cal-accent-bg"
           >
-            <Xmark className="w-4 h-4 text-gray-500 dark:text-[#7a9cc0]" />
+            <Xmark className="w-4 h-4 text-gray-500 dark:text-cal-text-secondary" />
           </button>
         </div>
 
@@ -115,33 +159,80 @@ export function HistoryDrawer({
           {isLoading && (
             <p className="px-4 py-3 text-xs text-gray-400 animate-pulse">Loading history…</p>
           )}
-          {!isLoading && entries.length === 0 && (
-            <p className="px-4 py-6 text-xs text-center text-gray-400 dark:text-[#4a7ab5]">No changes yet</p>
+          {!isLoading && groups.length === 0 && (
+            <p className="px-4 py-6 text-xs text-center text-gray-400 dark:text-cal-text-secondary">No changes yet</p>
           )}
-          {entries.map((entry) => (
-            <div
-              key={entry.id}
-              className="flex items-start gap-2 px-4 py-2.5 border-b border-gray-50 dark:border-[#1e3a5f]/20 hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/10"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="text-xs text-gray-700 dark:text-[#cdd9e5] leading-snug">
-                  <span className="font-medium">{entry.displayName}</span>{' '}
-                  {describeEntry(entry)}
-                </p>
-                <p className="text-[11px] text-gray-400 dark:text-[#4a7ab5] mt-0.5">
-                  {formatDistanceToNow(new Date(entry.created_at), { addSuffix: true })}
-                </p>
+          {groups.map((group) => (
+            <div key={group.id} className="border-b border-gray-100 dark:border-cal-border/70">
+              {/* Group header */}
+              <div className="flex items-center justify-between px-4 py-2 bg-gray-50/50 dark:bg-cal-accent-bg/20">
+                <span className="text-[11px] text-gray-500 dark:text-cal-text-secondary font-medium">
+                  {group.label}
+                  {group.entries.length > 1 && (
+                    <span className="text-gray-400 dark:text-cal-text-secondary/60 ml-1">
+                      ({group.entries.length} changes)
+                    </span>
+                  )}
+                </span>
+                {group.entries.some((e) => e.edit_type !== 'revert') && (
+                  confirmGroupId === group.id ? (
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        onClick={() => setConfirmGroupId(null)}
+                        disabled={restoring}
+                        className="text-[10px] px-2 py-0.5 rounded text-gray-500 hover:bg-gray-200 dark:hover:bg-cal-accent-bg transition-colors"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => handleRestoreToPoint(group.timestamp)}
+                        disabled={restoring}
+                        className="text-[10px] px-2 py-0.5 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
+                      >
+                        {restoring ? 'Restoring…' : 'Confirm'}
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmGroupId(group.id)}
+                      disabled={restoring}
+                      title="Restore itinerary to this point"
+                      className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                    >
+                      <ClockRotateLeft className="w-3 h-3" />
+                      Restore to here
+                    </button>
+                  )
+                )}
               </div>
-              {entry.edit_type !== 'revert' && (
-                <button
-                  onClick={() => handleRevert(entry)}
-                  title="Revert this change"
-                  aria-label={`Revert: ${describeEntry(entry)}`}
-                  className="shrink-0 p-1 rounded text-gray-400 hover:text-gray-600 dark:hover:text-[#cdd9e5] hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30"
+
+              {/* Group entries */}
+              {group.entries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="flex items-start gap-2 px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-cal-accent-bg/30"
                 >
-                  <Undo className="w-3.5 h-3.5" />
-                </button>
-              )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-gray-700 dark:text-cal-text leading-snug">
+                      <span className="font-medium">{entry.displayName}</span>{' '}
+                      {describeEntry(entry)}
+                    </p>
+                    <p className="text-[11px] text-gray-400 dark:text-cal-text-secondary mt-0.5">
+                      {formatDistanceToNow(new Date(entry.created_at), { addSuffix: true })}
+                    </p>
+                  </div>
+                  {entry.edit_type !== 'revert' && (
+                    <button
+                      onClick={() => handleRevert(entry)}
+                      title="Revert this change"
+                      aria-label={`Revert: ${describeEntry(entry)}`}
+                      className="shrink-0 p-1 rounded text-gray-400 hover:text-gray-600 dark:hover:text-cal-text hover:bg-gray-100 dark:hover:bg-cal-accent-bg"
+                    >
+                      <Undo className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/apps/web/components/calendar/hooks/useActivityHistory.ts
+++ b/apps/web/components/calendar/hooks/useActivityHistory.ts
@@ -1,55 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@travyl/shared'
+import { fetchAuditEntries } from '@travyl/shared'
+import type { EnrichedAuditEntry } from '@travyl/shared'
 
-export interface AuditEntry {
-  id: string
-  activity_id: string
-  edit_type: 'create' | 'delete' | 'move' | 'edit' | 'revert'
-  original_data: Record<string, unknown> | null
-  new_data: Record<string, unknown> | null
-  user_id: string | null
-  created_at: string
-  displayName: string   // merged from profiles
-  activityName: string  // best-effort from new_data or original_data
-}
-
-async function fetchHistory(tripId: string): Promise<AuditEntry[]> {
-  const { data: edits, error } = await supabase
-    .from('itinerary_edits')
-    .select('*')
-    .eq('trip_id', tripId)
-    .order('created_at', { ascending: false })
-    .limit(100)
-
-  if (error || !edits) return []
-
-  const userIds = [...new Set(edits.map((e) => e.user_id).filter(Boolean))]
-  const { data: profiles } = await supabase
-    .from('profiles')
-    .select('id, display_name')
-    .in('id', userIds)
-
-  const nameMap: Record<string, string> = {}
-  for (const p of profiles ?? []) {
-    nameMap[p.id] = p.display_name ?? 'Unknown'
-  }
-
-  return edits.map((e) => ({
-    ...e,
-    displayName: e.user_id ? (nameMap[e.user_id] ?? 'Unknown') : 'Unknown',
-    activityName:
-      (e.new_data as any)?.title ??
-      (e.original_data as any)?.title ??
-      (e.new_data as any)?.activity_name ??
-      (e.original_data as any)?.activity_name ??
-      'Activity',
-  }))
-}
+export type AuditEntry = EnrichedAuditEntry
+export type { EnrichedAuditEntry }
 
 export function useActivityHistory(tripId: string, enabled: boolean) {
   return useQuery({
     queryKey: ['activity-history', tripId],
-    queryFn: () => fetchHistory(tripId),
+    queryFn: () => fetchAuditEntries(tripId),
     enabled,
     staleTime: 0,
   })

--- a/apps/web/components/trip/TripHistoryPanel.tsx
+++ b/apps/web/components/trip/TripHistoryPanel.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { History, X } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@travyl/shared'
+import { supabase, fetchAuditEntries, type EnrichedAuditEntry } from '@travyl/shared'
 import { formatDistanceToNow } from 'date-fns'
 
 // ── Types ───────────────────────────────────────────────────
@@ -29,18 +29,42 @@ function actionBadge(action: string): { label: string; color: string; bg: string
   return { label: 'Changed', color: '#94a3b8', bg: 'rgba(148,163,184,0.12)' }
 }
 
+// ── Helpers ─────────────────────────────────────────────────
+
+function auditEntryToHistoryEntry(e: EnrichedAuditEntry, nameMap: Record<string, string>): HistoryEntry {
+  let action = ''
+  switch (e.edit_type) {
+    case 'create':  action = `Added "${e.activityName}"`; break
+    case 'delete':  action = `Removed "${e.activityName}"`; break
+    case 'move':    action = `Moved "${e.activityName}"`; break
+    case 'edit':    action = `Edited "${e.activityName}"`; break
+    case 'revert':  action = `Reverted "${e.activityName}"`; break
+    default:        action = `Changed "${e.activityName}"`
+  }
+
+  return {
+    id: `audit-${e.id}`,
+    type: 'audit',
+    action,
+    activityName: e.activityName,
+    displayName: e.user_id ? (nameMap[e.user_id] ?? 'Someone') : 'Someone',
+    timestamp: e.created_at,
+  }
+}
+
 // ── Data fetcher ────────────────────────────────────────────
 
 async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
   const entries: HistoryEntry[] = []
 
-  // 1. Fetch audit entries from itinerary_edits
-  const { data: edits } = await supabase
-    .from('itinerary_edits')
-    .select('*')
-    .eq('trip_id', tripId)
-    .order('created_at', { ascending: false })
-    .limit(50)
+  // 1. Fetch audit entries from shared service
+  const edits = await fetchAuditEntries(tripId, { limit: 100 })
+
+  // Build name map from returned entries (already resolved by shared service)
+  const nameMap: Record<string, string> = {}
+  for (const e of edits) {
+    if (e.user_id) nameMap[e.user_id] = e.displayName
+  }
 
   // 2. Fetch activity records for created_at timestamps (supplements audit)
   const { data: activities } = await supabase
@@ -50,56 +74,29 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
     .order('created_at', { ascending: false })
     .limit(50)
 
-  // Collect all user IDs for profile lookup
-  const userIds = new Set<string>()
-  for (const e of edits ?? []) if (e.user_id) userIds.add(e.user_id)
-  for (const a of activities ?? []) if (a.user_id) userIds.add(a.user_id)
+  // Add any missing user IDs from activities
+  const activityUserIds = new Set<string>()
+  for (const a of activities ?? []) if (a.user_id) activityUserIds.add(a.user_id)
 
-  const nameMap: Record<string, string> = {}
-  if (userIds.size > 0) {
+  const missingIds = [...activityUserIds].filter((id) => !nameMap[id])
+  if (missingIds.length > 0) {
     const { data: profiles } = await supabase
       .from('profiles')
       .select('id, display_name')
-      .in('id', [...userIds])
+      .in('id', missingIds)
     for (const p of profiles ?? []) {
       nameMap[p.id] = p.display_name ?? 'Unknown'
     }
   }
 
-  // Build audit entries
+  // Track which activities have audit creates
   const auditActivityIds = new Set<string>()
-  for (const e of edits ?? []) {
-    const name =
-      (e.new_data as any)?.title ??
-      (e.original_data as any)?.title ??
-      (e.new_data as any)?.activity_name ??
-      (e.original_data as any)?.activity_name ??
-      'Activity'
-    const displayName = e.user_id ? (nameMap[e.user_id] ?? 'Someone') : 'Someone'
-
-    let action = ''
-    switch (e.edit_type) {
-      case 'create':  action = `Added "${name}"`; break
-      case 'delete':  action = `Removed "${name}"`; break
-      case 'move':    action = `Moved "${name}"`; break
-      case 'edit':    action = `Edited "${name}"`; break
-      case 'revert':  action = `Reverted "${name}"`; break
-      default:        action = `Changed "${name}"`
-    }
-
-    entries.push({
-      id: `audit-${e.id}`,
-      type: 'audit',
-      action,
-      activityName: name,
-      displayName,
-      timestamp: e.created_at,
-    })
-
+  for (const e of edits) {
     if (e.edit_type === 'create') auditActivityIds.add(e.activity_id)
+    entries.push(auditEntryToHistoryEntry(e, nameMap))
   }
 
-  // Add activity creation entries that have no audit trail (pre-audit activities)
+  // Add activity creation entries that have no audit trail
   for (const a of activities ?? []) {
     if (auditActivityIds.has(a.id)) continue
     const displayName = a.user_id ? (nameMap[a.user_id] ?? 'Someone') : 'Someone'
@@ -113,7 +110,7 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
     })
   }
 
-  // 3. Always pull from trip_context — user_history (manual actions) + itinerary (planner)
+  // 3. Enrich from trip_context
   {
     const { data: trip } = await supabase
       .from('trips')
@@ -124,7 +121,6 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
     if (trip) {
       const ctx = trip.trip_context as any
 
-      // User actions (manual adds/removes)
       const userHistory = (ctx?.user_history ?? []) as { action: string; timestamp: string; actor: string }[]
       for (const h of userHistory) {
         entries.push({
@@ -137,7 +133,6 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
         })
       }
 
-      // Planner-generated itinerary items (only if no audit data)
       if (entries.length === userHistory.length) {
         const itinerary = ctx?.itinerary ?? []
         for (const day of itinerary) {
@@ -155,7 +150,6 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
         }
       }
 
-      // Trip lifecycle events
       entries.push({
         id: 'trip-created',
         type: 'audit',
@@ -178,9 +172,7 @@ async function fetchTripHistory(tripId: string): Promise<HistoryEntry[]> {
     }
   }
 
-  // Sort all entries by timestamp, newest first
   entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-
   return entries
 }
 
@@ -197,7 +189,6 @@ function useTripHistory(tripId: string, enabled: boolean) {
 
 // ── Panel Component ─────────────────────────────────────────
 
-// Compact floating panel — top-right corner, no backdrop, doesn't block the page
 function HistoryPanel({ tripId, isOpen, onClose }: { tripId: string; isOpen: boolean; onClose: () => void }) {
   const { data: entries = [], isLoading } = useTripHistory(tripId, isOpen)
 

--- a/packages/shared/src/services/historyService.ts
+++ b/packages/shared/src/services/historyService.ts
@@ -1,0 +1,125 @@
+import { supabase } from './supabase'
+import type { EnrichedAuditEntry, ItineraryEditRow, TimelineGroup } from '../types'
+
+export interface FetchAuditOptions {
+  limit?: number
+}
+
+/**
+ * Fetches itinerary edit entries with profile display name resolution.
+ */
+export async function fetchAuditEntries(
+  tripId: string,
+  options: FetchAuditOptions = {},
+): Promise<EnrichedAuditEntry[]> {
+  const { data: edits, error } = await supabase
+    .from('itinerary_edits')
+    .select('*')
+    .eq('trip_id', tripId)
+    .order('created_at', { ascending: false })
+    .limit(options.limit ?? 100)
+
+  if (error || !edits) return []
+
+  const userIds = [...new Set(edits.map((e) => e.user_id).filter(Boolean))]
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .in('id', userIds)
+
+  const nameMap: Record<string, string> = {}
+  for (const p of profiles ?? []) {
+    nameMap[p.id] = p.display_name ?? 'Unknown'
+  }
+
+  return edits.map((e) => ({
+    ...e,
+    displayName: e.user_id ? (nameMap[e.user_id] ?? 'Unknown') : 'Unknown',
+    activityName:
+      (e.new_data as any)?.title ??
+      (e.original_data as any)?.title ??
+      (e.new_data as any)?.activity_name ??
+      (e.original_data as any)?.activity_name ??
+      'Activity',
+  }))
+}
+
+/**
+ * Groups audit entries into timeline windows.
+ * Entries within `windowMinutes` of each other are bundled together.
+ */
+export function groupAuditEntries(
+  entries: EnrichedAuditEntry[],
+  windowMinutes: number = 3,
+): TimelineGroup[] {
+  if (entries.length === 0) return []
+
+  const groups: TimelineGroup[] = []
+  let currentEntries: EnrichedAuditEntry[] = []
+  let currentStart: Date | null = null
+
+  for (const entry of entries) {
+    const ts = new Date(entry.created_at)
+
+    if (!currentStart) {
+      currentStart = ts
+      currentEntries = [entry]
+      continue
+    }
+
+    const diffMs = currentStart.getTime() - ts.getTime()
+    if (diffMs <= windowMinutes * 60 * 1000) {
+      currentEntries.push(entry)
+    } else {
+      groups.push(buildGroup(currentEntries))
+      currentStart = ts
+      currentEntries = [entry]
+    }
+  }
+
+  if (currentEntries.length > 0) {
+    groups.push(buildGroup(currentEntries))
+  }
+
+  return groups
+}
+
+function buildGroup(entries: EnrichedAuditEntry[]): TimelineGroup {
+  const ts = entries[0].created_at
+  const date = new Date(ts)
+  const label = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+  return {
+    id: `group-${entries[0].id}`,
+    entries,
+    label,
+    timestamp: ts,
+    earliestId: entries[0].id,
+  }
+}
+
+/**
+ * Builds a restore plan: for each entry after `targetTimestamp`,
+ * returns the reverse operation needed. The plan is ordered from
+ * most recent to oldest, so executing in order reverses state
+ * back to the target point.
+ */
+export function buildRestorePlan(
+  entries: EnrichedAuditEntry[],
+  targetTimestamp: string,
+): EnrichedAuditEntry[] {
+  const target = new Date(targetTimestamp).getTime()
+
+  // Collect entries that happened AFTER the target point
+  const after = entries
+    .filter((e) => new Date(e.created_at).getTime() > target)
+    // Process from most recent to oldest
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+
+  // Filter out revert entries — they shouldn't be re-reverted as part of bulk restore
+  return after.filter((e) => e.edit_type !== 'revert')
+}

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -82,3 +82,9 @@ export {
   mapApiPlace,
 } from './placesDiscovery';
 export type { DiscoverPageResult } from './placesDiscovery';
+
+export {
+  fetchAuditEntries,
+  groupAuditEntries,
+  buildRestorePlan,
+} from './historyService';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1058,3 +1058,29 @@ export interface BudgetItem {
   fixed: boolean;
   expenses: BudgetExpense[];
 }
+
+// ─── History / Audit ───────────────────────────────────────
+
+export interface ItineraryEditRow {
+  id: string
+  trip_id: string
+  activity_id: string
+  edit_type: 'create' | 'delete' | 'move' | 'edit' | 'revert'
+  original_data: Record<string, unknown> | null
+  new_data: Record<string, unknown> | null
+  user_id: string | null
+  created_at: string
+}
+
+export interface EnrichedAuditEntry extends ItineraryEditRow {
+  displayName: string
+  activityName: string
+}
+
+export interface TimelineGroup {
+  id: string
+  entries: EnrichedAuditEntry[]
+  label: string
+  timestamp: string
+  earliestId: string
+}


### PR DESCRIPTION
## Summary
- Add `fetchAuditEntries`, `groupAuditEntries`, `buildRestorePlan` to `@travyl/shared`
- Group history entries into 3-minute time windows with labels
- "Restore to here" button per window with inline confirmation
- Execute bulk restore plan by reversing all changes after target timestamp
- Refactor `useActivityHistory` and `TripHistoryPanel` to use shared fetcher

## Test plan
- [ ] Open calendar HistoryDrawer → entries grouped in time windows
- [ ] "Restore to here" button visible per group
- [ ] Click restore → confirmation shown → execute → entries reverted
- [ ] TripHistoryPanel continues working with shared data source