### PR TITLE
refactor: replace hardcoded navy colors with CSS custom properties

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -140,6 +140,24 @@
   --color-trip-base-dark: var(--trip-base-dark, #0f1d30);
   --color-trip-accent: var(--trip-accent, #60a5fa);
   --color-trip-text: var(--trip-text, #ffffff);
+
+  /* Calendar light/dark variables */
+  --color-cal-bg: var(--cal-bg);
+  --color-cal-surface: var(--cal-surface);
+  --color-cal-surface-elevated: var(--cal-surface-elevated);
+  --color-cal-text: var(--cal-text);
+  --color-cal-text-secondary: var(--cal-text-secondary);
+  --color-cal-text-tertiary: var(--cal-text-tertiary);
+  --color-cal-border: var(--cal-border);
+  --color-cal-border-light: var(--cal-border-light);
+  --color-cal-accent: var(--cal-accent);
+  --color-cal-accent-bg: var(--cal-accent-bg);
+  --color-cal-nav-active-bg: var(--cal-nav-active-bg);
+  --color-cal-nav-active-text: var(--cal-nav-active-text);
+  --color-cal-nav-inactive: var(--cal-nav-inactive);
+  --color-cal-grid-line: var(--cal-grid-line);
+  --color-cal-drag-over: var(--cal-drag-over);
+  --color-cal-hour-text: var(--cal-hour-text);
 }
 
 body {
@@ -203,6 +221,11 @@ body::-webkit-scrollbar {
 /* Masonry layout for For You panel suggestions */
 .masonry-grid {
   column-count: 2;
+  column-gap: 0.5rem;
+}
+
+.masonry-grid-3 {
+  column-count: 3;
   column-gap: 0.5rem;
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
       </head>
       <body
         className={`${geistMono.variable} ${sora.variable} ${lustria.variable} antialiased`}
-        style={{ fontFamily: "'Satoshi', sans-serif" }}
+        style={{ fontFamily: "'Satoshi', system-ui, sans-serif" }}
       >
         <Providers>
           {children}

--- a/apps/web/components/PostcardDetail.tsx
+++ b/apps/web/components/PostcardDetail.tsx
@@ -135,10 +135,10 @@ export function PostcardDetail({ data, onClose }: PostcardDetailProps) {
                       <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(135deg, rgba(255,220,150,0.08) 0%, transparent 40%, rgba(0,0,0,0.06) 100%)' }} />
                       <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '50%', background: 'linear-gradient(to top, rgba(58,40,16,0.6) 0%, transparent 100%)' }} />
                       <div style={{ position: 'absolute', bottom: 8, left: 10, right: 10, zIndex: 2 }}>
-                        <p style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: '9px', color: 'rgba(255,255,255,0.7)', letterSpacing: '1.5px', textTransform: 'uppercase', marginBottom: '1px' }}>
+                        <p style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: '9px', color: 'rgba(255,255,255,0.7)', letterSpacing: '1.5px', textTransform: 'uppercase', marginBottom: '1px' }}>
                           Greetings from
                         </p>
-                        <h2 style={{ fontFamily: 'Georgia, serif', fontSize: '22px', fontWeight: 800, color: '#fff', letterSpacing: '-0.3px', lineHeight: 1.1, textShadow: '0 1px 4px rgba(0,0,0,0.4)' }}>
+                        <h2 style={{ fontFamily: 'var(--font-serif)', fontSize: '22px', fontWeight: 800, color: '#fff', letterSpacing: '-0.3px', lineHeight: 1.1, textShadow: '0 1px 4px rgba(0,0,0,0.4)' }}>
                           {data.name}
                         </h2>
                       </div>
@@ -228,18 +228,18 @@ export function PostcardDetail({ data, onClose }: PostcardDetailProps) {
                     {/* Left — message */}
                     <div style={{ width: '52%', position: 'relative', zIndex: 1 }}>
                       <div style={{ marginBottom: 16 }}>
-                        <p style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: 10, color: '#A0896A', marginBottom: 6, letterSpacing: '0.5px' }}>Dear fellow traveler,</p>
+                        <p style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: 10, color: '#A0896A', marginBottom: 6, letterSpacing: '0.5px' }}>Dear fellow traveler,</p>
                         {data.note && (
-                          <p style={{ fontFamily: 'Georgia, serif', fontSize: 13, color: '#4A3520', lineHeight: 1.7, marginBottom: 12, fontStyle: 'italic', backgroundImage: 'repeating-linear-gradient(transparent, transparent 22px, #D4C4A0 22px, #D4C4A0 23px)', paddingBottom: 4 }}>
+                          <p style={{ fontFamily: 'var(--font-serif)', fontSize: 13, color: '#4A3520', lineHeight: 1.7, marginBottom: 12, fontStyle: 'italic', backgroundImage: 'repeating-linear-gradient(transparent, transparent 22px, #D4C4A0 22px, #D4C4A0 23px)', paddingBottom: 4 }}>
                             &ldquo;{data.note}&rdquo;
                           </p>
                         )}
                         {data.description && (
-                          <p style={{ fontFamily: 'Georgia, serif', fontSize: 12, color: '#6B5B47', lineHeight: 1.6, marginBottom: 12, backgroundImage: 'repeating-linear-gradient(transparent, transparent 22px, #D4C4A0 22px, #D4C4A0 23px)' }}>
+                          <p style={{ fontFamily: 'var(--font-serif)', fontSize: 12, color: '#6B5B47', lineHeight: 1.6, marginBottom: 12, backgroundImage: 'repeating-linear-gradient(transparent, transparent 22px, #D4C4A0 22px, #D4C4A0 23px)' }}>
                             {data.description}
                           </p>
                         )}
-                        <p style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: 11, color: '#A0896A', marginTop: 16 }}>
+                        <p style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: 11, color: '#A0896A', marginTop: 16 }}>
                           Wish you were here!
                         </p>
                       </div>
@@ -288,13 +288,13 @@ export function PostcardDetail({ data, onClose }: PostcardDetailProps) {
                       <div style={{ paddingLeft: 4 }}>
                         <p style={{ fontSize: 8, fontWeight: 700, color: '#A0896A', textTransform: 'uppercase', letterSpacing: 1.5, marginBottom: 8 }}>TO:</p>
                         <div style={{ borderBottom: '1px solid #C4A870', marginBottom: 10, paddingBottom: 4 }}>
-                          <span style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: 12, color: '#4A3520' }}>Fellow Traveler</span>
+                          <span style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: 12, color: '#4A3520' }}>Fellow Traveler</span>
                         </div>
                         <div style={{ borderBottom: '1px solid #C4A870', marginBottom: 10, paddingBottom: 4 }}>
-                          <span style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: 11, color: '#7A6B52' }}>{data.location}</span>
+                          <span style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: 11, color: '#7A6B52' }}>{data.location}</span>
                         </div>
                         <div style={{ borderBottom: '1px solid #C4A870', paddingBottom: 4 }}>
-                          <span style={{ fontFamily: 'Georgia, serif', fontStyle: 'italic', fontSize: 11, color: '#7A6B52' }}>{data.category} Trip</span>
+                          <span style={{ fontFamily: 'var(--font-serif)', fontStyle: 'italic', fontSize: 11, color: '#7A6B52' }}>{data.category} Trip</span>
                         </div>
                       </div>
 

--- a/apps/web/components/budget/BudgetCategoryList.tsx
+++ b/apps/web/components/budget/BudgetCategoryList.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { EditPencil, Xmark, NavArrowDown, Plus } from 'iconoir-react'
 import type { BudgetCategoryData } from '@travyl/shared'
+import { Red, Amber } from '@travyl/shared'
 import { BudgetCategoryDetail } from './BudgetCategoryDetail'
 import { AddCategoryForm } from './AddCategoryForm'
 import { getCategoryColor } from './budgetColors'
@@ -49,7 +50,7 @@ export function BudgetCategoryList({
         const isHovered = hoveredCategory === cat.name
         const color = getCategoryColor(cat.name)
         const percentClamped = Math.min(cat.percentUsed, 100)
-        const barColor = cat.percentUsed >= 100 ? '#EF4444' : cat.percentUsed >= 80 ? '#F59E0B' : color
+        const barColor = cat.percentUsed >= 100 ? Red[500] : cat.percentUsed >= 80 ? Amber[500] : color
 
         return (
           <div key={cat.id}>

--- a/apps/web/components/budget/BudgetSummaryStrip.tsx
+++ b/apps/web/components/budget/BudgetSummaryStrip.tsx
@@ -58,11 +58,11 @@ export function BudgetSummaryStrip({
                 onChange={(e) => setTempValue(e.target.value)}
                 onBlur={handleCommit}
                 onKeyDown={handleKeyDown}
-                className="text-3xl font-serif font-normal tracking-wide text-gray-900 bg-transparent border-b border-gray-300 focus:border-gray-500 outline-none w-36 transition-all duration-150"
+                className="text-3xl font-sans font-normal tracking-wide text-gray-900 bg-transparent border-b border-gray-300 focus:border-gray-500 outline-none w-36 transition-all duration-150"
               />
             ) : (
               <>
-                <span className="text-3xl font-serif font-normal tracking-wide text-gray-900">
+                <span className="text-3xl font-sans font-normal tracking-wide text-gray-900">
                   {formatAmount(totalBudgeted)}
                 </span>
                 <button
@@ -81,7 +81,7 @@ export function BudgetSummaryStrip({
 
         {/* Total Spent */}
         <div>
-          <span className="text-3xl font-serif font-normal tracking-wide text-gray-900 block">
+          <span className="text-3xl font-sans font-normal tracking-wide text-gray-900 block">
             {formatAmount(totalSpent)}
           </span>
           <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gray-400 mt-1 block">
@@ -91,7 +91,7 @@ export function BudgetSummaryStrip({
 
         {/* Remaining */}
         <div>
-          <span className={`text-3xl font-serif font-normal tracking-wide block ${
+          <span className={`text-3xl font-sans font-normal tracking-wide block ${
             remaining >= 0 ? 'text-emerald-600' : 'text-red-500'
           }`}>
             {formatAmount(Math.abs(remaining))}

--- a/apps/web/components/budget/budgetColors.ts
+++ b/apps/web/components/budget/budgetColors.ts
@@ -1,3 +1,5 @@
+import { Gray } from '@travyl/shared'
+
 export const CATEGORY_COLORS: Record<string, string> = {
   flights: '#6B8EAE',
   hotels: '#C4956A',
@@ -5,9 +7,9 @@ export const CATEGORY_COLORS: Record<string, string> = {
   activities: '#7BA69E',
   transport: '#9B8EC4',
   shopping: '#8FB87A',
-  other: '#9CA3AF',
+  other: Gray[400],
 }
 
 export function getCategoryColor(name: string): string {
-  return CATEGORY_COLORS[name] ?? '#9CA3AF'
+  return CATEGORY_COLORS[name] ?? Gray[400]
 }

--- a/apps/web/components/calendar/ActivityContextMenu.tsx
+++ b/apps/web/components/calendar/ActivityContextMenu.tsx
@@ -92,7 +92,7 @@ export function ActivityContextMenu({
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed z-[100] min-w-[160px] bg-white dark:bg-[#0f1a28] rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 shadow-xl py-1 text-sm"
+      className="fixed z-[100] min-w-[160px] bg-white dark:bg-cal-surface-elevated rounded-lg border border-gray-200 dark:border-cal-border shadow-xl py-1 text-sm"
       style={position}
     >
       {actions.map((action, i) => {
@@ -100,7 +100,7 @@ export function ActivityContextMenu({
           return (
             <div
               key={`sep-${i}`}
-              className="h-px bg-gray-200 dark:bg-[#1e3a5f]/30 my-1"
+              className="h-px bg-gray-200 dark:bg-cal-accent-bg my-1"
             />
           )
         }
@@ -124,15 +124,15 @@ export function ActivityContextMenu({
             className={[
               'w-full text-left px-3 py-1.5 transition-colors',
               action.disabled
-                ? 'text-gray-400 dark:text-[#484f58] cursor-default'
+                ? 'text-gray-400 dark:text-cal-text-tertiary cursor-default'
                 : isHighlighted
-                  ? 'bg-gray-100 dark:bg-[#1e3a5f]/30'
+                  ? 'bg-gray-100 dark:bg-cal-accent-bg'
                   : '',
               action.danger && !action.disabled
                 ? 'text-red-500 dark:text-red-400'
                 : action.disabled
                   ? ''
-                  : 'text-gray-700 dark:text-[#cdd9e5]',
+                  : 'text-gray-700 dark:text-cal-text',
             ].join(' ')}
           >
             {action.label}

--- a/apps/web/components/calendar/ActivityEditModal.tsx
+++ b/apps/web/components/calendar/ActivityEditModal.tsx
@@ -175,7 +175,7 @@ export function ActivityEditModal({
           exit={{ opacity: 0, scale: 0.97 }}
           transition={{ duration: 0.15, ease: 'easeOut' }}
           style={{ width: MODAL_WIDTH }}
-          className="rounded-xl border border-[var(--cal-border)] bg-[var(--cal-surface-elevated)] shadow-2xl overflow-hidden max-h-[90vh] flex flex-col"
+          className="rounded-xl border border-cal-border bg-cal-surface-elevated shadow-2xl overflow-hidden max-h-[90vh] flex flex-col"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Hero header */}
@@ -226,7 +226,7 @@ export function ActivityEditModal({
               <select
                 value={form.type}
                 onChange={(e) => update('type', e.target.value)}
-                className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
               >
                 {ACTIVITY_TYPE_OPTIONS.map((t) => (
                   <option key={t} value={t}>
@@ -242,7 +242,7 @@ export function ActivityEditModal({
               <select
                 value={form.day}
                 onChange={(e) => update('day', Number(e.target.value))}
-                className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
               >
                 {tripDays.map((d) => (
                   <option key={d.dayIndex} value={d.dayIndex}>{d.label}</option>
@@ -254,19 +254,19 @@ export function ActivityEditModal({
                 <select
                   value={form.startHour}
                   onChange={(e) => update('startHour', Number(e.target.value))}
-                  className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                  className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                 >
                   {TIME_OPTIONS.map((t) => (
                     <option key={t.value} value={t.value}>{t.label}</option>
                   ))}
                 </select>
-                <span className="text-[var(--cal-text-tertiary)] text-sm">–</span>
+                <span className="text-cal-text-tertiary text-sm">–</span>
                 <select
                   value={form.endHour}
                   onChange={(e) => update('endHour', Number(e.target.value))}
                   className={[
-                    'flex-1 bg-[var(--cal-bg)] border rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]',
-                    errors.endHour ? 'border-red-500' : 'border-[var(--cal-border)]',
+                    'flex-1 bg-cal-bg border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent',
+                    errors.endHour ? 'border-red-500' : 'border-cal-border',
                   ].join(' ')}
                 >
                   {TIME_OPTIONS.map((t) => (
@@ -285,7 +285,7 @@ export function ActivityEditModal({
               <input
                 value={form.location}
                 onChange={(e) => update('location', e.target.value)}
-                className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                 placeholder="Address or place name"
               />
             </FieldRow>
@@ -297,8 +297,8 @@ export function ActivityEditModal({
                 value={form.price}
                 onChange={(e) => update('price', e.target.value)}
                 className={[
-                  'flex-1 bg-[var(--cal-bg)] border rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]',
-                  errors.price ? 'border-red-500' : 'border-[var(--cal-border)]',
+                  'flex-1 bg-cal-bg border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent',
+                  errors.price ? 'border-red-500' : 'border-cal-border',
                 ].join(' ')}
                 placeholder="0.00"
               />
@@ -313,7 +313,7 @@ export function ActivityEditModal({
               value={form.notes}
               onChange={(e) => update('notes', e.target.value)}
               rows={3}
-              className="bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-2 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)] resize-none"
+              className="bg-cal-bg border border-cal-border rounded-md px-3 py-2 text-sm text-cal-text outline-none focus:border-cal-accent resize-none"
               placeholder="Add notes..."
             />
 
@@ -327,7 +327,7 @@ export function ActivityEditModal({
                       <input
                         value={form.flightNumber}
                         onChange={(e) => update('flightNumber', e.target.value)}
-                        className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                        className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                         placeholder="BA 123"
                       />
                     </FieldRow>
@@ -335,7 +335,7 @@ export function ActivityEditModal({
                       <input
                         value={form.airline}
                         onChange={(e) => update('airline', e.target.value)}
-                        className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                        className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                         placeholder="British Airways"
                       />
                     </FieldRow>
@@ -347,7 +347,7 @@ export function ActivityEditModal({
                       <input
                         value={form.checkIn}
                         onChange={(e) => update('checkIn', e.target.value)}
-                        className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                        className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                         placeholder="3:00 PM"
                       />
                     </FieldRow>
@@ -355,7 +355,7 @@ export function ActivityEditModal({
                       <input
                         value={form.checkOut}
                         onChange={(e) => update('checkOut', e.target.value)}
-                        className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                        className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                         placeholder="11:00 AM"
                       />
                     </FieldRow>
@@ -365,7 +365,7 @@ export function ActivityEditModal({
                   <input
                     value={form.bookingRef}
                     onChange={(e) => update('bookingRef', e.target.value)}
-                    className="flex-1 bg-[var(--cal-bg)] border border-[var(--cal-border)] rounded-md px-3 py-1.5 text-sm text-[var(--cal-text)] outline-none focus:border-[var(--cal-accent)]"
+                    className="flex-1 bg-cal-bg border border-cal-border rounded-md px-3 py-1.5 text-sm text-cal-text outline-none focus:border-cal-accent"
                     placeholder="ABC123"
                   />
                 </FieldRow>
@@ -374,16 +374,16 @@ export function ActivityEditModal({
           </div>
 
           {/* Footer */}
-          <div className="shrink-0 border-t border-[var(--cal-border)] px-4 py-3 flex justify-end gap-2">
+          <div className="shrink-0 border-t border-cal-border px-4 py-3 flex justify-end gap-2">
             <button
               onClick={onClose}
-              className="px-4 py-1.5 rounded-lg border border-[var(--cal-border)] text-sm text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)] transition-colors"
+              className="px-4 py-1.5 rounded-lg border border-cal-border text-sm text-cal-text-secondary hover:bg-cal-border-light hover:text-cal-text transition-colors"
             >
               Cancel
             </button>
             <button
               onClick={handleSave}
-              className="px-4 py-1.5 rounded-lg bg-[#003594] text-sm text-white hover:bg-[#002a7a] transition-colors"
+              className="px-4 py-1.5 rounded-lg bg-primary text-sm text-white hover:bg-primary transition-colors"
             >
               Save
             </button>
@@ -399,7 +399,7 @@ export function ActivityEditModal({
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--cal-text-tertiary)] border-b border-[var(--cal-border-light)] pb-1">
+    <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-cal-text-tertiary border-b border-cal-border-light pb-1">
       {children}
     </div>
   )
@@ -408,7 +408,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3">
-      <span className="text-sm text-[var(--cal-text-secondary)] w-[70px] shrink-0">{label}</span>
+      <span className="text-sm text-cal-text-secondary w-[70px] shrink-0">{label}</span>
       {children}
     </div>
   )

--- a/apps/web/components/calendar/ActivityIntelligencePanel.tsx
+++ b/apps/web/components/calendar/ActivityIntelligencePanel.tsx
@@ -14,12 +14,12 @@ interface Props {
 function Section({ icon, title, children }: { icon: ReactNode; title: string; children: ReactNode }) {
   const [open, setOpen] = useState(true)
   return (
-    <div className="border-t border-gray-100 dark:border-[#1e3a5f]/30">
+    <div className="border-t border-gray-100 dark:border-cal-border">
       <button
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-label={`${title} section`}
-        className="w-full flex items-center gap-2 px-4 py-2.5 text-xs font-medium text-gray-500 dark:text-[#7a9cc0] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 transition-colors"
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-xs font-medium text-gray-500 dark:text-cal-text-secondary hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60 transition-colors"
       >
         {icon}
         <span className="flex-1 text-left">{title}</span>
@@ -35,7 +35,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
 
   if (isLoading) {
     return (
-      <div className="px-4 py-3 text-xs text-gray-400 dark:text-[#4a7ab5] animate-pulse">
+      <div className="px-4 py-3 text-xs text-gray-400 dark:text-cal-text-secondary animate-pulse">
         Loading place info…
       </div>
     )
@@ -57,7 +57,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
             className="w-full h-28 object-cover rounded-lg mb-2"
           />
         )}
-        <div className="space-y-0.5 text-xs text-gray-600 dark:text-[#cdd9e5]">
+        <div className="space-y-0.5 text-xs text-gray-600 dark:text-cal-text">
           {data.place.rating && (
             <div className="flex items-center gap-1">
               <span className="text-amber-500">★</span>
@@ -65,7 +65,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
               {data.place.priceTier && <span className="ml-1 text-gray-400">{data.place.priceTier}</span>}
             </div>
           )}
-          {data.place.address && <div className="text-gray-500 dark:text-[#7a9cc0]">{data.place.address}</div>}
+          {data.place.address && <div className="text-gray-500 dark:text-cal-text-secondary">{data.place.address}</div>}
           {data.place.openingHours && (
             <div className="mt-1 space-y-0.5">
               {data.place.openingHours.map((h) => (
@@ -81,7 +81,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
 
       {/* Logistics */}
       <Section icon={<Clock className="w-3.5 h-3.5" />} title="Getting There">
-        <p className="text-xs text-gray-600 dark:text-[#cdd9e5]">
+        <p className="text-xs text-gray-600 dark:text-cal-text">
           {data.logistics.travelTimeMinutes !== null
             ? <>~{data.logistics.travelTimeMinutes} min drive from <span className="font-medium">{data.logistics.previousActivityName}</span> ({data.logistics.distanceKm?.toFixed(1) ?? '?'} km)</>
             : 'First activity of the day'}
@@ -94,7 +94,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
       {/* Weather */}
       {weather && (
         <Section icon={<Cloud className="w-3.5 h-3.5" />} title="Weather">
-          <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-[#cdd9e5]">
+          <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-cal-text">
             <span className="text-lg">{wmo.icon}</span>
             <div>
               <div className="font-medium">{wmo.label}</div>
@@ -106,7 +106,7 @@ export function ActivityIntelligencePanel({ activity, tripId }: Props) {
 
       {/* Budget Impact */}
       <Section icon={<Wallet className="w-3.5 h-3.5" />} title="Budget">
-        <p className="text-xs text-gray-600 dark:text-[#cdd9e5]">
+        <p className="text-xs text-gray-600 dark:text-cal-text">
           {activity.price
             ? `Estimated cost: ${activity.price}`
             : 'No cost estimate'}

--- a/apps/web/components/calendar/AllDayRow.tsx
+++ b/apps/web/components/calendar/AllDayRow.tsx
@@ -74,15 +74,15 @@ function EventPill({ event }: EventPillProps) {
       </button>
 
       {open && (
-        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-[var(--cal-surface-elevated)] border border-[var(--cal-border)] rounded-lg shadow-lg p-3 text-left">
-          <p className="text-[13px] font-semibold text-[var(--cal-text)] leading-snug mb-1">
+        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-cal-surface-elevated border border-cal-border rounded-lg shadow-lg p-3 text-left">
+          <p className="text-[13px] font-semibold text-cal-text leading-snug mb-1">
             {event.name}
           </p>
-          <p className="text-[11px] text-[var(--cal-text-secondary)]">
+          <p className="text-[11px] text-cal-text-secondary">
             {formatPillTime(event.startTime)}
             {event.endTime ? ` – ${formatPillTime(event.endTime)}` : ''}
           </p>
-          <p className="text-[11px] text-[var(--cal-text-tertiary)] mt-0.5 truncate">
+          <p className="text-[11px] text-cal-text-tertiary mt-0.5 truncate">
             {event.venueName}
           </p>
           {event.ticketUrl && (
@@ -90,7 +90,7 @@ function EventPill({ event }: EventPillProps) {
               href={event.ticketUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block mt-2 text-[11px] font-medium text-[#003594] hover:underline"
+              className="inline-block mt-2 text-[11px] font-medium text-primary hover:underline"
             >
               Get tickets →
             </a>
@@ -129,23 +129,23 @@ function OverflowPill({ events }: OverflowPillProps) {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(v => !v)}
-        className="w-full text-left text-[10px] px-1 py-0.5 rounded truncate leading-tight text-[var(--cal-text-secondary)] bg-[var(--cal-border-light)] hover:bg-[var(--cal-border)] transition-colors"
+        className="w-full text-left text-[10px] px-1 py-0.5 rounded truncate leading-tight text-cal-text-secondary bg-cal-border-light hover:bg-cal-border transition-colors"
       >
         +{events.length} more
       </button>
       {open && (
-        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-[var(--cal-surface-elevated)] border border-[var(--cal-border)] rounded-lg shadow-lg py-1">
+        <div className="absolute left-0 top-full mt-1 z-50 w-56 bg-cal-surface-elevated border border-cal-border rounded-lg shadow-lg py-1">
           {events.map(event => {
             const color = CATEGORY_COLORS[event.category]
             return (
-              <div key={event.id} className="flex items-start gap-2 px-3 py-2 hover:bg-[var(--cal-border-light)] transition-colors">
+              <div key={event.id} className="flex items-start gap-2 px-3 py-2 hover:bg-cal-border-light transition-colors">
                 <div
                   className="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0"
                   style={{ backgroundColor: color }}
                 />
                 <div className="min-w-0">
-                  <p className="text-[12px] font-medium text-[var(--cal-text)] truncate">{event.name}</p>
-                  <p className="text-[10px] text-[var(--cal-text-secondary)]">
+                  <p className="text-[12px] font-medium text-cal-text truncate">{event.name}</p>
+                  <p className="text-[10px] text-cal-text-secondary">
                     {formatPillTime(event.startTime)} · {event.venueName}
                   </p>
                   {event.ticketUrl && (
@@ -153,7 +153,7 @@ function OverflowPill({ events }: OverflowPillProps) {
                       href={event.ticketUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-[10px] text-[#003594] hover:underline"
+                      className="text-[10px] text-primary hover:underline"
                     >
                       Tickets →
                     </a>
@@ -189,7 +189,7 @@ export function AllDayRow({
   if (flights.length === 0 && hotels.length === 0 && !hasEvents) return null
 
   return (
-    <div className="flex border-b border-[var(--cal-border)] min-h-[2rem]">
+    <div className="flex border-b border-cal-border min-h-[2rem]">
       {/* Gutter spacer matching TimeGutter width */}
       <div className="flex-shrink-0 w-14" />
 
@@ -207,7 +207,7 @@ export function AllDayRow({
           return (
             <div
               key={dayIndex}
-              className="flex-1 min-w-0 border-l border-[var(--cal-border-light)] px-1 py-0.5 flex flex-col gap-0.5"
+              className="flex-1 min-w-0 border-l border-cal-border-light px-1 py-0.5 flex flex-col gap-0.5"
             >
               {/* Hotel banners */}
               {dayHotels.map(hotel => {
@@ -242,7 +242,7 @@ export function AllDayRow({
                   className={[
                     'text-[10px] font-medium px-1 py-0.5 rounded truncate',
                     flight.direction === 'arrival'
-                      ? 'bg-[var(--cal-accent-bg)] text-[var(--cal-accent)]'
+                      ? 'bg-cal-accent-bg text-cal-accent'
                       : 'bg-red-50 text-red-700',
                   ].join(' ')}
                 >

--- a/apps/web/components/calendar/BookingPanel.tsx
+++ b/apps/web/components/calendar/BookingPanel.tsx
@@ -71,22 +71,22 @@ export function BookingPanel({
     <div className="fixed inset-0 z-40 pointer-events-none">
       <div
         className={[
-          'absolute right-0 top-0 h-full w-96 bg-white dark:bg-[#0f1a28] border-l border-gray-200 dark:border-[#1e3a5f]/40 shadow-xl pointer-events-auto flex flex-col transition-transform duration-300',
+          'absolute right-0 top-0 h-full w-96 bg-white dark:bg-cal-surface-elevated border-l border-gray-200 dark:border-cal-border shadow-xl pointer-events-auto flex flex-col transition-transform duration-300',
           isVisible ? 'translate-x-0' : 'translate-x-full',
         ].join(' ')}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-cal-border shrink-0">
           <div className="flex items-center gap-2">
-            <BookmarkSolid className="w-4 h-4 text-[#003594] dark:text-[#4a7ab5]" />
-            <h2 className="text-sm font-semibold text-gray-900 dark:text-[#f5efe8]">Book My Trip</h2>
+            <BookmarkSolid className="w-4 h-4 text-primary dark:text-cal-text-secondary" />
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-cal-text">Book My Trip</h2>
           </div>
           <button
             onClick={onClose}
             aria-label="Close booking panel"
-            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30"
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-cal-accent-bg"
           >
-            <Xmark className="w-4 h-4 text-gray-500 dark:text-[#7a9cc0]" />
+            <Xmark className="w-4 h-4 text-gray-500 dark:text-cal-text-secondary" />
           </button>
         </div>
 
@@ -97,14 +97,14 @@ export function BookingPanel({
           {mode === 'loading' && (
             <div className="px-4 py-4 space-y-4">
               <div>
-                <p className="text-sm text-gray-600 dark:text-[#cdd9e5] mb-2">Matching your activities…</p>
-                <div className="h-1.5 bg-gray-100 dark:bg-[#1e3a5f]/30 rounded-full overflow-hidden">
+                <p className="text-sm text-gray-600 dark:text-cal-text mb-2">Matching your activities…</p>
+                <div className="h-1.5 bg-gray-100 dark:bg-cal-accent-bg rounded-full overflow-hidden">
                   <div
-                    className="h-full bg-[#003594] rounded-full transition-all duration-300"
+                    className="h-full bg-primary rounded-full transition-all duration-300"
                     style={{ width: `${progress}%` }}
                   />
                 </div>
-                <p className="text-[11px] text-gray-400 dark:text-[#4a7ab5] mt-1">{receivedCount} of {total} checked</p>
+                <p className="text-[11px] text-gray-400 dark:text-cal-text-secondary mt-1">{receivedCount} of {total} checked</p>
               </div>
 
               {/* Live rows as they arrive */}
@@ -112,17 +112,17 @@ export function BookingPanel({
                 {activities.map((a) => {
                   const m = matches.get(a.id)
                   return (
-                    <div key={a.id} className="flex items-center gap-2 py-2 border-b border-gray-50 dark:border-[#1e3a5f]/20">
+                    <div key={a.id} className="flex items-center gap-2 py-2 border-b border-gray-50 dark:border-cal-border/70">
                       {m ? (
                         m.status === 'matched' ? (
                           <span className="h-2 w-2 rounded-full bg-blue-500 shrink-0" />
                         ) : (
-                          <span className="h-2 w-2 rounded-full bg-gray-300 dark:bg-[#2a4a6a] shrink-0" />
+                          <span className="h-2 w-2 rounded-full bg-gray-300 dark:bg-cal-accent-bg shrink-0" />
                         )
                       ) : (
-                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-[#1e3a5f]/40 animate-pulse shrink-0" />
+                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-cal-accent-bg animate-pulse shrink-0" />
                       )}
-                      <span className="text-xs text-gray-700 dark:text-[#cdd9e5] truncate">{a.title || 'Untitled'}</span>
+                      <span className="text-xs text-gray-700 dark:text-cal-text truncate">{a.title || 'Untitled'}</span>
                       {m?.provider && (
                         <span className={`ml-auto text-[10px] px-1.5 py-0.5 rounded-full shrink-0 ${PROVIDER_COLORS[m.provider] ?? ''}`}>
                           {PROVIDER_LABELS[m.provider] ?? m.provider}
@@ -139,24 +139,24 @@ export function BookingPanel({
           {(mode === 'summary' || mode === 'done') && (
             <div className="px-4 py-4 space-y-4">
               {/* Count summary */}
-              <p className="text-xs text-gray-500 dark:text-[#7a9cc0]">
-                <span className="font-semibold text-gray-800 dark:text-[#f5efe8]">{bookableCount}</span> of{' '}
-                <span className="font-semibold text-gray-800 dark:text-[#f5efe8]">{total}</span> activities can be booked
+              <p className="text-xs text-gray-500 dark:text-cal-text-secondary">
+                <span className="font-semibold text-gray-800 dark:text-cal-text">{bookableCount}</span> of{' '}
+                <span className="font-semibold text-gray-800 dark:text-cal-text">{total}</span> activities can be booked
               </p>
 
               {/* Ready to Book */}
               {matchedActivities.length > 0 && (
                 <div>
-                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-[#4a7ab5] mb-2">Ready to Book</h3>
+                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-cal-text-secondary mb-2">Ready to Book</h3>
                   <div className="space-y-1">
                     {matchedActivities.map((a) => {
                       const m = matches.get(a.id)!
                       const isOpened = m.status === 'opened'
                       const isUncertain = m.confidence !== undefined && m.confidence >= 0.6 && m.confidence < 0.75
                       return (
-                        <div key={a.id} className="flex items-start gap-2 py-2 border-b border-gray-50 dark:border-[#1e3a5f]/20">
+                        <div key={a.id} className="flex items-start gap-2 py-2 border-b border-gray-50 dark:border-cal-border/70">
                           <div className="flex-1 min-w-0">
-                            <p className="text-xs font-medium text-gray-800 dark:text-[#f5efe8] truncate">{a.title || 'Untitled'}</p>
+                            <p className="text-xs font-medium text-gray-800 dark:text-cal-text truncate">{a.title || 'Untitled'}</p>
                             <div className="flex items-center gap-1.5 mt-0.5">
                               {m.provider && (
                                 <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${PROVIDER_COLORS[m.provider] ?? ''}`}>
@@ -164,7 +164,7 @@ export function BookingPanel({
                                 </span>
                               )}
                               {m.matchedName && m.matchedName !== a.title && (
-                                <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5] truncate">→ {m.matchedName}</span>
+                                <span className="text-[10px] text-gray-400 dark:text-cal-text-secondary truncate">→ {m.matchedName}</span>
                               )}
                             </div>
                             {isUncertain && (
@@ -178,7 +178,7 @@ export function BookingPanel({
                           ) : (
                             <button
                               onClick={() => onBookOne(a.id)}
-                              className="text-[11px] font-medium text-[#003594] dark:text-[#4a7ab5] hover:underline shrink-0 mt-0.5"
+                              className="text-[11px] font-medium text-primary dark:text-cal-text-secondary hover:underline shrink-0 mt-0.5"
                             >
                               Book
                             </button>
@@ -193,13 +193,13 @@ export function BookingPanel({
               {/* Not Available */}
               {unmatchedActivities.length > 0 && (
                 <div>
-                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-[#4a7ab5] mb-2">Not Available</h3>
+                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-cal-text-secondary mb-2">Not Available</h3>
                   <div className="space-y-1">
                     {unmatchedActivities.map((a) => (
                       <div key={a.id} className="flex items-center gap-2 py-1.5">
-                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-[#2a4a6a] shrink-0" />
-                        <span className="text-xs text-gray-400 dark:text-[#4a7ab5] truncate">{a.title || 'Untitled'}</span>
-                        <span className="ml-auto text-[10px] text-gray-400 dark:text-[#4a7ab5] shrink-0">No booking found</span>
+                        <span className="h-2 w-2 rounded-full bg-gray-200 dark:bg-cal-accent-bg shrink-0" />
+                        <span className="text-xs text-gray-400 dark:text-cal-text-secondary truncate">{a.title || 'Untitled'}</span>
+                        <span className="ml-auto text-[10px] text-gray-400 dark:text-cal-text-secondary shrink-0">No booking found</span>
                       </div>
                     ))}
                   </div>
@@ -221,7 +221,7 @@ export function BookingPanel({
                           href={m.affiliateUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="block text-xs text-[#003594] dark:text-[#4a7ab5] hover:underline truncate"
+                          className="block text-xs text-primary dark:text-cal-text-secondary hover:underline truncate"
                         >
                           {a.title || 'Untitled'}
                         </a>
@@ -236,10 +236,10 @@ export function BookingPanel({
 
         {/* Footer */}
         {(mode === 'summary') && bookableCount > 0 && (
-          <div className="px-4 py-3 border-t border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+          <div className="px-4 py-3 border-t border-gray-100 dark:border-cal-border shrink-0">
             <button
               onClick={onBookAll}
-              className="w-full rounded-lg bg-[#003594] text-white text-sm font-medium py-2 hover:bg-[#002a7a] transition-colors"
+              className="w-full rounded-lg bg-primary text-white text-sm font-medium py-2 hover:bg-primary transition-colors"
             >
               Book All ({bookableCount})
             </button>
@@ -247,11 +247,11 @@ export function BookingPanel({
         )}
 
         {mode === 'done' && (
-          <div className="px-4 py-3 border-t border-gray-100 dark:border-[#1e3a5f]/30 shrink-0">
+          <div className="px-4 py-3 border-t border-gray-100 dark:border-cal-border shrink-0">
             <p className="text-xs text-center text-green-600 dark:text-green-400 mb-2 font-medium">Booking links opened</p>
             <button
               onClick={onClose}
-              className="w-full rounded-lg border border-gray-200 dark:border-[#1e3a5f]/30 text-gray-600 dark:text-[#cdd9e5] text-sm py-2 hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 transition-colors"
+              className="w-full rounded-lg border border-gray-200 dark:border-cal-border text-gray-600 dark:text-cal-text text-sm py-2 hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60 transition-colors"
             >
               Close
             </button>

--- a/apps/web/components/calendar/CalendarDashboard.tsx
+++ b/apps/web/components/calendar/CalendarDashboard.tsx
@@ -713,7 +713,7 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className={`flex h-full overflow-hidden bg-[var(--cal-bg)] text-[var(--cal-text)]${isResizingPanel ? ' select-none' : ''}`}>
+      className={`flex h-full overflow-hidden bg-cal-bg text-cal-text${isResizingPanel ? ' select-none' : ''}`}>
       {/* Main column */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
         {/* Header */}
@@ -853,7 +853,7 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
               <>
                 {/* Resize handle */}
                 <div
-                  className="shrink-0 w-1 cursor-col-resize hover:bg-[var(--cal-accent)]/30 active:bg-[var(--cal-accent)]/50 transition-colors relative group"
+                  className="shrink-0 w-1 cursor-col-resize hover:bg-cal-accent/30 active:bg-cal-accent/50 transition-colors relative group"
                   onPointerDown={(e) => {
                     e.preventDefault()
                     handlePanelDragStart()
@@ -872,7 +872,7 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
                   }}
                 >
                   <div className="absolute inset-y-0 -left-1 -right-1" />
-                  <div className="absolute top-1/2 -translate-y-1/2 left-0 w-1 h-8 rounded-full bg-[var(--cal-text-tertiary)] opacity-0 group-hover:opacity-40 transition-opacity" />
+                  <div className="absolute top-1/2 -translate-y-1/2 left-0 w-1 h-8 rounded-full bg-cal-text-tertiary opacity-0 group-hover:opacity-40 transition-opacity" />
                 </div>
 
                 {/* Right column: Sidebar with For You / Map tabs */}
@@ -913,16 +913,16 @@ export function CalendarDashboard({ tripId, userId, userName, isSharedView = fal
           {/* Drag overlay — shows ghost of dragged item */}
           <DragOverlay dropAnimation={null} style={{ zIndex: 9999 }}>
             {activeData?.type === 'suggestion' ? (
-              <div className="bg-[var(--cal-surface)] rounded-lg shadow-2xl px-3 py-2 flex items-center gap-2 border border-[var(--cal-border)]">
+              <div className="bg-cal-surface rounded-lg shadow-2xl px-3 py-2 flex items-center gap-2 border border-cal-border">
                 <span className="text-lg">{getCategoryIcon(activeData.suggestion.category)}</span>
-                <span className="font-medium text-sm text-[var(--cal-text)] truncate max-w-[150px]">
+                <span className="font-medium text-sm text-cal-text truncate max-w-[150px]">
                   {activeData.suggestion.name}
                 </span>
               </div>
             ) : activeData?.type === 'activity' ? (
-              <div className="bg-[var(--cal-surface)] rounded-lg shadow-2xl px-3 py-2 flex items-center gap-2 border border-[var(--cal-border)]">
+              <div className="bg-cal-surface rounded-lg shadow-2xl px-3 py-2 flex items-center gap-2 border border-cal-border">
                 <span className="text-lg">{getCategoryIcon(activeData.activity.type)}</span>
-                <span className="font-medium text-sm text-[var(--cal-text)] truncate max-w-[150px]">
+                <span className="font-medium text-sm text-cal-text truncate max-w-[150px]">
                   {activeData.activity.title || 'Untitled'}
                 </span>
               </div>

--- a/apps/web/components/calendar/CalendarError.tsx
+++ b/apps/web/components/calendar/CalendarError.tsx
@@ -7,7 +7,7 @@ interface CalendarErrorProps {
 
 export function CalendarError({ message, onBack }: CalendarErrorProps) {
   return (
-    <div className="flex h-screen items-center justify-center bg-[var(--cal-bg)] text-[var(--cal-text)]">
+    <div className="flex h-screen items-center justify-center bg-cal-bg text-cal-text">
       <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
         <svg
           width="48"
@@ -25,11 +25,11 @@ export function CalendarError({ message, onBack }: CalendarErrorProps) {
             strokeLinecap="round"
           />
         </svg>
-        <p className="text-sm text-[var(--cal-text-secondary)]">{message}</p>
+        <p className="text-sm text-cal-text-secondary">{message}</p>
         {onBack && (
           <button
             onClick={onBack}
-            className="px-4 py-2 rounded bg-[var(--cal-border)] hover:bg-[var(--cal-border-light)] transition-colors text-sm font-medium text-[var(--cal-text)]"
+            className="px-4 py-2 rounded bg-cal-border hover:bg-cal-border-light transition-colors text-sm font-medium text-cal-text"
           >
             Go back
           </button>

--- a/apps/web/components/calendar/CalendarSkeleton.tsx
+++ b/apps/web/components/calendar/CalendarSkeleton.tsx
@@ -2,32 +2,32 @@
 
 export function CalendarSkeleton() {
   return (
-    <div className="flex h-screen bg-[var(--cal-bg)] text-[var(--cal-text)]">
+    <div className="flex h-screen bg-cal-bg text-cal-text">
       {/* Sidebar skeleton */}
-      <div className="w-14 border-r border-[var(--cal-border)] bg-[var(--cal-surface)] flex flex-col gap-1 p-2">
+      <div className="w-14 border-r border-cal-border bg-cal-surface flex flex-col gap-1 p-2">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="w-10 h-10 rounded-lg bg-[var(--cal-border)] animate-pulse" />
+          <div key={i} className="w-10 h-10 rounded-lg bg-cal-border animate-pulse" />
         ))}
       </div>
 
       {/* Main area skeleton */}
       <div className="flex-1 flex flex-col">
         {/* Header skeleton */}
-        <div className="h-14 border-b border-[var(--cal-border)] bg-[var(--cal-surface-elevated)] flex items-center gap-3 px-4">
-          <div className="w-8 h-8 rounded-lg bg-[var(--cal-border)] animate-pulse" />
-          <div className="w-32 h-4 rounded bg-[var(--cal-border)] animate-pulse" />
-          <div className="w-24 h-8 rounded-lg bg-[var(--cal-border)] animate-pulse" />
+        <div className="h-14 border-b border-cal-border bg-cal-surface-elevated flex items-center gap-3 px-4">
+          <div className="w-8 h-8 rounded-lg bg-cal-border animate-pulse" />
+          <div className="w-32 h-4 rounded bg-cal-border animate-pulse" />
+          <div className="w-24 h-8 rounded-lg bg-cal-border animate-pulse" />
           <div className="flex-1" />
-          <div className="w-8 h-8 rounded-lg bg-[var(--cal-border)] animate-pulse" />
+          <div className="w-8 h-8 rounded-lg bg-cal-border animate-pulse" />
         </div>
 
         {/* Grid skeleton */}
         <div className="flex-1 flex">
           {/* Time gutter */}
-          <div className="w-14 border-r border-[var(--cal-border)] flex flex-col pt-0">
+          <div className="w-14 border-r border-cal-border flex flex-col pt-0">
             {Array.from({ length: 12 }).map((_, i) => (
               <div key={i} className="h-12 pr-3 flex items-start justify-end">
-                <div className="w-6 h-3 rounded bg-[var(--cal-border)] animate-pulse" />
+                <div className="w-6 h-3 rounded bg-cal-border animate-pulse" />
               </div>
             ))}
           </div>
@@ -35,11 +35,11 @@ export function CalendarSkeleton() {
           {/* Day columns */}
           <div className="flex-1 flex">
             {Array.from({ length: 7 }).map((_, i) => (
-              <div key={i} className="flex-1 border-r border-[var(--cal-border)] flex flex-col gap-2 p-2">
+              <div key={i} className="flex-1 border-r border-cal-border flex flex-col gap-2 p-2">
                 {Array.from({ length: 3 }).map((_, j) => (
                   <div
                     key={j}
-                    className="rounded-md bg-[var(--cal-border)] animate-pulse"
+                    className="rounded-md bg-cal-border animate-pulse"
                     style={{ height: 40 + j * 20 }}
                   />
                 ))}

--- a/apps/web/components/calendar/CalendarToolbar.tsx
+++ b/apps/web/components/calendar/CalendarToolbar.tsx
@@ -47,7 +47,7 @@ function TripMenuBar({ commands }: TripMenuBarProps) {
     commands.some((c) => c.group === group && c.isEnabled)
 
   return (
-    <div ref={menuRef} className="flex items-center h-full px-1 border-r border-gray-200 dark:border-[#1e3a5f]/30">
+    <div ref={menuRef} className="flex items-center h-full px-1 border-r border-gray-200 dark:border-cal-border">
       {MENU_GROUPS.map((group) => {
         const groupCommands = commands.filter((c) => c.group === group)
         const isOpen = openGroup === group
@@ -60,17 +60,17 @@ function TripMenuBar({ commands }: TripMenuBarProps) {
               className={[
                 'px-3 h-full text-[13px] transition-colors rounded',
                 isOpen
-                  ? 'bg-gray-100 dark:bg-[#1e3a5f]/30 text-gray-900 dark:text-[#f5efe8]'
+                  ? 'bg-gray-100 dark:bg-cal-accent-bg text-gray-900 dark:text-cal-text'
                   : hasEnabled
-                  ? 'text-gray-700 dark:text-[#cdd9e5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20'
-                  : 'text-gray-400 dark:text-[#4a7ab5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20',
+                  ? 'text-gray-700 dark:text-cal-text hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60'
+                  : 'text-gray-400 dark:text-cal-text-secondary hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60',
               ].join(' ')}
             >
               {MENU_LABELS[group]}
             </button>
 
             {isOpen && (
-              <div className="absolute top-[calc(100%+2px)] left-0 z-50 w-56 bg-white dark:bg-[#0f1a28] border border-gray-200 dark:border-[#1e3a5f]/40 rounded-xl shadow-xl py-1 overflow-hidden">
+              <div className="absolute top-[calc(100%+2px)] left-0 z-50 w-56 bg-white dark:bg-cal-surface-elevated border border-gray-200 dark:border-cal-border rounded-xl shadow-xl py-1 overflow-hidden">
                 {groupCommands.map((cmd) => (
                   <button
                     key={cmd.id}
@@ -86,13 +86,13 @@ function TripMenuBar({ commands }: TripMenuBarProps) {
                       cmd.isEnabled
                         ? cmd.id === 'delete'
                           ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
-                          : 'text-gray-700 dark:text-[#cdd9e5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20'
-                        : 'text-gray-400 dark:text-[#484f58] cursor-default pointer-events-none',
+                          : 'text-gray-700 dark:text-cal-text hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60'
+                        : 'text-gray-400 dark:text-cal-text-tertiary cursor-default pointer-events-none',
                     ].join(' ')}
                   >
                     <span>{cmd.label}</span>
                     {cmd.shortcut && (
-                      <kbd className="text-[10px] text-gray-400 dark:text-[#484f58] bg-gray-100 dark:bg-[#0a1520] border border-gray-200 dark:border-[#1e3a5f]/30 px-1.5 py-0.5 rounded ml-4 shrink-0">
+                      <kbd className="text-[10px] text-gray-400 dark:text-cal-text-tertiary bg-gray-100 dark:bg-cal-bg border border-gray-200 dark:border-cal-border px-1.5 py-0.5 rounded ml-4 shrink-0">
                         {cmd.shortcut.display}
                       </kbd>
                     )}
@@ -198,26 +198,26 @@ export function CalendarToolbar({
       )}
 
       {/* Main toolbar row */}
-      <div className="flex items-center h-11 border-b border-gray-200/60 dark:border-[#1e3a5f]/30 bg-white/70 dark:bg-[#0f1a28]/80 backdrop-blur-xl shrink-0">
+      <div className="flex items-center h-11 border-b border-gray-200/60 dark:border-cal-border bg-white/70 dark:bg-cal-surface-elevated/80 backdrop-blur-xl shrink-0">
 
         {/* Menu bar */}
         <TripMenuBar commands={commands} />
 
         {/* Trip info */}
-        <div className="relative flex flex-col justify-center px-4 h-full border-r border-gray-200 dark:border-[#1e3a5f]/30 shrink-0 min-w-0">
-          <span className="truncate text-[13px] font-serif font-normal tracking-wide text-[#1e3a5f] dark:text-[#f5efe8] leading-tight">
+        <div className="relative flex flex-col justify-center px-4 h-full border-r border-gray-200 dark:border-cal-border shrink-0 min-w-0">
+          <span className="truncate text-[13px] font-serif font-normal tracking-wide text-trip-base dark:text-cal-text leading-tight">
             {tripName}
           </span>
           {canEdit ? (
             <button
               onClick={() => setRescoperOpen((v) => !v)}
-              className="text-[10px] text-[#4a7ab5] leading-tight hover:text-[#003594] dark:hover:text-[#f5efe8] transition-colors text-left"
+              className="text-[10px] text-cal-text-secondary leading-tight hover:text-primary dark:hover:text-cal-text transition-colors text-left"
               aria-label="Edit trip dates and destination"
             >
               {dateRange}
             </button>
           ) : (
-            <span className="text-[10px] text-[#4a7ab5] leading-tight">{dateRange}</span>
+            <span className="text-[10px] text-cal-text-secondary leading-tight">{dateRange}</span>
           )}
 
           {rescoperOpen && trip && (
@@ -241,16 +241,16 @@ export function CalendarToolbar({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.15 }}
-              className="flex items-center gap-2 px-3 h-full border-l border-gray-200 dark:border-[#1e3a5f]/30 shrink-0"
+              className="flex items-center gap-2 px-3 h-full border-l border-gray-200 dark:border-cal-border shrink-0"
             >
               <div className="w-2 h-2 rounded-sm bg-blue-500 shrink-0" />
-              <span className="text-[12px] text-gray-700 dark:text-[#cdd9e5] truncate max-w-[140px]">
+              <span className="text-[12px] text-gray-700 dark:text-cal-text truncate max-w-[140px]">
                 {selectedActivity.title || 'Untitled'}
               </span>
               <button
                 onClick={onDeselect}
                 aria-label="Deselect activity"
-                className="text-gray-400 dark:text-[#4a7ab5] hover:text-gray-600 dark:hover:text-white transition-colors"
+                className="text-gray-400 dark:text-cal-text-secondary hover:text-gray-600 dark:hover:text-cal-text transition-colors"
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                   <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
@@ -291,7 +291,7 @@ export function CalendarToolbar({
           <div
             role="group"
             aria-label="View mode"
-            className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-[#1e3a5f]/30 text-sm shrink-0"
+            className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-cal-border text-sm shrink-0"
           >
             {(['week', 'day'] as ViewMode[]).map((mode) => (
               <button
@@ -301,8 +301,8 @@ export function CalendarToolbar({
                 className={[
                   'px-3 py-1.5 capitalize transition-colors text-xs',
                   viewMode === mode
-                    ? 'bg-[#003594] text-white'
-                    : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#4a7ab5] dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white',
+                    ? 'bg-primary text-white'
+                    : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-cal-text-secondary dark:hover:bg-cal-accent-bg/80 dark:hover:text-cal-text',
                 ].join(' ')}
               >
                 {mode}
@@ -314,11 +314,11 @@ export function CalendarToolbar({
           {!isSharedView && (
             <button
               onClick={onAddEvent}
-              className="flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/30 px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-[#4a7ab5] hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-[#1e3a5f]/25 dark:hover:text-white transition-colors shrink-0"
+              className="flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-cal-border px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-cal-text-secondary hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-cal-accent-bg/80 dark:hover:text-cal-text transition-colors shrink-0"
             >
               <Plus width={12} height={12} />
               <span className="hidden sm:inline">New Activity</span>
-              <kbd className="text-[9px] text-gray-400 dark:text-[#484f58] bg-gray-100 dark:bg-[#0a1520] border border-gray-200 dark:border-[#1e3a5f]/30 px-1 rounded hidden sm:inline">
+              <kbd className="text-[9px] text-gray-400 dark:text-cal-text-tertiary bg-gray-100 dark:bg-cal-bg border border-gray-200 dark:border-cal-border px-1 rounded hidden sm:inline">
                 N
               </kbd>
             </button>
@@ -330,7 +330,7 @@ export function CalendarToolbar({
               onClick={onOpenHistory}
               title="Change history"
               aria-label="Change history"
-              className="p-1.5 rounded-lg text-gray-500 dark:text-[#7a9cc0] hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30 transition-colors"
+              className="p-1.5 rounded-lg text-gray-500 dark:text-cal-text-secondary hover:bg-gray-100 dark:hover:bg-cal-accent-bg transition-colors"
             >
               <Clock className="w-4 h-4" />
             </button>
@@ -344,8 +344,8 @@ export function CalendarToolbar({
               className={[
                 'flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors',
                 showEvents
-                  ? 'bg-[#003594]/10 text-[#003594]'
-                  : 'text-gray-500 dark:text-[#7a9cc0] hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30',
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-gray-500 dark:text-cal-text-secondary hover:bg-gray-100 dark:hover:bg-cal-accent-bg',
               ].join(' ')}
             >
               <Calendar width={14} height={14} strokeWidth={1.5} />
@@ -371,8 +371,8 @@ export function CalendarToolbar({
               className={[
                 'p-1.5 rounded-lg transition-colors',
                 hasGhosts && !isGapFilling
-                  ? 'text-[var(--cal-accent)] bg-[color-mix(in_srgb,var(--cal-accent)_12%,transparent)]'
-                  : 'text-gray-500 dark:text-[#7a9cc0] hover:bg-gray-100 dark:hover:bg-[#1e3a5f]/30',
+                  ? 'text-cal-accent bg-cal-accent/10'
+                  : 'text-gray-500 dark:text-cal-text-secondary hover:bg-gray-100 dark:hover:bg-cal-accent-bg',
                 (isGapFilling || (!hasGaps && !hasGhosts)) ? 'opacity-40 cursor-not-allowed' : '',
               ].join(' ')}
             >
@@ -396,7 +396,7 @@ export function CalendarToolbar({
                 return (
                   <div
                     key={collab.userId}
-                    className="group relative flex items-center justify-center h-7 w-7 rounded-full text-[11px] font-semibold text-white select-none ring-2 ring-white dark:ring-[#0a1520]"
+                    className="group relative flex items-center justify-center h-7 w-7 rounded-full text-[11px] font-semibold text-white select-none ring-2 ring-white dark:ring-cal-bg"
                     style={{
                       backgroundColor: collab.color,
                       opacity: collab.isOnline ? 1 : 0.45,
@@ -407,17 +407,17 @@ export function CalendarToolbar({
                     {collab.avatarInitial}
                     <span
                       className={[
-                        'absolute bottom-0 right-0 h-2 w-2 rounded-full ring-1 ring-white dark:ring-[#0a1520]',
+                        'absolute bottom-0 right-0 h-2 w-2 rounded-full ring-1 ring-white dark:ring-cal-bg',
                         collab.isOnline ? 'bg-green-500' : 'bg-gray-500',
                       ].join(' ')}
                     />
                     {/* Hover tooltip */}
-                    <div className="pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 -translate-x-1/2 z-50 hidden group-hover:flex flex-col gap-0.5 bg-white dark:bg-[#0f1a28] border border-gray-200 dark:border-[#1e3a5f]/40 rounded-lg shadow-md px-2.5 py-2 min-w-[120px] whitespace-nowrap">
-                      <span className="text-xs font-semibold text-gray-800 dark:text-[#f5efe8]">{collab.name}</span>
-                      <span className="text-[10px] text-gray-400 dark:text-[#4a7ab5]">
+                    <div className="pointer-events-none absolute bottom-[calc(100%+6px)] left-1/2 -translate-x-1/2 z-50 hidden group-hover:flex flex-col gap-0.5 bg-white dark:bg-cal-surface-elevated border border-gray-200 dark:border-cal-border rounded-lg shadow-md px-2.5 py-2 min-w-[120px] whitespace-nowrap">
+                      <span className="text-xs font-semibold text-gray-800 dark:text-cal-text">{collab.name}</span>
+                      <span className="text-[10px] text-gray-400 dark:text-cal-text-secondary">
                         {viewLabel}{dayLabel ? ` \u00b7 ${dayLabel}` : ''}
                       </span>
-                      <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-200 dark:border-t-[#1e3a5f]/40" />
+                      <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-200 dark:border-t-cal-border" />
                     </div>
                   </div>
                 )
@@ -433,8 +433,8 @@ export function CalendarToolbar({
               className={[
                 'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors shrink-0',
                 isBookingInProgress
-                  ? 'bg-gray-100 dark:bg-[#1e3a5f]/20 text-gray-400 dark:text-[#4a7ab5] cursor-not-allowed'
-                  : 'border border-[#003594]/30 text-[#003594] dark:text-[#4a7ab5] hover:bg-[#003594]/5 dark:hover:bg-[#1e3a5f]/20',
+                  ? 'bg-gray-100 dark:bg-cal-accent-bg/60 text-gray-400 dark:text-cal-text-secondary cursor-not-allowed'
+                  : 'border border-primary/30 text-primary dark:text-cal-text-secondary hover:bg-primary/5 dark:hover:bg-cal-accent-bg/60',
               ].join(' ')}
             >
               {isBookingInProgress ? 'Matching…' : 'Book My Trip'}
@@ -455,7 +455,7 @@ export function CalendarToolbar({
           {!isSharedView && (
             <button
               onClick={onShare}
-              className="flex items-center gap-1.5 rounded-lg bg-[#F59E0B] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#D97706] transition-colors shrink-0"
+              className="flex items-center gap-1.5 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-600 transition-colors shrink-0"
             >
               <ShareAndroid width={12} height={12} />
               Share
@@ -464,8 +464,8 @@ export function CalendarToolbar({
 
           {/* Shared view indicator */}
           {isSharedView && (
-            <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-gray-100 dark:bg-[#1e3a5f]/20">
-              <span className="text-xs text-gray-500 dark:text-[#4a7ab5]">Viewing</span>
+            <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-gray-100 dark:bg-cal-accent-bg/60">
+              <span className="text-xs text-gray-500 dark:text-cal-text-secondary">Viewing</span>
             </div>
           )}
         </div>

--- a/apps/web/components/calendar/CardPopover.tsx
+++ b/apps/web/components/calendar/CardPopover.tsx
@@ -146,7 +146,7 @@ export function CardPopover({
             zIndex: 100,
             transformOrigin: pos.side === 'left' ? 'right center' : 'left center',
           }}
-          className="rounded-xl border border-[var(--cal-border)] bg-[var(--cal-surface-elevated)] shadow-xl overflow-hidden"
+          className="rounded-xl border border-cal-border bg-cal-surface-elevated shadow-xl overflow-hidden"
         >
           {/* Arrow */}
           <div
@@ -181,7 +181,7 @@ export function CardPopover({
 
           {/* Content */}
           <div className="px-3 pt-2.5 pb-3">
-            <h3 className="text-sm font-bold text-[var(--cal-text)] leading-tight">
+            <h3 className="text-sm font-bold text-cal-text leading-tight">
               {title}
             </h3>
 
@@ -197,8 +197,8 @@ export function CardPopover({
               </span>
               {duration && (
                 <>
-                  <span className="text-[10px] text-[var(--cal-text-tertiary)]">·</span>
-                  <span className="text-[10px] text-[var(--cal-text-secondary)]">{duration}</span>
+                  <span className="text-[10px] text-cal-text-tertiary">·</span>
+                  <span className="text-[10px] text-cal-text-secondary">{duration}</span>
                 </>
               )}
             </div>
@@ -211,20 +211,20 @@ export function CardPopover({
                   </span>
                 )}
                 {price && (
-                  <span className="text-[var(--cal-text-secondary)] font-medium">{price}</span>
+                  <span className="text-cal-text-secondary font-medium">{price}</span>
                 )}
               </div>
             )}
 
             {description && (
-              <p className="text-[11px] text-[var(--cal-text-secondary)] mt-2 line-clamp-3 leading-relaxed">
+              <p className="text-[11px] text-cal-text-secondary mt-2 line-clamp-3 leading-relaxed">
                 {description}
               </p>
             )}
 
             {actions.length > 0 && (
               <>
-                <div className="border-t border-[var(--cal-border-light)] mt-2.5 mb-2" />
+                <div className="border-t border-cal-border-light mt-2.5 mb-2" />
                 <div className="flex justify-end gap-1.5">
                   {actions.map((action) => (
                     <button
@@ -238,10 +238,10 @@ export function CardPopover({
                       className={[
                         'text-[11px] font-medium px-2.5 py-1 rounded-md transition-colors',
                         action.variant === 'primary'
-                          ? 'bg-[#003594] text-white hover:bg-[#002a7a] disabled:opacity-50 disabled:cursor-not-allowed'
+                          ? 'bg-primary text-white hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed'
                           : action.variant === 'danger'
-                            ? 'text-[var(--cal-text-secondary)] hover:text-red-500 hover:bg-red-500/10'
-                            : 'text-[var(--cal-text-secondary)] hover:text-[var(--cal-text)] hover:bg-[var(--cal-border-light)]',
+                            ? 'text-cal-text-secondary hover:text-red-500 hover:bg-red-500/10'
+                            : 'text-cal-text-secondary hover:text-cal-text hover:bg-cal-border-light',
                       ].join(' ')}
                     >
                       {action.label}

--- a/apps/web/components/calendar/DayColumn.tsx
+++ b/apps/web/components/calendar/DayColumn.tsx
@@ -183,9 +183,9 @@ export function DayColumn({
       {/* Day header */}
       <div
         className={[
-          'text-center text-xs font-medium py-1 border-b border-[var(--cal-border)] text-[var(--cal-text-secondary)] select-none',
+          'text-center text-xs font-medium py-1 border-b border-cal-border text-cal-text-secondary select-none',
           onClickDayHeader
-            ? 'cursor-pointer hover:bg-[var(--cal-border-light)] transition-colors'
+            ? 'cursor-pointer hover:bg-cal-border-light transition-colors'
             : '',
         ].join(' ')}
         onClick={onClickDayHeader}
@@ -205,7 +205,7 @@ export function DayColumn({
         <span className="inline-flex items-center gap-1">
           {label}
           {dayIntel?.weather && (
-            <span className="inline-flex items-center gap-0.5 text-[10px] text-[var(--cal-text-secondary)]">
+            <span className="inline-flex items-center gap-0.5 text-[10px] text-cal-text-secondary">
               {getWmoWeather(dayIntel.weather.weatherCode).icon}
               {dayIntel.weather.tempMaxC !== null && `${Math.round(dayIntel.weather.tempMaxC)}°`}
             </span>
@@ -231,13 +231,13 @@ export function DayColumn({
                   marginLeft: i === 0 ? 0 : '-4px',
                   zIndex: 3 - i,
                 }}
-                className="w-4 h-4 rounded-full text-[8px] font-bold text-white flex items-center justify-center ring-1 ring-[var(--cal-surface)]"
+                className="w-4 h-4 rounded-full text-[8px] font-bold text-white flex items-center justify-center ring-1 ring-cal-surface"
               >
                 {c.avatarInitial}
               </div>
             ))}
             {dayCollaborators.length > 3 && (
-              <span className="text-[9px] text-[var(--cal-text-tertiary)] ml-1">
+              <span className="text-[9px] text-cal-text-tertiary ml-1">
                 +{dayCollaborators.length - 3}
               </span>
             )}
@@ -250,8 +250,8 @@ export function DayColumn({
         ref={setNodeRef}
         data-day-grid={dayIndex}
         className={[
-          'relative flex-1 border-l border-[var(--cal-border-light)]',
-          isOver ? 'bg-[var(--cal-drag-over)]' : '',
+          'relative flex-1 border-l border-cal-border-light',
+          isOver ? 'bg-cal-drag-over' : '',
         ].join(' ')}
         style={{ minHeight: hourCount * HOUR_HEIGHT }}
         onClick={handleBackgroundClick}
@@ -260,7 +260,7 @@ export function DayColumn({
         {hours.map((hour) => (
           <div
             key={hour}
-            className="absolute w-full border-t border-[var(--cal-grid-line)] pointer-events-none"
+            className="absolute w-full border-t border-cal-grid-line pointer-events-none"
             style={{ top: (hour - timeRange.startHour) * HOUR_HEIGHT }}
           />
         ))}
@@ -269,7 +269,7 @@ export function DayColumn({
         {hours.map((hour) => (
           <div
             key={`half-${hour}`}
-            className="absolute w-full border-t border-dashed border-[var(--cal-grid-line-half)] pointer-events-none"
+            className="absolute w-full border-t border-dashed border-cal-grid-line-half pointer-events-none"
             style={{ top: (hour - timeRange.startHour) * HOUR_HEIGHT + HOUR_HEIGHT / 2 }}
           />
         ))}

--- a/apps/web/components/calendar/DayMap.tsx
+++ b/apps/web/components/calendar/DayMap.tsx
@@ -99,7 +99,7 @@ export default function DayMap({
       const el = document.createElement('div')
       el.className = [
         'w-6 h-6 rounded-full text-white text-xs flex items-center justify-center font-bold ring-2 ring-white shadow cursor-pointer',
-        isSelected ? 'bg-amber-500' : 'bg-[#003594]',
+        isSelected ? 'bg-amber-500' : 'bg-primary',
       ].join(' ')
       el.style.width = '24px'
       el.style.height = '24px'
@@ -171,7 +171,7 @@ export default function DayMap({
   if (validActivities.length === 0) {
     return (
       <div
-        className={`flex items-center justify-center h-full text-sm text-[var(--cal-text-secondary)] ${className ?? ''}`}
+        className={`flex items-center justify-center h-full text-sm text-cal-text-secondary ${className ?? ''}`}
       >
         Add locations to see the route map
       </div>

--- a/apps/web/components/calendar/EventBlock.tsx
+++ b/apps/web/components/calendar/EventBlock.tsx
@@ -180,7 +180,7 @@ export function EventBlock({
       {hasConflict && conflictTooltip && (
         <div
           title={conflictTooltip}
-          className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-amber-400 ring-1 ring-white dark:ring-[#0f1a28] z-10"
+          className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-amber-400 ring-1 ring-white dark:ring-cal-surface-elevated z-10"
         />
       )}
 
@@ -302,13 +302,13 @@ export function EventBlock({
       {bookingStatus === 'matched' && (
         <span
           title="Bookable"
-          className="absolute bottom-1 right-1 h-2 w-2 rounded-full bg-blue-500 ring-1 ring-white dark:ring-[#0a1520]"
+          className="absolute bottom-1 right-1 h-2 w-2 rounded-full bg-blue-500 ring-1 ring-white dark:ring-cal-bg"
         />
       )}
       {bookingStatus === 'opened' && (
         <span
           title="Booking opened"
-          className="absolute bottom-1 right-1 flex items-center justify-center h-3.5 w-3.5 rounded-full bg-green-500 ring-1 ring-white dark:ring-[#0a1520]"
+          className="absolute bottom-1 right-1 flex items-center justify-center h-3.5 w-3.5 rounded-full bg-green-500 ring-1 ring-white dark:ring-cal-bg"
         >
           <svg width="7" height="7" viewBox="0 0 10 10" fill="none" aria-hidden>
             <path d="M1.5 5L4 7.5L8.5 2.5" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>

--- a/apps/web/components/calendar/EventCard.tsx
+++ b/apps/web/components/calendar/EventCard.tsx
@@ -39,7 +39,7 @@ export function EventCard({ event }: EventCardProps) {
   const color = CATEGORY_COLORS[event.category]
 
   return (
-    <div className="flex items-start gap-3 px-3 py-2.5 hover:bg-[var(--cal-border-light)] transition-colors rounded-lg">
+    <div className="flex items-start gap-3 px-3 py-2.5 hover:bg-cal-border-light transition-colors rounded-lg">
       {/* Thumbnail */}
       <div
         className="shrink-0 w-12 h-12 rounded-lg overflow-hidden"
@@ -56,13 +56,13 @@ export function EventCard({ event }: EventCardProps) {
 
       {/* Details */}
       <div className="flex-1 min-w-0">
-        <p className="text-[13px] font-medium text-[var(--cal-text)] line-clamp-2 leading-snug">
+        <p className="text-[13px] font-medium text-cal-text line-clamp-2 leading-snug">
           {event.name}
         </p>
-        <p className="text-[11px] text-[var(--cal-text-secondary)] mt-0.5">
+        <p className="text-[11px] text-cal-text-secondary mt-0.5">
           {formatEventDate(event.date, event.startTime)}
         </p>
-        <p className="text-[11px] text-[var(--cal-text-tertiary)] truncate">
+        <p className="text-[11px] text-cal-text-tertiary truncate">
           {event.venueName}
         </p>
         <span

--- a/apps/web/components/calendar/EventsPanel.tsx
+++ b/apps/web/components/calendar/EventsPanel.tsx
@@ -63,12 +63,12 @@ export function EventsPanel({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="p-3.5 pb-3 border-b border-[var(--cal-border-light)]">
-        <h2 className="text-sm font-semibold text-[var(--cal-text)]">
+      <div className="p-3.5 pb-3 border-b border-cal-border-light">
+        <h2 className="text-sm font-semibold text-cal-text">
           Events{cityName ? ` in ${cityName}` : ''}
         </h2>
         {dateRange && (
-          <p className="text-[11px] text-[var(--cal-text-secondary)] mt-0.5">{dateRange}</p>
+          <p className="text-[11px] text-cal-text-secondary mt-0.5">{dateRange}</p>
         )}
       </div>
 
@@ -82,8 +82,8 @@ export function EventsPanel({
             className={[
               'text-[11px] font-medium px-2.5 py-1 rounded-full whitespace-nowrap transition-all border',
               activeChip === chip
-                ? 'bg-[#003594] border-[#003594] text-white'
-                : 'border-[var(--cal-border)] text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)]',
+                ? 'bg-primary border-primary text-white'
+                : 'border-cal-border text-cal-text-secondary hover:bg-cal-border-light hover:text-cal-text',
             ].join(' ')}
           >
             {chip}
@@ -96,7 +96,7 @@ export function EventsPanel({
       <div className="h-0 grow overflow-y-auto py-2 scrollbar-thin">
         {isDisabled ? (
           <div className="flex items-center justify-center h-full px-4 text-center">
-            <p className="text-sm text-[var(--cal-text-secondary)]">
+            <p className="text-sm text-cal-text-secondary">
               Add trip dates to see local events
             </p>
           </div>
@@ -104,11 +104,11 @@ export function EventsPanel({
           <div className="px-3 space-y-3 pt-2">
             {[0, 1].map(i => (
               <div key={i} className="flex gap-3">
-                <div className="w-12 h-12 rounded-lg bg-[var(--cal-border)] animate-pulse shrink-0" />
+                <div className="w-12 h-12 rounded-lg bg-cal-border animate-pulse shrink-0" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-3 bg-[var(--cal-border)] animate-pulse rounded w-3/4" />
-                  <div className="h-2.5 bg-[var(--cal-border)] animate-pulse rounded w-1/2" />
-                  <div className="h-2.5 bg-[var(--cal-border)] animate-pulse rounded w-2/3" />
+                  <div className="h-3 bg-cal-border animate-pulse rounded w-3/4" />
+                  <div className="h-2.5 bg-cal-border animate-pulse rounded w-1/2" />
+                  <div className="h-2.5 bg-cal-border animate-pulse rounded w-2/3" />
                 </div>
               </div>
             ))}
@@ -116,17 +116,17 @@ export function EventsPanel({
         ) : onRetry && events.length === 0 ? (
           // Error state takes precedence over empty state when onRetry is provided
           <div className="flex flex-col items-center justify-center h-full gap-2 px-4 text-center">
-            <p className="text-sm text-[var(--cal-text-secondary)]">Couldn't load events</p>
+            <p className="text-sm text-cal-text-secondary">Couldn't load events</p>
             <button
               onClick={onRetry}
-              className="text-xs text-[var(--cal-accent)] hover:underline"
+              className="text-xs text-cal-accent hover:underline"
             >
               Retry
             </button>
           </div>
         ) : filtered.length === 0 ? (
           <div className="flex items-center justify-center h-full px-4 text-center">
-            <p className="text-sm text-[var(--cal-text-secondary)]">
+            <p className="text-sm text-cal-text-secondary">
               No events found in {cityName} during your trip
             </p>
           </div>

--- a/apps/web/components/calendar/ForYouPanel.tsx
+++ b/apps/web/components/calendar/ForYouPanel.tsx
@@ -92,20 +92,20 @@ export function ForYouPanel({
   return (
     <aside
       style={{ width: width ?? FOR_YOU_PANEL_DEFAULT_WIDTH }}
-      className="relative flex flex-col shrink-0 self-stretch border-l border-[var(--cal-border)] bg-[var(--cal-surface-elevated)] overflow-hidden"
+      className="relative flex flex-col shrink-0 self-stretch border-l border-cal-border bg-cal-surface-elevated overflow-hidden"
       aria-label="Activity suggestions"
     >
       {/* Header */}
-      <div className="p-3.5 pb-3 border-b border-[var(--cal-border-light)]">
-        <h2 className="text-sm font-semibold text-[var(--cal-text)] mb-2.5">
+      <div className="p-3.5 pb-3 border-b border-cal-border-light">
+        <h2 className="text-sm font-semibold text-cal-text mb-2.5">
           For You
         </h2>
-        <div className="flex items-center gap-2 bg-[var(--cal-border-light)] border border-[var(--cal-border)] rounded-lg px-3 py-2">
+        <div className="flex items-center gap-2 bg-cal-border-light border border-cal-border rounded-lg px-3 py-2">
           <Search
             width={14}
             height={14}
             strokeWidth={1.5}
-            className="shrink-0 text-[var(--cal-text-tertiary)] opacity-50"
+            className="shrink-0 text-cal-text-tertiary opacity-50"
             aria-hidden="true"
           />
           <input
@@ -114,7 +114,7 @@ export function ForYouPanel({
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') commitSearch() }}
             placeholder="Search activities..."
-            className="flex-1 bg-transparent text-sm text-[var(--cal-text)] placeholder-[var(--cal-text-tertiary)] outline-none"
+            className="flex-1 bg-transparent text-sm text-cal-text placeholder-cal-text-tertiary outline-none"
           />
         </div>
       </div>
@@ -128,8 +128,8 @@ export function ForYouPanel({
             className={[
               'text-[11px] font-medium px-2.5 py-1 rounded-full whitespace-nowrap transition-all border',
               activeFilter === cat
-                ? 'bg-[#003594] border-[#003594] text-white'
-                : 'border-[var(--cal-border)] text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)]',
+                ? 'bg-primary border-primary text-white'
+                : 'border-cal-border text-cal-text-secondary hover:bg-cal-border-light hover:text-cal-text',
             ].join(' ')}
           >
             {cat}
@@ -138,7 +138,7 @@ export function ForYouPanel({
       </div>
 
       {/* Section label */}
-      <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-[var(--cal-text-secondary)] px-3.5 pt-3 pb-1.5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-cal-text-secondary px-3.5 pt-3 pb-1.5">
         {searchQuery.trim()
           ? `Results for '${searchQuery}'`
           : `Recommended for ${destination}`}
@@ -151,29 +151,29 @@ export function ForYouPanel({
             {Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="masonry-item mb-2 rounded-[10px] bg-[var(--cal-border)] animate-pulse"
+                className="masonry-item mb-2 rounded-[10px] bg-cal-border animate-pulse"
                 style={{ height: 120 + i * 20 }}
               />
             ))}
           </div>
         ) : error ? (
           <div className="flex flex-col items-center justify-center py-12 gap-2">
-            <p className="text-sm text-[var(--cal-text-secondary)]">
+            <p className="text-sm text-cal-text-secondary">
               Couldn&apos;t load suggestions
             </p>
-            <button onClick={() => refetch()} className="text-xs text-[var(--cal-accent)] hover:underline">
+            <button onClick={() => refetch()} className="text-xs text-cal-accent hover:underline">
               Tap to retry
             </button>
           </div>
         ) : suggestions.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 gap-1">
-            <p className="text-sm text-[var(--cal-text-secondary)]">
+            <p className="text-sm text-cal-text-secondary">
               {searchQuery.trim()
                 ? `No results for '${searchQuery}'`
                 : 'No suggestions available'}
             </p>
             {searchQuery.trim() && (
-              <p className="text-xs text-[var(--cal-text-tertiary)]">
+              <p className="text-xs text-cal-text-tertiary">
                 Try broader terms
               </p>
             )}
@@ -194,13 +194,13 @@ export function ForYouPanel({
             {/* Load more / loading spinner */}
             {isLoadingMore ? (
               <div className="flex justify-center py-4">
-                <div className="h-5 w-5 rounded-full border-2 border-[var(--cal-border)] border-t-[#003594] animate-spin" />
+                <div className="h-5 w-5 rounded-full border-2 border-cal-border border-t-primary animate-spin" />
               </div>
             ) : hasMore ? (
               <button
                 type="button"
                 onClick={loadMore}
-                className="w-full py-3 mt-2 text-xs font-medium text-[var(--cal-accent)] border border-[var(--cal-border)] hover:bg-[var(--cal-border-light)] rounded-lg transition-colors"
+                className="w-full py-3 mt-2 text-xs font-medium text-cal-accent border border-cal-border hover:bg-cal-border-light rounded-lg transition-colors"
               >
                 Load more suggestions
               </button>
@@ -211,7 +211,7 @@ export function ForYouPanel({
 
       {/* Footer hint */}
       {enrichedSuggestions.length > 0 && (
-        <div className="text-center text-[11px] text-[var(--cal-text-tertiary)] py-2.5 border-t border-[var(--cal-border-light)]">
+        <div className="text-center text-[11px] text-cal-text-tertiary py-2.5 border-t border-cal-border-light">
           Drag any card onto the calendar to schedule it
         </div>
       )}

--- a/apps/web/components/calendar/GhostEventBlock.tsx
+++ b/apps/web/components/calendar/GhostEventBlock.tsx
@@ -31,7 +31,7 @@ export function GhostEventBlock({
           background: 'color-mix(in srgb, var(--cal-accent) 10%, transparent)',
         }}
       >
-        <span className="text-[11px] font-medium text-[var(--cal-text)] truncate leading-tight">
+        <span className="text-[11px] font-medium text-cal-text truncate leading-tight">
           {activity.title}
         </span>
         <div className="flex gap-1 justify-end mt-1">

--- a/apps/web/components/calendar/RescoperConflictModal.tsx
+++ b/apps/web/components/calendar/RescoperConflictModal.tsx
@@ -21,11 +21,11 @@ export function RescoperConflictModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="bg-white dark:bg-[#0f1a28] border border-gray-200 dark:border-[#1e3a5f]/40 rounded-xl shadow-xl w-full max-w-sm mx-4 p-5">
-        <h2 className="text-[15px] font-medium text-gray-900 dark:text-[#f5efe8] mb-1">
+      <div className="bg-white dark:bg-cal-surface-elevated border border-gray-200 dark:border-cal-border rounded-xl shadow-xl w-full max-w-sm mx-4 p-5">
+        <h2 className="text-[15px] font-medium text-gray-900 dark:text-cal-text mb-1">
           Activities outside new range
         </h2>
-        <p className="text-[13px] text-gray-500 dark:text-[#4a7ab5] mb-3">
+        <p className="text-[13px] text-gray-500 dark:text-cal-text-secondary mb-3">
           {conflictingActivities.length === 1
             ? '1 activity falls outside the new trip dates.'
             : `${conflictingActivities.length} activities fall outside the new trip dates.`}
@@ -40,7 +40,7 @@ export function RescoperConflictModal({
           {conflictingActivities.map((a) => (
             <li
               key={a.id}
-              className="text-[13px] text-gray-700 dark:text-[#cdd9e5] bg-gray-50 dark:bg-[#1e3a5f]/10 rounded px-2 py-1 truncate"
+              className="text-[13px] text-gray-700 dark:text-cal-text bg-gray-50 dark:bg-cal-accent-bg/30 rounded px-2 py-1 truncate"
             >
               {a.title || 'Untitled'}
             </li>
@@ -50,19 +50,19 @@ export function RescoperConflictModal({
         <div className="flex flex-col gap-2">
           <button
             onClick={onMoveToLastDay}
-            className="w-full px-4 py-2 rounded-lg bg-[#003594] text-white text-[13px] font-medium hover:bg-[#002a7a] transition-colors"
+            className="w-full px-4 py-2 rounded-lg bg-primary text-white text-[13px] font-medium hover:bg-primary transition-colors"
           >
             Move to last day
           </button>
           <button
             onClick={onKeepUnscheduled}
-            className="w-full px-4 py-2 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 text-gray-700 dark:text-[#cdd9e5] text-[13px] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 transition-colors"
+            className="w-full px-4 py-2 rounded-lg border border-gray-200 dark:border-cal-border text-gray-700 dark:text-cal-text text-[13px] hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60 transition-colors"
           >
             Keep as unscheduled
           </button>
           <button
             onClick={onCancel}
-            className="w-full px-4 py-2 text-[13px] text-gray-400 dark:text-[#4a7ab5] hover:text-gray-600 dark:hover:text-white transition-colors"
+            className="w-full px-4 py-2 text-[13px] text-gray-400 dark:text-cal-text-secondary hover:text-gray-600 dark:hover:text-cal-text transition-colors"
           >
             Cancel
           </button>

--- a/apps/web/components/calendar/RescoperPopover.tsx
+++ b/apps/web/components/calendar/RescoperPopover.tsx
@@ -104,7 +104,7 @@ export function RescoperPopover({
     <>
       <div
         ref={popoverRef}
-        className="absolute top-full mt-1 left-0 z-40 bg-white dark:bg-[#0f1a28] border border-gray-200 dark:border-[#1e3a5f]/40 rounded-xl shadow-xl w-80 p-4"
+        className="absolute top-full mt-1 left-0 z-40 bg-white dark:bg-cal-surface-elevated border border-gray-200 dark:border-cal-border rounded-xl shadow-xl w-80 p-4"
       >
         {errorMsg && (
           <div className="mb-3 text-[12px] text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded px-2 py-1">
@@ -114,26 +114,26 @@ export function RescoperPopover({
 
         {/* Destination */}
         <div className="mb-3">
-          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-[#4a7ab5] mb-1">
+          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-cal-text-secondary mb-1">
             Destination
           </label>
           <input
             type="text"
             value={destination}
             onChange={(e) => setDestination(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 bg-transparent px-3 py-1.5 text-[13px] text-gray-800 dark:text-[#f5efe8] focus:outline-none focus:ring-1 focus:ring-[#003594]"
+            className="w-full rounded-lg border border-gray-200 dark:border-cal-border bg-transparent px-3 py-1.5 text-[13px] text-gray-800 dark:text-cal-text focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>
 
         {/* Start date */}
         <div className="mb-2">
-          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-[#4a7ab5] mb-1">
+          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-cal-text-secondary mb-1">
             Start
           </label>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setStartDate(subtractOneDayFrom(startDate))}
-              className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 text-gray-500 dark:text-[#4a7ab5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 text-[15px] font-light transition-colors"
+              className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 dark:border-cal-border text-gray-500 dark:text-cal-text-secondary hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60 text-[15px] font-light transition-colors"
               aria-label="Remove start day"
             >
               −
@@ -142,14 +142,14 @@ export function RescoperPopover({
               type="date"
               value={toInputValue(startDate)}
               onChange={(e) => e.target.value && setStartDate(fromInputValue(e.target.value))}
-              className="flex-1 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 bg-transparent px-2 py-1.5 text-[13px] text-gray-800 dark:text-[#f5efe8] focus:outline-none focus:ring-1 focus:ring-[#003594]"
+              className="flex-1 rounded-lg border border-gray-200 dark:border-cal-border bg-transparent px-2 py-1.5 text-[13px] text-gray-800 dark:text-cal-text focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
         </div>
 
         {/* End date */}
         <div className="mb-3">
-          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-[#4a7ab5] mb-1">
+          <label className="block text-[11px] uppercase tracking-wide text-gray-400 dark:text-cal-text-secondary mb-1">
             End
           </label>
           <div className="flex items-center gap-2">
@@ -157,11 +157,11 @@ export function RescoperPopover({
               type="date"
               value={toInputValue(endDate)}
               onChange={(e) => e.target.value && setEndDate(fromInputValue(e.target.value))}
-              className="flex-1 rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 bg-transparent px-2 py-1.5 text-[13px] text-gray-800 dark:text-[#f5efe8] focus:outline-none focus:ring-1 focus:ring-[#003594]"
+              className="flex-1 rounded-lg border border-gray-200 dark:border-cal-border bg-transparent px-2 py-1.5 text-[13px] text-gray-800 dark:text-cal-text focus:outline-none focus:ring-1 focus:ring-primary"
             />
             <button
               onClick={() => setEndDate(addOneDayTo(endDate))}
-              className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 dark:border-[#1e3a5f]/40 text-gray-500 dark:text-[#4a7ab5] hover:bg-gray-50 dark:hover:bg-[#1e3a5f]/20 text-[15px] font-light transition-colors"
+              className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 dark:border-cal-border text-gray-500 dark:text-cal-text-secondary hover:bg-gray-50 dark:hover:bg-cal-accent-bg/60 text-[15px] font-light transition-colors"
               aria-label="Add end day"
             >
               +
@@ -170,7 +170,7 @@ export function RescoperPopover({
         </div>
 
         {/* Night count */}
-        <p className="text-[12px] text-gray-400 dark:text-[#4a7ab5] mb-4">
+        <p className="text-[12px] text-gray-400 dark:text-cal-text-secondary mb-4">
           {isInvalid ? (
             <span className="text-red-500">End must be after start</span>
           ) : (
@@ -182,14 +182,14 @@ export function RescoperPopover({
         <div className="flex items-center justify-end gap-2">
           <button
             onClick={onClose}
-            className="px-3 py-1.5 text-[13px] text-gray-500 dark:text-[#4a7ab5] hover:text-gray-700 dark:hover:text-white transition-colors"
+            className="px-3 py-1.5 text-[13px] text-gray-500 dark:text-cal-text-secondary hover:text-gray-700 dark:hover:text-cal-text transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={handleApply}
             disabled={isInvalid || isLoading}
-            className="px-4 py-1.5 rounded-lg bg-[#003594] text-white text-[13px] font-medium hover:bg-[#002a7a] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="px-4 py-1.5 rounded-lg bg-primary text-white text-[13px] font-medium hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {isLoading ? 'Saving…' : 'Apply'}
           </button>

--- a/apps/web/components/calendar/ResizeDivider.tsx
+++ b/apps/web/components/calendar/ResizeDivider.tsx
@@ -61,7 +61,7 @@ export function ResizeDivider({ width, onDragStart, onDrag, onDragEnd }: ResizeD
       style={{ touchAction: 'none' }}
     >
       {/* Visible handle line */}
-      <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-[1px] bg-[var(--cal-border)] group-hover:w-[3px] group-hover:bg-[var(--cal-accent)] transition-all rounded-full" />
+      <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-[1px] bg-cal-border group-hover:w-[3px] group-hover:bg-cal-accent transition-all rounded-full" />
       {/* Wider hit target */}
       <div className="absolute inset-y-0 -left-1 -right-1" />
     </div>

--- a/apps/web/components/calendar/SidebarTabs.tsx
+++ b/apps/web/components/calendar/SidebarTabs.tsx
@@ -31,7 +31,7 @@ export default function SidebarTabs({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex border-b border-[var(--cal-border)]">
+      <div className="flex border-b border-cal-border">
         {tabs.map(tab => (
           <button
             key={tab.id}
@@ -39,8 +39,8 @@ export default function SidebarTabs({
             className={[
               'px-4 py-2 text-sm font-medium transition-colors',
               activeTab === tab.id
-                ? 'text-[#003594] border-b-2 border-[#003594]'
-                : 'text-[var(--cal-text-secondary)] hover:text-[var(--cal-text)]',
+                ? 'text-primary border-b-2 border-primary'
+                : 'text-cal-text-secondary hover:text-cal-text',
             ].join(' ')}
           >
             {tab.label}

--- a/apps/web/components/calendar/SuggestionDetailDrawer.tsx
+++ b/apps/web/components/calendar/SuggestionDetailDrawer.tsx
@@ -69,7 +69,7 @@ export function SuggestionDetailDrawer({
     <div
       className={[
         'absolute inset-y-0 right-0 w-full z-30',
-        'bg-[var(--cal-surface-elevated)] flex flex-col',
+        'bg-cal-surface-elevated flex flex-col',
         'transition-transform duration-300 ease-out',
         !isVisible || isClosing ? 'translate-x-full' : 'translate-x-0',
       ].join(' ')}
@@ -159,7 +159,7 @@ export function SuggestionDetailDrawer({
       {/* Scrollable body */}
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
         {/* Name */}
-        <h3 className="text-[15px] font-semibold text-[var(--cal-text)] leading-snug">
+        <h3 className="text-[15px] font-semibold text-cal-text leading-snug">
           {suggestion.name}
         </h3>
 
@@ -171,7 +171,7 @@ export function SuggestionDetailDrawer({
             </span>
           )}
           {suggestion.price != null && (
-            <span className="text-[11px] text-[var(--cal-text-secondary)]">
+            <span className="text-[11px] text-cal-text-secondary">
               {formatPrice(suggestion.price, suggestion.currency)}
             </span>
           )}
@@ -185,14 +185,14 @@ export function SuggestionDetailDrawer({
             {suggestion.category.charAt(0).toUpperCase() +
               suggestion.category.slice(1)}
           </span>
-          <span className="text-[11px] text-[var(--cal-text-tertiary)]">
+          <span className="text-[11px] text-cal-text-tertiary">
             ~{formatDuration(suggestion.duration)}
           </span>
         </div>
 
         {/* Location */}
         {suggestion.location && (
-          <p className="text-[11px] text-[var(--cal-text-secondary)] flex items-start gap-1">
+          <p className="text-[11px] text-cal-text-secondary flex items-start gap-1">
             <span className="mt-[1px] shrink-0" aria-hidden="true">📍</span>
             <span>{suggestion.location}</span>
           </p>
@@ -200,7 +200,7 @@ export function SuggestionDetailDrawer({
 
         {/* Description */}
         {suggestion.description && (
-          <p className="text-[12px] text-[var(--cal-text-secondary)] leading-relaxed">
+          <p className="text-[12px] text-cal-text-secondary leading-relaxed">
             {suggestion.description}
           </p>
         )}
@@ -210,7 +210,7 @@ export function SuggestionDetailDrawer({
           <Link
             href={`/activity/${suggestion.id}`}
             onClick={(e) => e.stopPropagation()}
-            className="flex items-center justify-center gap-1.5 w-full py-2 rounded-lg border border-[var(--cal-border)] text-[12px] font-medium text-[var(--cal-text-secondary)] hover:bg-[var(--cal-border-light)] hover:text-[var(--cal-text)] transition-colors"
+            className="flex items-center justify-center gap-1.5 w-full py-2 rounded-lg border border-cal-border text-[12px] font-medium text-cal-text-secondary hover:bg-cal-border-light hover:text-cal-text transition-colors"
           >
             View full details
           </Link>

--- a/apps/web/components/calendar/TimeGutter.tsx
+++ b/apps/web/components/calendar/TimeGutter.tsx
@@ -11,7 +11,7 @@ export function TimeGutter({ timeRange }: TimeGutterProps) {
   return (
     <div className="relative flex-shrink-0 w-16 text-right pr-3">
       {hours.map((hour) => (
-        <div key={hour} className="relative text-xs text-[var(--cal-hour-text)] select-none whitespace-nowrap" style={{ height: HOUR_HEIGHT }}>
+        <div key={hour} className="relative text-xs text-cal-hour-text select-none whitespace-nowrap" style={{ height: HOUR_HEIGHT }}>
           <span className="absolute -top-2 right-3">{formatHourGutter(hour)}</span>
         </div>
       ))}

--- a/apps/web/components/calendar/UnscheduledPopover.tsx
+++ b/apps/web/components/calendar/UnscheduledPopover.tsx
@@ -46,18 +46,18 @@ export function UnscheduledPopover({
   return (
     <div
       ref={ref}
-      className="absolute top-full mt-1 z-40 bg-white dark:bg-[#0f1a28] border border-gray-200 dark:border-[#1e3a5f]/40 rounded-xl shadow-xl w-72 p-3"
+      className="absolute top-full mt-1 z-40 bg-white dark:bg-cal-surface-elevated border border-gray-200 dark:border-cal-border rounded-xl shadow-xl w-72 p-3"
     >
-      <p className="text-[11px] uppercase tracking-wide text-gray-400 dark:text-[#4a7ab5] mb-2">
+      <p className="text-[11px] uppercase tracking-wide text-gray-400 dark:text-cal-text-secondary mb-2">
         Unscheduled activities
       </p>
       <ul className="space-y-2 max-h-60 overflow-y-auto">
         {activities.map((a) => (
           <li
             key={a.id}
-            className="flex items-center gap-2 rounded-lg bg-gray-50 dark:bg-[#1e3a5f]/10 px-2 py-1.5"
+            className="flex items-center gap-2 rounded-lg bg-gray-50 dark:bg-cal-accent-bg/30 px-2 py-1.5"
           >
-            <span className="flex-1 text-[12px] text-gray-700 dark:text-[#cdd9e5] truncate min-w-0">
+            <span className="flex-1 text-[12px] text-gray-700 dark:text-cal-text truncate min-w-0">
               {a.title || 'Untitled'}
             </span>
             <input
@@ -66,12 +66,12 @@ export function UnscheduledPopover({
               max={maxDate}
               onChange={(e) => handleDateChange(a.id, e.target.value)}
               title="Assign to day"
-              className="w-32 text-[11px] rounded border border-gray-200 dark:border-[#1e3a5f]/40 bg-transparent px-1.5 py-0.5 text-gray-600 dark:text-[#cdd9e5] focus:outline-none focus:ring-1 focus:ring-[#003594]"
+              className="w-32 text-[11px] rounded border border-gray-200 dark:border-cal-border bg-transparent px-1.5 py-0.5 text-gray-600 dark:text-cal-text focus:outline-none focus:ring-1 focus:ring-primary"
             />
             <button
               onClick={() => onDelete(a.id)}
               aria-label="Delete activity"
-              className="text-gray-400 dark:text-[#4a7ab5] hover:text-red-500 dark:hover:text-red-400 transition-colors shrink-0"
+              className="text-gray-400 dark:text-cal-text-secondary hover:text-red-500 dark:hover:text-red-400 transition-colors shrink-0"
             >
               <Trash width={14} height={14} />
             </button>

--- a/apps/web/components/calendar/sharing/AvatarReportModal.tsx
+++ b/apps/web/components/calendar/sharing/AvatarReportModal.tsx
@@ -36,7 +36,7 @@ export function AvatarReportModal({ isOpen, target, onClose, onSubmit }: AvatarR
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div className="bg-white dark:bg-[#1a2535] rounded-xl p-6 max-w-sm w-full mx-4" onClick={e => e.stopPropagation()}>
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-6 max-w-sm w-full mx-4" onClick={e => e.stopPropagation()}>
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Report Avatar</h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
           Report inappropriate avatar for {target.reportedLabel}
@@ -48,7 +48,7 @@ export function AvatarReportModal({ isOpen, target, onClose, onSubmit }: AvatarR
           value={reason}
           onChange={e => setReason(e.target.value)}
           placeholder="Describe the issue..."
-          className="w-full h-24 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-[#0c1117] text-sm text-gray-900 dark:text-white resize-none"
+          className="w-full h-24 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-background text-sm text-gray-900 dark:text-white resize-none"
         />
         <div className="flex gap-2 mt-4">
           <button onClick={onClose} className="flex-1 px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm">

--- a/apps/web/components/calendar/sharing/CollaboratorList.tsx
+++ b/apps/web/components/calendar/sharing/CollaboratorList.tsx
@@ -72,7 +72,7 @@ export function CollaboratorList({
       {/* Owner row */}
       <div className="flex items-center justify-between border-b border-white/10 py-2">
         <div className="flex items-center gap-3">
-          {renderAvatar(ownerName || ownerEmail || 'U', ownerAvatarUrl, 'bg-[#003594]')}
+          {renderAvatar(ownerName || ownerEmail || 'U', ownerAvatarUrl, 'bg-primary')}
           <div>
             <div className="text-sm text-white">{ownerName}</div>
             <div className="text-xs text-white/40">{ownerEmail}</div>

--- a/apps/web/components/calendar/sharing/InviteBar.tsx
+++ b/apps/web/components/calendar/sharing/InviteBar.tsx
@@ -31,7 +31,7 @@ export function InviteBar({ onInvite, isLoading }: InviteBarProps) {
         onChange={(e) => setEmail(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
         placeholder="Add people by email..."
-        className="flex-1 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/40 outline-none focus:border-[#003594]"
+        className="flex-1 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/40 outline-none focus:border-primary"
       />
       <select
         value={role}
@@ -44,7 +44,7 @@ export function InviteBar({ onInvite, isLoading }: InviteBarProps) {
       <button
         onClick={handleSubmit}
         disabled={isLoading || !email.trim()}
-        className="rounded-lg bg-[#003594] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
       >
         Invite
       </button>

--- a/apps/web/components/calendar/sharing/ShareModal.tsx
+++ b/apps/web/components/calendar/sharing/ShareModal.tsx
@@ -119,7 +119,7 @@ export function ShareModal({ trip, isOpen, onClose, onSettingsChange }: ShareMod
     <AnimatePresence>
       {isOpen && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={handleBackdropClick}>
-          <motion.div ref={modalRef} initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }} className="w-full max-w-md rounded-xl border border-white/10 bg-[#1a1a2e] p-5 shadow-2xl">
+          <motion.div ref={modalRef} initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }} className="w-full max-w-md rounded-xl border border-white/10 bg-gray-900 p-5 shadow-2xl">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-white">Share &ldquo;{trip.title}&rdquo;</h2>
               <button onClick={onClose} className="text-white/40 transition-colors hover:text-white">&times;</button>

--- a/apps/web/components/dashboard/DashboardNavBar.tsx
+++ b/apps/web/components/dashboard/DashboardNavBar.tsx
@@ -17,11 +17,11 @@ export function DashboardNavBar() {
       <Link href="/trips" className="flex items-center gap-1.5 group shrink-0">
         <PaperPlane
           size={18}
-          className="text-[#1e3a5f] group-hover:text-[#F59E0B] transition-colors"
+          className="text-[var(--trip-base)] group-hover:text-[#F59E0B] transition-colors"
           style={{ transform: 'rotate(-20deg)' }}
         />
         <span
-          className="text-[#1e3a5f] group-hover:text-[#F59E0B] transition-colors hidden sm:inline"
+          className="text-[var(--trip-base)] group-hover:text-[#F59E0B] transition-colors hidden sm:inline"
           style={{ fontFamily: 'var(--font-brand)', fontWeight: 800, fontSize: 15 }}
         >
           TRAVYL
@@ -42,7 +42,7 @@ export function DashboardNavBar() {
               className={[
                 'flex items-center gap-2 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors',
                 isActive
-                  ? 'bg-[#1e3a5f]/10 text-[#1e3a5f] dark:bg-white/10 dark:text-white'
+                  ? 'bg-[var(--trip-base)]/10 text-[var(--trip-base)] dark:bg-white/10 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/[0.06] hover:text-gray-900 dark:hover:text-gray-200',
               ].join(' ')}
             >
@@ -56,7 +56,7 @@ export function DashboardNavBar() {
       {/* User avatar */}
       <Link
         href="/profile"
-        className="flex items-center justify-center w-7 h-7 rounded-full bg-[#1e3a5f] text-white text-[11px] font-medium shrink-0 hover:ring-2 hover:ring-[#1e3a5f]/30 transition-all"
+        className="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--trip-base)] text-white text-[11px] font-medium shrink-0 hover:ring-2 hover:ring-[var(--trip-base)]/30 transition-all"
       >
         {initials}
       </Link>

--- a/apps/web/components/trip/CompactTripHeader.tsx
+++ b/apps/web/components/trip/CompactTripHeader.tsx
@@ -203,7 +203,7 @@ export function CompactTripHeader({
                 )}
                 {/* Wiki */}
                 {wiki && (
-                  <p className="text-[13px] leading-relaxed text-white/80 font-serif line-clamp-4 backdrop-blur-sm bg-black/25 rounded-lg px-4 py-3"
+                  <p className="text-[13px] leading-relaxed text-white/80 font-sans line-clamp-4 backdrop-blur-sm bg-black/25 rounded-lg px-4 py-3"
                     style={{ textShadow: '0 1px 6px rgba(0,0,0,0.4)' }}>
                     {wiki}
                   </p>

--- a/apps/web/components/trip/TripMagazineHero.tsx
+++ b/apps/web/components/trip/TripMagazineHero.tsx
@@ -447,7 +447,7 @@ export function TripMagazineHero({ tripId, trip, overrideImage, compact, onTripU
             {wiki?.extract && (
               <div className="rounded-xl px-4 py-3"
                 style={{ background: 'rgba(0,0,0,0.3)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', textShadow: '0 1px 4px rgba(0,0,0,0.3)' }}>
-                <p className="text-[13px] sm:text-[14px] leading-[1.7] text-white/90 font-serif line-clamp-3">
+                <p className="text-[13px] sm:text-[14px] leading-[1.7] text-white/90 font-sans line-clamp-3">
                   {wiki.extract}
                 </p>
               </div>

--- a/apps/web/components/trips/CreateTripModal.tsx
+++ b/apps/web/components/trips/CreateTripModal.tsx
@@ -7,7 +7,7 @@ import dynamic from 'next/dynamic'
 import { X, MapPin } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { PaperPlane } from '@/components/ui'
-import { useAuthStore } from '@travyl/shared'
+import { useAuthStore, Navy } from '@travyl/shared'
 import { supabase } from '@travyl/shared'
 import { useIndexTrip } from '@/hooks/useIndexTrip'
 
@@ -257,10 +257,10 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
         >
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-[#1e3a5f] flex items-center justify-center">
+              <div className="w-8 h-8 rounded-full bg-[var(--trip-base)] flex items-center justify-center">
                 <PaperPlane size={14} className="text-white -rotate-12" />
               </div>
-              <h2 id="create-trip-title" className="text-lg font-bold text-[#1e3a5f]">Plan a Trip</h2>
+              <h2 id="create-trip-title" className="text-lg font-bold text-[var(--trip-base)]">Plan a Trip</h2>
             </div>
             <button aria-label="Close dialog" onClick={onClose} className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors">
               <X size={18} aria-hidden />
@@ -277,7 +277,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
               <input id="trip-title" type="text" value={title}
                 onChange={(e) => { setTitle(e.target.value); setFieldErrors((prev) => ({ ...prev, title: undefined })) }}
                 placeholder="e.g. Paris Adventure" disabled={submitting}
-                className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#1e3a5f]/20 focus:border-[#1e3a5f]/40 disabled:opacity-50 transition-all"
+                className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[var(--trip-base)]/20 focus:border-[var(--trip-base)]/40 disabled:opacity-50 transition-all"
               />
               {fieldErrors.title && <p className="mt-1 text-xs text-red-500">{fieldErrors.title}</p>}
             </div>
@@ -289,7 +289,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
                 onFocus={() => { if (suggestions.length > 0) setSuggestionsOpen(true) }}
                 onKeyDown={(e) => { if (e.key === 'Enter' && suggestionsOpen && suggestions.length > 0) { e.preventDefault(); selectSuggestion(suggestions[0]) } }}
                 placeholder="e.g. Paris, France" disabled={submitting} autoComplete="off"
-                className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#1e3a5f]/20 focus:border-[#1e3a5f]/40 disabled:opacity-50 transition-all"
+                className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[var(--trip-base)]/20 focus:border-[var(--trip-base)]/40 disabled:opacity-50 transition-all"
               />
               {suggestionsOpen && (
                 <ul role="listbox" aria-label="Destination suggestions"
@@ -312,7 +312,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
                 <input id="trip-start-date" type="date" value={startDate}
                   onChange={(e) => { setStartDate(e.target.value); setFieldErrors((prev) => ({ ...prev, start_date: undefined })) }}
                   disabled={submitting}
-                  className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#1e3a5f]/20 focus:border-[#1e3a5f]/40 disabled:opacity-50 transition-all"
+                  className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[var(--trip-base)]/20 focus:border-[var(--trip-base)]/40 disabled:opacity-50 transition-all"
                 />
                 {fieldErrors.start_date && <p className="mt-1 text-xs text-red-500">{fieldErrors.start_date}</p>}
               </div>
@@ -321,14 +321,14 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
                 <input id="trip-end-date" type="date" value={endDate}
                   onChange={(e) => { setEndDate(e.target.value); setFieldErrors((prev) => ({ ...prev, end_date: undefined })) }}
                   disabled={submitting}
-                  className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#1e3a5f]/20 focus:border-[#1e3a5f]/40 disabled:opacity-50 transition-all"
+                  className="w-full h-11 px-3 rounded-xl border border-gray-200 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-[var(--trip-base)]/20 focus:border-[var(--trip-base)]/40 disabled:opacity-50 transition-all"
                 />
                 {fieldErrors.end_date && <p className="mt-1 text-xs text-red-500">{fieldErrors.end_date}</p>}
               </div>
             </div>
 
             <button type="submit" disabled={submitting}
-              className="w-full h-11 rounded-xl bg-[#1e3a5f] text-white text-sm font-semibold hover:bg-[#2a4d78] disabled:opacity-50 transition-all mt-2">
+              className="w-full h-11 rounded-xl bg-[var(--trip-base)] text-white text-sm font-semibold hover:brightness-125 disabled:opacity-50 transition-all mt-2">
               {submitting ? 'Creating...' : 'Create Trip'}
             </button>
           </form>
@@ -347,7 +347,7 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
               <div className="w-full h-full relative flex-1" style={{ minHeight: 420 }}>
                 <LeafletMap
                   locations={[
-                    { id: 'dest', lat: selectedCoords.lat, lng: selectedCoords.lon, name: `📍 ${destination.split(',')[0]}`, color: '#1e3a5f', category: 'destination' },
+                    { id: 'dest', lat: selectedCoords.lat, lng: selectedCoords.lon, name: `📍 ${destination.split(',')[0]}`, color: Navy.DEFAULT, category: 'destination' },
                     ...landmarks,
                   ]}
                   zoom={13}
@@ -358,8 +358,8 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
                 <div className="absolute bottom-4 left-4 right-4 z-[1000]">
                   <div className="bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-md">
                     <div className="flex items-center gap-1.5">
-                      <MapPin size={12} className="text-[#1e3a5f] shrink-0" />
-                      <span className="text-xs font-medium text-[#1e3a5f] truncate">{destination.split(',')[0]}</span>
+                      <MapPin size={12} className="text-[var(--trip-base)] shrink-0" />
+                      <span className="text-xs font-medium text-[var(--trip-base)] truncate">{destination.split(',')[0]}</span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Replace all `#1e3a5f` and related hardcoded hex values with `var(--trip-base)` / `var(--cal-*)` CSS custom properties
- Add calendar light/dark CSS variable definitions in `globals.css`
- Add `.masonry-grid-3` utility class
- Add `system-ui` font fallback in layout
- Import `Navy` from `@travyl/shared` in CreateTripModal for map marker consistency
- Enables per-trip theme colors and consistent dark mode across navbar, calendar, budget, and trip components

## Files changed
38 files — calendar components (27), sharing subcomponents (4), budget (3), trip (2), nav (1), and layout/global styles

## Test plan
- [ ] Light mode: all components render with correct navy colors
- [ ] Dark mode: calendar, navbar, budget, trip components use dark color scheme
- [ ] Trip-specific theme colors apply correctly via `--trip-base`