### PR TITLE
fix: remove duplicate /api/events/search route causing SST deploy failure

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -206,11 +206,6 @@ api.route('GET /events', {
   link: [cacheTable, supabaseSecretKey, supabaseUrl, ticketmasterApiKey],
 })
 
-api.route('GET /api/events/search', {
-  handler: 'services/events.handler',
-  link: [cacheTable, supabaseSecretKey, supabaseUrl, ticketmasterApiKey],
-})
-
 api.route('GET /events/{id}/details', {
   handler: 'services/events.detailsHandler',
   link: [supabaseSecretKey, supabaseUrl, ticketmasterApiKey],


### PR DESCRIPTION
## Summary
Removes a duplicate `GET /api/events/search` route definition in `infra/api.ts` that was causing `Component name not unique` errors during `sst deploy --stage production`.

## Root cause
The route was defined twice with different handlers:
- Line 199: `services/events-search.handler` (uses PredictHQ)
- Line 209: `services/events.handler` (uses Ticketmaster) — **removed**

SST generates component names from route paths, so identical routes produce duplicate component names.