### PR TITLE
fix(web): unblock build — wrong iconoir name + null user guards

### DIFF
--- a/apps/web/app/(main)/profile/page.tsx
+++ b/apps/web/app/(main)/profile/page.tsx
@@ -38,7 +38,7 @@ export default function ProfilePage() {
     }
   }
 
-  const displayName = profile?.display_name || user.email?.split('@')[0] || 'User'
+  const displayName = profile?.display_name || user?.email?.split('@')[0] || 'User'
   const initials = displayName
     .split(' ')
     .map((word) => word[0])
@@ -71,7 +71,7 @@ export default function ProfilePage() {
               {/* User Info */}
               <div>
                 <h1 className="text-3xl font-bold text-gray-900 mb-2">{displayName}</h1>
-                <p className="text-gray-600 mb-4">{user.email}</p>
+                <p className="text-gray-600 mb-4">{user?.email}</p>
 
                 {/* Stats */}
                 <div className="flex gap-6">

--- a/apps/web/app/(main)/profile/settings/page.tsx
+++ b/apps/web/app/(main)/profile/settings/page.tsx
@@ -310,6 +310,13 @@ export default function ProfileSettings() {
           return;
         }
 
+        // AuthGuard wraps the page so user should exist by the time this
+        // effect runs, but TypeScript needs the explicit narrow.
+        if (!user) {
+          setIsLoading(false);
+          return;
+        }
+
         // Fetch profile data
         const profile = await fetchProfile(user.id);
         setProfileData(profile);

--- a/apps/web/components/calendar/HistoryDrawer.tsx
+++ b/apps/web/components/calendar/HistoryDrawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState, useMemo } from 'react'
-import { Xmark, Undo, ClockRotateLeft } from 'iconoir-react'
+import { Xmark, Undo, ClockRotateRight } from 'iconoir-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useActivityHistory, type AuditEntry } from './hooks/useActivityHistory'
 import { formatDistanceToNow } from 'date-fns'
@@ -199,7 +199,7 @@ export function HistoryDrawer({
                       title="Restore itinerary to this point"
                       className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
                     >
-                      <ClockRotateLeft className="w-3 h-3" />
+                      <ClockRotateRight className="w-3 h-3" />
                       Restore to here
                     </button>
                   )


### PR DESCRIPTION
## Summary
Develop has been failing \`next build\` since the merges of #701 (AuthGuard profile layout) and #702 (trip history restore-to-point). This PR fixes three blockers so the rest of the queue can be verified locally.

## Fixes
1. **HistoryDrawer.tsx** — \`ClockRotateLeft\` doesn't exist in iconoir-react; the real icon is \`ClockRotateRight\`. Replaced import + JSX usage.
2. **app/(main)/profile/page.tsx** — \`user.email\` (×2) — \`user\` is now nullable behind AuthGuard. Added optional chaining.
3. **app/(main)/profile/settings/page.tsx** — \`loadProfile\` useEffect dereferenced \`user.id\` and a long list of \`user.user_metadata.*\` fields. Added an explicit \`if (!user) return\` narrow at the top of the effect.

## Test plan
- [x] \`npm run build\` clean for apps/web
- [ ] Profile page renders for logged-in user (no functional regression)
- [ ] Calendar history drawer renders the rotate icon (was missing entirely before)