### PR TITLE
ci(expo-preview): install eas-cli so npx eas update can find it

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -23,6 +23,7 @@ jobs:
         uses: expo/expo-github-action@v8
         with:
           expo-version: latest
+          eas-version: latest
           eas-cache: true
           token: ${{ secrets.EXPO_TOKEN }}
 


### PR DESCRIPTION
## Summary
Both auto-runs since #690 enabled the EAS-update workflow have **failed** at the \`Publish Update\` step with:
\`\`\`
npm error could not determine executable to run
\`\`\`

## Root cause
\`expo/expo-github-action@v8\` was given \`expo-version: latest\` but no \`eas-version\`, so eas-cli was never installed on the runner. \`npx eas update\` then has no binary to resolve.

## Fix
One line — add \`eas-version: latest\` to the action inputs.

## Test plan
- After merge, the next push to develop should produce a green \`Expo Preview\` workflow run and refresh the preview-channel binary tied to the constant QR code (so demos will pick up the latest mobile code automatically).