### PR TITLE
fix(web/places): guard grid showcase against tiny/empty filtered list

### DIFF
--- a/apps/web/app/(main)/places/page.tsx
+++ b/apps/web/app/(main)/places/page.tsx
@@ -551,9 +551,17 @@ export default function PlacesPage() {
                       style={{ maxWidth: 900, height: 480 }}
                     >
                       {(() => {
-                        const prevP = filtered[gridShowcaseIdx === 0 ? filtered.length - 1 : gridShowcaseIdx - 1];
-                        const nextP = filtered[(gridShowcaseIdx + 1) % filtered.length];
-                        const nextNextP = filtered[(gridShowcaseIdx + 2) % filtered.length];
+                        // Defensive: showcase is gated on filtered[gridShowcaseIdx]
+                        // existing, but if filtered shrinks via search/filter while
+                        // showcase is open, peek-card lookups can resolve to
+                        // undefined and crash on .image / .name.
+                        const activeP = filtered[gridShowcaseIdx];
+                        if (!activeP || filtered.length === 0) return null;
+                        const prevP =
+                          filtered[gridShowcaseIdx === 0 ? filtered.length - 1 : gridShowcaseIdx - 1] ??
+                          activeP;
+                        const nextP = filtered[(gridShowcaseIdx + 1) % filtered.length] ?? activeP;
+                        const nextNextP = filtered[(gridShowcaseIdx + 2) % filtered.length] ?? activeP;
                         // Deck-of-cards animation: exit pulls card toward viewer, enter reveals from behind
                         const shuffleVariants = {
                           enter: (d: number) => ({ scale: 0.85, y: 30, opacity: 0, rotate: d > 0 ? 2 : -2 }),


### PR DESCRIPTION
## Summary
- **Crash:** the grid-showcase peek-card lookups (\`prevP\`, \`nextP\`, \`nextNextP\`) used modulo arithmetic without checking that the resulting indices were defined. When \`filtered\` shrunk while the showcase was open (search/category change), the JSX crashed on \`prevP.image\`/\`prevP.name\`.

## Fix
- Guard at the top of the peek-card IIFE: if the active item is missing or the filtered list is empty, render \`null\`.
- Each peek-card lookup now falls back to the active item rather than \`undefined\`, so 1-/2-item filtered lists render without flicker.

## Test plan
- [x] \`npm run build\` clean for apps/web
- [ ] Open showcase → apply a category filter that returns 0 items → no crash, showcase closes cleanly