### PR TITLE
fix(web/places): skip filterByRadius when coords are missing

### DIFF
--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -109,10 +109,15 @@ export async function GET(req: NextRequest) {
     }
 
     // Filter by geographic radius to avoid returning places from wrong cities
-    // (e.g. Universal Studios Orlando in a New Delhi trip)
+    // (e.g. Universal Studios Orlando in a New Delhi trip). Skip when the
+    // caller didn't provide coords — `parseFloat('')` is NaN and every
+    // distance check returns NaN, which the filter would treat as out-of-
+    // range and silently drop every result for NLP-only queries.
     const searchLat = parseFloat(lat)
     const searchLng = parseFloat(lng)
-    data = filterByRadius(data, searchLat, searchLng, 50)
+    if (Number.isFinite(searchLat) && Number.isFinite(searchLng)) {
+      data = filterByRadius(data, searchLat, searchLng, 50)
+    }
 
     // Map to PlaceItem format using the canonical shared mapper — strip items with no valid image
     const requestedCat = category


### PR DESCRIPTION
## Summary
- **Bug:** NLP-only queries (\`?q=rooftop+bars\` with no \`lat\`/\`lng\`) silently returned \`[]\`. Root cause: \`parseFloat('')\` is \`NaN\`, every haversine distance came out as \`NaN\`, \`NaN < 50\` is false, and \`filterByRadius\` dropped every result.

## Fix
- Wrap the \`filterByRadius\` call in \`Number.isFinite(searchLat) && Number.isFinite(searchLng)\`. Geographic filtering only runs when we actually have a reference point. NLP-only queries now return what NLP found, deduplicated and image-filtered as before.

## Test plan
- [x] \`npm run build\` clean
- [ ] \`curl '/api/places?q=rooftop+bars'\` returns non-empty array (verify on dev)
- [ ] \`curl '/api/places?lat=37.77&lng=-122.42&category=restaurant'\` still filters by radius