### PR TITLE
fix(mobile/home): remove dead place-detail modal scaffolding

### DIFF
--- a/apps/mobile/app/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/(tabs)/(home)/index.tsx
@@ -38,12 +38,10 @@ import {
   FontFamily,
 } from '@travyl/shared';
 import { savePlanToSupabase } from '@travyl/shared';
-import type { PlaceItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useAddToTrip } from '@/hooks/useAddToTrip';
 
 import { PaperPlane } from '@/components/icons/PaperPlane';
-import { CardStackCarousel } from '@/components/places/CardStackCarousel';
 import {
   HowItWorks,
   GetInspired,
@@ -273,12 +271,6 @@ export default function HomeScreen() {
     ? [heroConfig.background_image_url]
     : SHUFFLED_STOCK;
   const [heroSlide, setHeroSlide] = useState(0);
-  const [selectedPlaceIdx, setSelectedPlaceIdx] = useState(-1);
-  const setSelectedPlace = useCallback((place: PlaceItem | null) => {
-    if (!place) { setSelectedPlaceIdx(-1); return; }
-    const idx = ([] as PlaceItem[]).findIndex((p) => p.id === place.id);
-    setSelectedPlaceIdx(idx >= 0 ? idx : -1);
-  }, []);
   useEffect(() => {
     if (heroSlides.length <= 1) return;
     // Pause rotation while user is typing — context shifts are jarring mid-input
@@ -884,19 +876,6 @@ export default function HomeScreen() {
       }}
     />
 
-    {/* ─── Place Detail — Magazine Card ─────────────────────────────── */}
-    {selectedPlaceIdx >= 0 && (
-      <CardStackCarousel
-        places={([] as PlaceItem[])}
-        initialIndex={selectedPlaceIdx}
-        favorites={[]}
-        onToggleFav={() => {}}
-        onAddToTrip={addToTrip}
-        tripSheet={{ state: tripSheetState, selectTrip, selectDay, dismiss, createTrip }}
-        overlay
-        onClose={() => setSelectedPlaceIdx(-1)}
-      />
-    )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- **Bug:** the home tab held a partial place-detail modal that never worked. \`setSelectedPlace\` searched a hardcoded empty array literal so the index was always \`-1\`, and the gated \`<CardStackCarousel places={[]} />\` was passed an empty array regardless. Nothing on the page ever called the setter.
- **Root cause:** leftover scaffolding from a previous refactor — \`GetInspired\` now ships its own self-contained carousel that handles taps internally, so the parent state was orphaned.

## Fix
Delete the orphaned state, callback, and JSX (and the now-unused \`PlaceItem\` / \`CardStackCarousel\` imports). No behavior change for users.

## Test plan
- [x] Mobile typecheck clean for home tab
- [ ] On device: home tab still renders, tapping a card in \`GetInspired\` still opens its inline carousel as before