### PR TITLE
fix(web/places): read auth token from session, not user object

### DIFF
--- a/apps/web/app/(main)/places/page.tsx
+++ b/apps/web/app/(main)/places/page.tsx
@@ -129,9 +129,11 @@ export default function PlacesPage() {
 
   const [activeTab, setActiveTab] = useState<TabKey>('all');
   const [searchQuery, setSearchQuery] = useState('');
-  // Favorites: server for authenticated users, localStorage for anonymous
-  const user = useAuthStore((s) => s.user);
-  const authToken = user ? (user as any).access_token ?? null : null;
+  // Favorites: server for authenticated users, localStorage for anonymous.
+  // Token lives on the Session, not the User — reading user.access_token
+  // returned undefined and silently downgraded everyone to anonymous favs.
+  const session = useAuthStore((s) => s.session);
+  const authToken = session?.access_token ?? null;
   const { data: serverFavs, addFavorite: serverAdd, removeFavorite: serverRemove } = useServerFavorites(authToken);
   const serverFavPlaceIds = useMemo(() => (serverFavs ?? []).map(f => f.place_id), [serverFavs]);
 


### PR DESCRIPTION
## Summary
- **Bug:** \`/places\` page read \`(user as any).access_token\` to decide between server vs localStorage favorites. Supabase puts the token on the **Session**, not the User — so the expression always evaluated to \`null\` and every authenticated visitor was silently downgraded to anonymous favorites. Cross-device sync was effectively dead on this page.

## Fix
- Pull \`session\` from \`useAuthStore\` and read \`session.access_token\`.
- Authenticated users get \`useServerFavorites(authToken)\`; anonymous users keep the localStorage path. No type cast needed.

## Test plan
- [x] \`npm run build\` clean
- [ ] Logged in: favoriting a place persists across browsers (server-backed)
- [ ] Logged out: favoriting still works locally (localStorage)