### PR TITLE
fix(mobile): discoverItemToPlaceItem — derive type from item.category

### DIFF
--- a/apps/mobile/utils/discoverToPlace.ts
+++ b/apps/mobile/utils/discoverToPlace.ts
@@ -1,5 +1,17 @@
 import type { DiscoverItem, PlaceItem } from '@travyl/shared';
 
+// The PlaceItem.type union is the contract. If the backend `category`
+// already names one of those values, pass it through; otherwise fall
+// back to 'attraction'. This isn't a curated lookup table — it's just
+// type narrowing on the union itself.
+const PLACE_TYPES: PlaceItem['type'][] = [
+  'destination', 'attraction', 'restaurant', 'experience', 'event', 'hotel',
+];
+function resolveType(category: string | undefined): PlaceItem['type'] {
+  const c = (category ?? '').toLowerCase();
+  return (PLACE_TYPES.find((t) => t === c)) ?? 'attraction';
+}
+
 /**
  * Convert a DiscoverItem into a PlaceItem so it can be used
  * with the shared PlaceDetailModal / CardFront / CardBack components.
@@ -10,7 +22,7 @@ export function discoverItemToPlaceItem(item: DiscoverItem): PlaceItem {
     name: item.name,
     image: item.images[0] ?? '',
     images: item.images,
-    type: 'attraction',
+    type: resolveType(item.category),
     rating: item.rating,
     tagline: item.location,
     category: item.category ?? 'Activity',


### PR DESCRIPTION
## Summary
- **Bug:** every \`DiscoverItem\` flowing through this converter got stamped as \`type: 'attraction'\` regardless of what the backend returned. Tab filters that compare \`p.type === activeTab\` therefore never matched anything from the discover feed — Restaurants, Events, and Hotels tabs all looked empty even when the data was correct.

## Fix
- Narrow on the existing \`PlaceItem.type\` union. If the backend's \`category\` string matches one of the canonical types (\`destination/attraction/restaurant/experience/event/hotel\`), pass it through; otherwise fall back to \`attraction\`.
- This is type narrowing on the union, not a hand-curated lookup table.

## Test plan
- [x] Mobile typecheck clean
- [ ] On device: Restaurants tab on home shows restaurant items from discover feed
- [ ] Events tab shows event items