### PR TITLE
fix(web/places): use 400/503 status codes instead of silent 200 []

### DIFF
--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -31,12 +31,16 @@ export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get('q')
 
   if (!API_URL) {
-    return NextResponse.json([])
+    return NextResponse.json([], { status: 503 })
   }
 
-  // Must have either coordinates or a text query — never silently default to a location
+  // Must have either coordinates or a text query — never silently default to
+  // a location. Return a 400 instead of a bare 200 [] so the client can
+  // distinguish "you didn't pass enough params" from "we searched and found
+  // nothing." Body shape stays an array for backwards-compat with callers
+  // that already do `.map()` on the response.
   if (!lat && !lng && !q) {
-    return NextResponse.json([])
+    return NextResponse.json([], { status: 400 })
   }
 
   // Extract auth from Supabase cookies so backend Lambdas can validate the user


### PR DESCRIPTION
## Summary
- **Bug:** \`/api/places\` returned \`200 []\` whenever no params were passed (e.g. home tries to bootstrap a discovery feed before geolocation is granted). Clients couldn't tell apart \"quiet area\" from \"missing params\" — both surfaced as a blank grid that read as a broken API.

## Fix
- Missing \`API_URL\` → **503**
- Missing both coords and \`q\` → **400**
- Body stays a bare array so existing callers that \`.map()\` the response keep working; only \`res.ok\` flips to false on the new statuses.
- Page can branch on \`res.ok\` to render \"Allow location access or search for a city\" instead of an empty grid.

## Test plan
- [x] \`npm run build\` clean
- [ ] \`curl /api/places\` → 400 (no params)
- [ ] \`curl /api/places?q=tokyo\` → 200 with results
- [ ] \`curl /api/places?lat=37.77&lng=-122.42\` → 200 with results