### PR TITLE
fix(mobile): CardStackCarousel — clearer dominant-axis gate for swipes

### DIFF
--- a/apps/mobile/components/places/CardStackCarousel.tsx
+++ b/apps/mobile/components/places/CardStackCarousel.tsx
@@ -421,12 +421,15 @@ export function CardStackCarousel({
     PanResponder.create({
       onStartShouldSetPanResponderCapture: () => false,
       onMoveShouldSetPanResponderCapture: (_, gs) => {
-        // Lower threshold for easier vertical dragging
-        if (Math.abs(gs.dy) > 6 && Math.abs(gs.dy) > Math.abs(gs.dx)) {
+        // Direction is decided by which axis dominates clearly. A bare `>`
+        // ratio let horizontal swipes get misclassified as vertical when the
+        // first few pixels of motion had a small dy component, which would
+        // dismiss the sheet instead of navigating between cards.
+        if (Math.abs(gs.dy) > 8 && Math.abs(gs.dy) > Math.abs(gs.dx) * 1.5) {
           gestureDirRef.current = 'v';
           return true;
         }
-        if (Math.abs(gs.dx) > 12 && Math.abs(gs.dx) > Math.abs(gs.dy)) {
+        if (Math.abs(gs.dx) > 15 && Math.abs(gs.dx) > Math.abs(gs.dy) * 1.5) {
           gestureDirRef.current = 'h';
           return true;
         }


### PR DESCRIPTION
## Summary
- **Bug:** the combined PanResponder used a bare \`>\` comparison to decide vertical (resize/dismiss the sheet) vs horizontal (navigate cards). On touch devices the first few px of a horizontal swipe often pick up small dy motion, slipping past the 6 px vertical threshold — the responder classified the swipe as vertical and **closed the overlay instead of navigating**.

## Fix
1. Raise vertical threshold 6 → 8 px so accidental motion doesn't trigger.
2. Both axes require dominance by a 1.5× ratio over the other (\`> Math.abs(otherAxis) * 1.5\`) so the dominant direction wins clearly.

## Test plan
- [x] Mobile typecheck clean
- [ ] On device: open a place's overlay, swipe left/right — navigates between similar places without dismissing the sheet
- [ ] Pull down on the sheet handle — still dismisses