### PR TITLE
fix(web/places): keep column count in sync with viewport on resize

### DIFF
--- a/apps/web/app/(main)/places/page.tsx
+++ b/apps/web/app/(main)/places/page.tsx
@@ -199,12 +199,20 @@ export default function PlacesPage() {
     }
   };
 
-  // Responsive column count on mount
+  // Responsive column count — keep in sync with viewport on mount AND resize.
+  // Previously this only ran once, so rotating the device or resizing the
+  // browser left the masonry layout stuck at the initial column count.
   useEffect(() => {
-    const w = window.innerWidth;
-    if (w < 550) setColumnCount(1);
-    else if (w < 768) setColumnCount(2);
-    else if (w < 900) setColumnCount(3);
+    const computeColumns = () => {
+      const w = window.innerWidth;
+      if (w < 550) setColumnCount(1);
+      else if (w < 768) setColumnCount(2);
+      else if (w < 900) setColumnCount(3);
+      else setColumnCount(4);
+    };
+    computeColumns();
+    window.addEventListener('resize', computeColumns);
+    return () => window.removeEventListener('resize', computeColumns);
   }, []);
 
   // Filter by tab


### PR DESCRIPTION
## Summary
- **Bug:** the responsive column-count effect ran once on mount and never registered a \`resize\` listener. Rotating a tablet or resizing the browser kept the masonry layout stuck at the initial column count.

## Fix
- Wrap the breakpoint logic in \`computeColumns()\`.
- Run on mount + register a \`resize\` listener that re-runs it.
- Add the missing explicit 4-column branch (was relying on the useState default).

## Test plan
- [x] \`npm run build\` clean
- [ ] Resize browser between 480, 700, 850, 1100 px — grid reflows correctly each time