### PR TITLE
fix(mobile): PlaceDetailModal — stop pan-responder from swallowing taps

### DIFF
--- a/apps/mobile/components/places/PlaceDetailModal.tsx
+++ b/apps/mobile/components/places/PlaceDetailModal.tsx
@@ -72,8 +72,13 @@ const PlaceDetailModal = memo(function PlaceDetailModal({
 
   const sheetPanResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: (_, gs) => Math.abs(gs.dy) > 5,
+      // Don't claim the responder on touch start — that swallowed taps on
+      // every Pressable inside the sheet ("Get Directions", flip button,
+      // tag pills, etc.). Only claim once the user has moved meaningfully
+      // downward AND vertically dominates over horizontal motion.
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_, gs) =>
+        gs.dy > 10 && Math.abs(gs.dy) > Math.abs(gs.dx) * 1.5,
       onPanResponderRelease: (_, gs) => {
         if (gs.dy > 100 || (gs.dy > 30 && gs.vy > 0.5)) {
           onCloseRef.current();


### PR DESCRIPTION
## Summary
- **Bug:** \`sheetPanResponder.onStartShouldSetPanResponder\` returned \`true\`, claiming the gesture on every touch. React Native Pressables don't auto-stop propagation, so taps on \"Get Directions\", the website link, the flip button, and tag pills inside the sheet were all unreliable — they'd start the drag gesture and the press never registered.

## Fix
1. \`onStartShouldSetPanResponder\` → \`false\` (don't claim on touch start).
2. \`onMoveShouldSetPanResponder\` requires \`dy > 10\` AND vertical dominance by 1.5× over horizontal motion — only an intentional downward drag claims the responder.

## Test plan
- [x] Mobile typecheck clean
- [ ] Open a place detail modal — tap \"Get Directions\", \"Visit Website\", flip button: all respond instantly
- [ ] Drag the sheet handle/header down: still dismisses