### PR TITLE
fix(mobile): SwipeableDeck — rubber-band on blocked back-swipes

### DIFF
--- a/apps/mobile/components/places/SwipeableDeck.tsx
+++ b/apps/mobile/components/places/SwipeableDeck.tsx
@@ -62,9 +62,18 @@ export default function SwipeableDeck({
       onPanResponderMove: (_, gs) => {
         const idx = currentIndexRef.current;
         const len = placesLenRef.current;
-        // Forward-only deck: only allow swiping left (gs.dx < 0)
-        if (gs.dx > 0) return;
-        if (idx >= len - 1) return;
+        // Forward-only deck — but show rubber-band resistance on right swipes
+        // and at the last card so the user gets feedback that the gesture is
+        // recognised but blocked (otherwise the card sits frozen and feels
+        // like a broken touch target).
+        if (gs.dx > 0) {
+          translateX.value = gs.dx * 0.18;
+          return;
+        }
+        if (idx >= len - 1) {
+          translateX.value = gs.dx * 0.18;
+          return;
+        }
         translateX.value = gs.dx;
       },
       onPanResponderRelease: (_, gs) => {


### PR DESCRIPTION
## Summary
- **Polish:** the deck is forward-only — right-swipes and end-of-deck swipes are intentionally blocked. The move handler simply ignored them, so the card sat frozen during the gesture and felt like a dead touch target. Users couldn't tell the difference between \"swipe blocked\" and \"app frozen.\"

## Fix
- Allow a damped 18% translation on blocked swipes so the card visibly follows the finger a bit.
- The existing \`onPanResponderRelease\` already \`withSpring(0)\`s back to center, completing the rubber-band loop.
- No behavior change — only the affordance.

## Test plan
- [x] Mobile typecheck clean
- [ ] On the home discover deck: swipe right → card resists/follows then springs back
- [ ] At the last card: swipe left → same rubber-band feedback