### PR TITLE
fix(web): proxy nominatim through /api/geocode to fix CORS storm

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/info/page.tsx
@@ -141,7 +141,8 @@ function useInfoData(tripId: string) {
     queryFn: async () => {
       if (!lat || !lng) {
         // Geocode destination
-        const geoRes = await fetch(`https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(trip?.destination ?? '')}&format=json&limit=1`);
+        const geoRes = await fetch(`/api/geocode?q=${encodeURIComponent(trip?.destination ?? '')}`);
+        if (!geoRes.ok) return [];
         const geo = await geoRes.json();
         if (!geo[0]) return [];
         const res = await fetch(`/api/foursquare?lat=${geo[0].lat}&lng=${geo[0].lon}&category=restaurant&limit=4`);

--- a/apps/web/app/api/geocode/route.ts
+++ b/apps/web/app/api/geocode/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rateLimit, CACHE_1H } from '@/lib/api-utils'
+
+/**
+ * Geocoding proxy for Nominatim (OpenStreetMap).
+ *
+ * Nominatim doesn't send CORS headers, so direct browser fetches fail in
+ * production. All client-side geocoding/reverse-geocoding goes through this
+ * route — we proxy the call server-side and cache for 1h.
+ *
+ * Forward geocode:
+ *   GET /api/geocode?q=Atlanta
+ *   GET /api/geocode?q=Atlanta&limit=5
+ *   GET /api/geocode?q=Atlanta&bbox=-85,33,-83,34   (viewbox + bounded)
+ *
+ * Reverse geocode:
+ *   GET /api/geocode?lat=37.77&lng=-122.42
+ *   GET /api/geocode?lat=37.77&lng=-122.42&zoom=10
+ *
+ * Returns the Nominatim payload as-is so callers don't need to remap.
+ */
+export async function GET(req: NextRequest) {
+  const rl = rateLimit(req, 'geocode', 60, 60000)
+  if (rl) return rl
+
+  const params = req.nextUrl.searchParams
+  const q = params.get('q')
+  const lat = params.get('lat')
+  const lng = params.get('lng')
+
+  let upstreamUrl: string
+
+  if (lat && lng) {
+    const zoom = params.get('zoom') ?? '10'
+    upstreamUrl = `https://nominatim.openstreetmap.org/reverse?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lng)}&format=json&zoom=${encodeURIComponent(zoom)}`
+  } else if (q) {
+    const limit = params.get('limit') ?? '1'
+    const bbox = params.get('bbox')
+    const viewbox = bbox ? `&viewbox=${encodeURIComponent(bbox)}&bounded=1` : ''
+    upstreamUrl = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=${encodeURIComponent(limit)}${viewbox}`
+  } else {
+    return NextResponse.json([], { status: 400 })
+  }
+
+  try {
+    const res = await fetch(upstreamUrl, {
+      ...CACHE_1H,
+      headers: {
+        // Nominatim requires a real User-Agent on every request
+        'User-Agent': 'Travyl/1.0 (travel planning app)',
+        'Accept-Language': params.get('lang') ?? 'en',
+      },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return NextResponse.json([], { status: res.status })
+    const data = await res.json()
+    const out = NextResponse.json(data)
+    out.headers.set('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+    return out
+  } catch {
+    return NextResponse.json([], { status: 502 })
+  }
+}

--- a/apps/web/components/trips/CreateTripModal.tsx
+++ b/apps/web/components/trips/CreateTripModal.tsx
@@ -81,10 +81,12 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
     }
     debounceRef.current = setTimeout(async () => {
       try {
-        const res = await fetch(
-          `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=5`,
-          { headers: { 'Accept-Language': 'en' } }
-        )
+        const res = await fetch(`/api/geocode?q=${encodeURIComponent(q)}&limit=5`)
+        if (!res.ok) {
+          setSuggestions([])
+          setSuggestionsOpen(false)
+          return
+        }
         const data: NominatimResult[] = await res.json()
         setSuggestions(data)
         setSuggestionsOpen(data.length > 0)
@@ -140,9 +142,9 @@ export function CreateTripModal({ open, onClose }: CreateTripModalProps) {
       POI_CATEGORIES.map(async ({ q, emoji, color, category }) => {
         try {
           const res = await fetch(
-            `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=4&viewbox=${bbox}&bounded=1`,
-            { headers: { 'Accept-Language': 'en' } }
+            `/api/geocode?q=${encodeURIComponent(q)}&limit=4&bbox=${encodeURIComponent(bbox)}`
           )
+          if (!res.ok) return []
           const data: { place_id: number; display_name: string; lat: string; lon: string }[] = await res.json()
           return data.map((p) => {
             const name = p.display_name.split(',')[0]

--- a/packages/shared/src/services/placesDiscovery.ts
+++ b/packages/shared/src/services/placesDiscovery.ts
@@ -155,11 +155,11 @@ async function enrichWithCoords(places: PlaceItem[]): Promise<PlaceItem[]> {
 }
 
 async function resolveCoords(query: string): Promise<{ lat: string; lng: string } | null> {
+  // Go through our /api/geocode proxy — Nominatim doesn't send CORS headers,
+  // so direct browser calls fail. Mobile hits the same proxy via getWebApiBase().
   try {
-    const res = await fetch(
-      `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1`,
-      { headers: { 'User-Agent': 'Travyl/1.0' } }
-    );
+    const res = await fetch(`${BASE()}/api/geocode?q=${encodeURIComponent(query)}`);
+    if (!res.ok) return null;
     const data = await res.json() as any[];
     if (data.length > 0) return { lat: data[0].lat, lng: data[0].lon };
   } catch {}
@@ -171,10 +171,8 @@ let _nearbyCityCache: string | null = null;
 async function getNearbyCityName(lat: number, lng: number): Promise<string | null> {
   if (_nearbyCityCache) return _nearbyCityCache;
   try {
-    const res = await fetch(
-      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json&zoom=10`,
-      { headers: { 'User-Agent': 'Travyl/1.0' } }
-    );
+    const res = await fetch(`${BASE()}/api/geocode?lat=${lat}&lng=${lng}&zoom=10`);
+    if (!res.ok) return null;
     const data = await res.json() as any;
     _nearbyCityCache = data.address?.city || data.address?.town || data.address?.county || null;
   } catch {}


### PR DESCRIPTION
## Summary
Live audit of \`/places\` in Chrome surfaced **125 console errors per page load** — every direct browser fetch to \`nominatim.openstreetmap.org\` was blocked by CORS (Nominatim doesn't send \`Access-Control-Allow-Origin\`). The page was firing 60+ hotel/place geocoding lookups that all failed silently. Worked in dev (errors fall through), dead in prod for any feature depending on those lookups.

## Root cause
Five client-side call sites were calling Nominatim directly:
- \`packages/shared/src/services/placesDiscovery.ts\` — \`resolveCoords\` + \`getNearbyCityName\`
- \`apps/web/components/trips/CreateTripModal.tsx\` — destination autocomplete + POI bbox search
- \`apps/web/app/(dashboard)/trip/[id]/info/page.tsx\` — destination geocode

## Fix
- New proxy route at \`apps/web/app/api/geocode/route.ts\`:
  - Forward (\`?q=\`) and reverse (\`?lat=&lng=\`) lookups
  - bbox/viewbox variant for \`CreateTripModal\`
  - Edge-cached for 1h (\`s-maxage=3600, stale-while-revalidate=86400\`) so common destinations don't even hit Nominatim after the first lookup
  - Real \`User-Agent\` (Nominatim ToS requirement)
  - 5 s timeout
- All five call sites now hit the proxy via \`getWebApiBase()\` (web → relative; mobile → \`process.env.EXPO_PUBLIC_WEB_API_URL\`). Mobile gets the caching benefit too.

## Test plan
- [x] \`npm run build\` clean
- [ ] \`/places\` page loads with **0 console errors** (before: 125)
- [ ] CreateTripModal city autocomplete still works
- [ ] Trip info page restaurant cards render