### PR TITLE
fix(mobile/home): keep takeoff overlay visible until trip page renders

### DIFF
--- a/apps/mobile/app/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/(tabs)/(home)/index.tsx
@@ -592,6 +592,8 @@ export default function HomeScreen() {
             <FontAwesome name="search" size={16} color={colors.textTertiary} />
             <TextInput
               ref={inputRef}
+              testID="home-trip-search-input"
+              accessibilityLabel="Trip search"
               value={tripQuery}
               onChangeText={(v) => { setTripQuery(v); if (plannerError) setPlannerError(null); }}
               onSubmitEditing={onSearch}
@@ -602,6 +604,8 @@ export default function HomeScreen() {
             />
             <Pressable
               ref={sendButtonRef}
+              testID="home-trip-search-submit"
+              accessibilityLabel="Plan trip"
               onPress={onSearch}
               onLayout={onButtonLayout}
               collapsable={false}

--- a/apps/mobile/components/home/TakeoffTransition.tsx
+++ b/apps/mobile/components/home/TakeoffTransition.tsx
@@ -21,7 +21,6 @@ const GAP_DUR = 200;
 const PASS2_DUR = 1600;
 const FLIGHT_TOTAL = PASS1_DUR + GAP_DUR + PASS2_DUR; // 2400
 const LOADING_START = 2600;
-const ANIMATION_END = 4600;
 const TRAIL_COUNT = 8;
 
 // Normalized phase boundaries (0-1)
@@ -126,15 +125,20 @@ export function TakeoffTransition({
       );
     }, LOADING_START);
 
-    const t2 = setTimeout(() => {
-      overlayOpacity.value = withTiming(0, { duration: 200 });
-      setTimeout(() => stableOnComplete(), 200);
-    }, ANIMATION_END);
+    // Note: previously this auto-faded the overlay at ANIMATION_END (4.6s)
+    // and called onComplete. But trip generation can take 10–30s, so the
+    // overlay would disappear before the new trip page rendered, flashing
+    // the home screen. Now we let the loading dots loop indefinitely and
+    // rely on the parent toggling `visible=false` to dismiss us.
+    return () => { clearTimeout(t1); };
+  }, [visible]);
 
-    return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
-    };
+  // Fade out when parent flips visible → false
+  useEffect(() => {
+    if (visible) return;
+    overlayOpacity.value = withTiming(0, { duration: 200 });
+    const t = setTimeout(() => stableOnComplete(), 200);
+    return () => clearTimeout(t);
   }, [visible]);
 
   // ─── Plane style — ALL math runs on UI thread ─────────────────


### PR DESCRIPTION
## Summary
- Removes the hardcoded `ANIMATION_END=4600ms` auto-fade so the takeoff overlay stays up for the full duration of trip generation (often 10-30s)
- Overlay now dismisses only when the parent flips `visible` to `false` (i.e. when the trip page is actually navigated to and ready)
- Fixes audit finding M2: "the animation went away before the trip was shown" — flash of home in between

## Test plan
- [x] Maestro generate-trip flow runs and overlay stays visible through generation
- [x] Trip page shows up cleanly with no home flash
- [ ] Manual: regen a couple of times to confirm overlay → trip page transition is seamless on a fresh sim