### PR TITLE
style: homogenize UI/UX across web app

### DIFF
--- a/apps/web/app/(dashboard)/trips/page.tsx
+++ b/apps/web/app/(dashboard)/trips/page.tsx
@@ -77,9 +77,9 @@ function SkeletonCard() {
 export default function MyTripsPage() {
   return (
     <Suspense fallback={
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
+          <h1 className="text-3xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <SkeletonCard />
@@ -234,9 +234,9 @@ function TripsContent() {
   if (isLoading && !isError) {
     return (
       <div className="flex flex-col min-h-screen">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4 flex-1 w-full">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 flex-1 w-full">
           <div className="flex items-center justify-between mb-6">
-            <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
+            <h1 className="text-3xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             <SkeletonCard />
@@ -252,18 +252,17 @@ function TripsContent() {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4 flex-1 w-full">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 flex-1 w-full">
         {/* Header Row: Title | View Toggle | Button */}
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
-          <h1 className="text-2xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+          <h1 className="text-3xl font-serif font-normal text-gray-900 dark:text-white tracking-wide">My Trips</h1>
 
           <div className="flex items-center gap-3 flex-wrap">
             {/* View Toggle */}
             <ViewToggle view={viewMode} onChange={setViewMode} />
 
             {/* Plan a Trip Button */}
-            <button className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-white text-sm font-semibold shadow-md hover:shadow-lg transition-all"
-              style={{ background: 'linear-gradient(135deg, #1e3a5f, #2d4a6f)' }}
+            <button className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#1e3a5f] hover:bg-[#162d4a] text-white text-sm font-semibold shadow-md hover:shadow-lg transition-all"
               onClick={() => setModalOpen(true)}
             >
               <Plus size={16} />
@@ -342,7 +341,7 @@ function TripsContent() {
                 {pastTrips.length > 0 && (
                   <div className="mt-10">
                     <div className="flex items-center gap-3 mb-4">
-                      <h2 className="text-lg font-serif font-normal text-gray-400 tracking-wide">Past Trips</h2>
+<h2 className="text-lg font-sans font-semibold text-gray-400">Past Trips</h2>
                       <div className="flex-1 h-px bg-gray-200" />
                     </div>
                     {viewMode === 'grid' ? (
@@ -368,10 +367,9 @@ function TripsContent() {
             <div className="w-20 h-20 rounded-full bg-gray-100 flex items-center justify-center mb-4">
               <PaperPlane size={32} className="text-gray-400" />
             </div>
-            <h2 className="text-lg font-serif font-normal text-gray-800 mb-1 tracking-wide">No trips yet</h2>
+            <h2 className="text-xl font-serif font-normal text-gray-800 mb-2 tracking-wide">No trips yet</h2>
             <p className="text-sm text-gray-500 mb-6 max-w-xs">Start planning your next adventure and it will appear here.</p>
-            <button className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold"
-              style={{ background: 'linear-gradient(135deg, #1e3a5f, #2d4a6f)' }}
+            <button className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#1e3a5f] hover:bg-[#162d4a] text-white text-sm font-semibold shadow-md hover:shadow-lg transition-all"
               onClick={() => setModalOpen(true)}
             >
               <Plus size={16} />

--- a/apps/web/components/PlaceCard.tsx
+++ b/apps/web/components/PlaceCard.tsx
@@ -89,7 +89,7 @@ function CardFrontInternal({
 
         {/* Name + Rating */}
         <div className="flex items-center gap-2" style={{ marginBottom: isCompact ? 0 : 4 }}>
-          <h3 className="font-extrabold text-white truncate drop-shadow-md" style={{ fontSize: isCompact ? 13 : isFull ? 20 : 16 }}>
+          <h3 className="font-sans font-semibold text-white truncate drop-shadow-md" style={{ fontSize: isCompact ? 13 : isFull ? 20 : 16 }}>
             {place.name}
           </h3>
           {!isCompact && place.rating != null && (
@@ -158,7 +158,7 @@ function CardBackWeb({ place, onFlip, width, height }: { place: PlaceItem; onFli
     >
       <div className="h-full overflow-y-auto p-4">
         {/* Header */}
-        <h3 className="text-lg font-bold mb-1">{place.name}</h3>
+        <h3 className="text-lg font-sans font-semibold mb-1">{place.name}</h3>
         <p className="text-xs text-white/60 uppercase tracking-wider mb-4">{place.category} · {place.type}</p>
 
         <div className="border-t border-white/10 pt-3 space-y-3">

--- a/apps/web/components/trips/TripCard.tsx
+++ b/apps/web/components/trips/TripCard.tsx
@@ -148,9 +148,9 @@ export function TripCard({ trip, className, style }: TripCardProps) {
             {trip.fork_count > 0 && (
               <div className="mb-2"><ForkCountBadge count={trip.fork_count} /></div>
             )}
-            <h2 className="text-lg font-extrabold text-white leading-tight mb-1 line-clamp-1 drop-shadow-md">
+            <h3 className="text-lg font-sans font-semibold text-white leading-tight mb-1 line-clamp-1 drop-shadow-md">
               {trip.title}
-            </h2>
+            </h3>
             <div className="flex items-center gap-1.5 mb-2">
               <MapPin size={11} className="text-white/50 shrink-0" />
               <span className="text-[12px] text-white/70">{trip.destination}</span>

--- a/apps/web/components/trips/TripListItem.tsx
+++ b/apps/web/components/trips/TripListItem.tsx
@@ -54,7 +54,7 @@ export function TripListItem({ trip }: TripListItemProps) {
   return (
     <Link
       href={`/trip/${trip.id}`}
-      className="flex items-center gap-4 rounded-xl bg-white border border-gray-200 px-4 py-3 cursor-pointer group transition-all hover:bg-gray-50 hover:border-gray-300 hover:shadow-sm"
+      className="flex items-center gap-4 rounded-2xl bg-white border border-gray-200 px-4 py-3 cursor-pointer group transition-all hover:bg-gray-50 hover:border-gray-300 hover:shadow-md"
     >
       {/* Thumbnail */}
       <div className="w-20 h-20 rounded-lg overflow-hidden shrink-0 relative">
@@ -78,7 +78,7 @@ export function TripListItem({ trip }: TripListItemProps) {
       <div className="flex-1 min-w-0">
         {/* Title + Status Badge */}
         <div className="flex items-center gap-2 mb-1">
-          <h3 className="text-base font-semibold text-gray-900 truncate">{trip.title}</h3>
+          <h3 className="text-base font-sans font-semibold text-gray-900 truncate">{trip.title}</h3>
           <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${badge.bg} ${badge.text} shrink-0`}>
             {badge.label}
           </span>


### PR DESCRIPTION
## Summary

Standardizes typography, spacing, buttons, and card styles across the web app for visual consistency.

## Changes

### Typography
- Trips page H1: `text-2xl` → `text-3xl` (proper page title size)
- TripCard title: `font-extrabold` → `font-sans font-semibold`
- TripListItem title: added `font-sans`
- PlaceCard title: `font-extrabold` → `font-sans font-semibold`

### Spacing  
- Page containers: `py-4` → `py-6` (consistent vertical padding)
- Header margins: `mb-4` → `mb-6` (consistent spacing)

### Buttons
- Primary CTA: solid navy background instead of gradients
- Consistent `px-5 py-2.5` sizing
- Added `shadow-md hover:shadow-lg` for elevation feedback

### Cards
- TripListItem: `rounded-xl` → `rounded-2xl` (matches TripCard)
- Added `hover:shadow-md` for consistent elevation

## Verification
- `npm run typecheck` passes
- No functional changes, purely visual

## Files Changed
- `apps/web/app/(dashboard)/trips/page.tsx`
- `apps/web/components/trips/TripCard.tsx`
- `apps/web/components/trips/TripListItem.tsx`
- `apps/web/components/PlaceCard.tsx`