### PR TITLE
fix(web): resolve collaborator avatar 400 error (issue #740)

### DIFF
--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -703,7 +703,7 @@ export async function updateTripThemeSettings(
 export async function fetchCollaborators(tripId: string): Promise<TripCollaborator[]> {
   const { data, error } = await supabase
     .from('trip_collaborators')
-    .select('*, profile:profiles!trip_collaborators_user_id_fkey(display_name, avatar_url)')
+    .select('*, profile:profiles(display_name, avatar_url)')
     .eq('trip_id', tripId)
     .order('created_at', { ascending: true })
   if (error) throw error


### PR DESCRIPTION
Fixes #740

## Problem
The  query was using an explicit FK constraint name  in the embedded select:



PostgREST returns 400 when the FK hint doesn't match the actual constraint name in the database. This caused collaborator avatars to fail loading on the calendar.

## Solution
Simplified the query to let PostgREST infer the relation:



This uses PostgREST's automatic relation detection instead of hardcoding a potentially-stale constraint name.

## Verification
- All 345 existing tests pass
- Change is minimal and targeted
- No breaking changes to the API interface

## Related
- Issue #740