### PR TITLE
feat(web+mobile): wire flight/hotel selection persistence + auto-seed web packing list

### DIFF
--- a/apps/mobile/app/(tabs)/favorites/index.tsx
+++ b/apps/mobile/app/(tabs)/favorites/index.tsx
@@ -133,7 +133,7 @@ export default function FavoritesScreen() {
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ['mobile-places-discover', userLocation?.lat],
+    queryKey: ['mobile-places-discover', userLocation?.lat, userLocation?.lng],
     queryFn: ({ pageParam }) => fetchDiscoverPage(pageParam, userLocation),
     initialPageParam: 0,
     getNextPageParam: (lastPage: DiscoverPageResult) =>

--- a/apps/mobile/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/app/(tabs)/profile/index.tsx
@@ -875,16 +875,29 @@ function PassportCountryModal({
     }).join('||'),
     [places],
   );
-  // SerpAPI google_maps results include coordinates alongside photos —
-  // for older trips that stored places without lat/lng (Japan, Spain,
-  // etc.), we pull both image AND coords from the same call so the map
-  // can populate. Keyed by VisitedPlace.id.
-  type PlaceEnrichment = { image?: string; lat?: number; lng?: number };
+  // SerpAPI google_maps results include coordinates, address, rating,
+  // category, description and a photo alongside the name. For older
+  // trips that stored places with just a name, we pull all of it from
+  // the same call so the visited cards aren't blank. Keyed by
+  // VisitedPlace.id.
+  type PlaceEnrichment = {
+    image?: string;
+    lat?: number;
+    lng?: number;
+    address?: string;
+    rating?: number;
+    reviewCount?: number;
+    category?: string;
+    description?: string;
+    phone?: string;
+    website?: string;
+    hours?: string;
+  };
 
   const { data: imageMapData, isLoading: imagesLoading, isError: imagesError, error: imagesErrorObj } = useQuery<Record<string, PlaceEnrichment>>({
     // Bumping the version string in the queryKey invalidates anything
     // cached from earlier (broken) attempts at this fetch.
-    queryKey: ['passport-place-enrichment-v4', group?.country, placeKeys],
+    queryKey: ['passport-place-enrichment-v5', group?.country, placeKeys],
     queryFn: async () => {
       if (!places.length) return {};
       const base = getWebApiBase();
@@ -930,23 +943,45 @@ function PassportCountryModal({
             if (!Array.isArray(data)) continue;
             const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
             const target = norm(p.name);
+            // Build a full enrichment payload from the matched row.
+            const buildEnrichment = (it: any): PlaceEnrichment | undefined => {
+              const img = pickAnyImage(it);
+              const lat = pickCoord(it, 'lat');
+              const lng = pickCoord(it, 'lng');
+              const enrichment: PlaceEnrichment = {
+                image: img,
+                lat,
+                lng,
+                address: it?.address || it?.formatted_address || it?.vicinity || undefined,
+                rating: typeof it?.rating === 'number' ? it.rating : (typeof it?.rating === 'string' ? parseFloat(it.rating) : undefined),
+                reviewCount: it?.reviews ?? it?.review_count ?? it?.reviewCount ?? it?.user_ratings_total ?? undefined,
+                category: it?.category || it?.type || (Array.isArray(it?.types) ? it.types[0] : undefined),
+                description: it?.description || it?.about || it?.summary || it?.tagline || undefined,
+                phone: it?.phone || it?.phone_number || it?.formatted_phone_number || undefined,
+                website: it?.website || it?.link || undefined,
+                hours: it?.hours || it?.opening_hours_summary || undefined,
+              };
+              const hasContent =
+                enrichment.image ||
+                (enrichment.lat != null && enrichment.lng != null) ||
+                enrichment.address ||
+                enrichment.rating != null ||
+                enrichment.description;
+              return hasContent ? enrichment : undefined;
+            };
             // First pass: exact-ish name match.
             for (const it of data) {
               const candidateName = norm(String(it?.name || ''));
               if (!target || !candidateName) continue;
               if (target.includes(candidateName) || candidateName.includes(target)) {
-                const img = pickAnyImage(it);
-                const lat = pickCoord(it, 'lat');
-                const lng = pickCoord(it, 'lng');
-                if (img || (lat != null && lng != null)) return { image: img, lat, lng };
+                const enrichment = buildEnrichment(it);
+                if (enrichment) return enrichment;
               }
             }
-            // Fallback: first result with an image OR coords, even if name doesn't overlap.
+            // Fallback: first result with any usable content, even if name doesn't overlap.
             for (const it of data) {
-              const img = pickAnyImage(it);
-              const lat = pickCoord(it, 'lat');
-              const lng = pickCoord(it, 'lng');
-              if (img || (lat != null && lng != null)) return { image: img, lat, lng };
+              const enrichment = buildEnrichment(it);
+              if (enrichment) return enrichment;
             }
           } catch {}
         }
@@ -1073,7 +1108,13 @@ function PassportCountryModal({
 
   const placeItems = useMemo<PlaceItem[]>(() => places.map((p) => {
     const enriched = enrichedByName.get(p.name.trim().toLowerCase());
-    const fallback = lookupImage(p.id);
+    // SerpAPI enrichment record for THIS specific place (by id), built
+    // by the passport-place-enrichment query above. For older trips
+    // that stored only a name, this is where rating, address,
+    // description, hours etc. come from — without it the magazine card
+    // flip is blank.
+    const serp = imageMapData?.[p.id];
+    const fallback = serp?.image;
     // Merge order: trip_context (latest, what the user actually saved) →
     // enriched discover record (richer fields) → SerpAPI fallback image.
     const tcImgs = p.images?.length ? p.images : (p.image ? [p.image] : []);
@@ -1090,20 +1131,20 @@ function PassportCountryModal({
       image: primary,
       images: merged,
       type: enriched?.type ?? 'attraction' as const,
-      rating: p.rating ?? enriched?.rating ?? 0,
-      reviewCount: p.reviewCount ?? enriched?.reviewCount,
+      rating: p.rating ?? enriched?.rating ?? serp?.rating ?? 0,
+      reviewCount: p.reviewCount ?? enriched?.reviewCount ?? serp?.reviewCount,
       tagline: p.city || enriched?.tagline || '',
-      category: p.category || enriched?.category || '',
-      description: p.description ?? enriched?.description,
-      address: p.address ?? enriched?.address,
-      phone: p.phone ?? enriched?.phone,
-      website: p.website ?? enriched?.website,
-      hours: p.hours ?? enriched?.hours,
+      category: p.category || enriched?.category || serp?.category || '',
+      description: p.description ?? enriched?.description ?? serp?.description,
+      address: p.address ?? enriched?.address ?? serp?.address,
+      phone: p.phone ?? enriched?.phone ?? serp?.phone,
+      website: p.website ?? enriched?.website ?? serp?.website,
+      hours: p.hours ?? enriched?.hours ?? serp?.hours,
       priceLevel: p.priceLevel ?? enriched?.priceLevel,
-      latitude: p.lat ?? undefined,
-      longitude: p.lng ?? undefined,
+      latitude: (p.lat ?? serp?.lat) ?? undefined,
+      longitude: (p.lng ?? serp?.lng) ?? undefined,
     } as PlaceItem;
-  }), [places, lookupImage, enrichedByName]);
+  }), [places, lookupImage, enrichedByName, imageMapData]);
 
   if (!group) return null;
   const sheetHeight = Dimensions.get('window').height * 0.5;

--- a/apps/mobile/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/app/(tabs)/profile/index.tsx
@@ -366,7 +366,11 @@ async function pickAndUploadImage(field: 'avatar' | 'cover', userId?: string): P
 // "didn't persist" when really it was a `file://` from a failed upload.
 function isPersistedImageUrl(url: string | null | undefined): boolean {
   if (!url) return false;
-  return url.startsWith('http://') || url.startsWith('https://');
+  const ok = url.startsWith('http://') || url.startsWith('https://');
+  if (!ok && url.startsWith('file://') && __DEV__) {
+    console.warn('[profile] dropping non-persisted image URL (likely from a failed upload):', url.slice(0, 80));
+  }
+  return ok;
 }
 
 
@@ -715,15 +719,36 @@ function PassportCountryModal({
     [trips, group],
   );
 
-  // Filter the user's favorited places to ones in this country. We match
-  // by address substring (cheapest test) or fall back to lat/lng overlap
-  // with the visited bounding box.
+  // Filter the user's favorited places to ones in this country.
+  // Strategy stack (each stage shipped a place to the country if matched):
+  //   1. Address substring contains the country name (e.g. "..., Japan").
+  //   2. Address substring contains a city the user visited in this country.
+  //   3. The trailing comma-segment of the address matches a list of common
+  //      country aliases (e.g. "USA" → "United States"). Catches places
+  //      where the address says "Honolulu, HI 96813, USA" but the trip
+  //      destination was "Honolulu, United States".
+  //   4. Lat/lng bounding box derived from the user's *visited* places —
+  //      only useful when at least one visited place has coords. For
+  //      Japan/Spain trips with no coords, this stage is empty.
+  const COUNTRY_ALIASES: Record<string, string[]> = {
+    'united states': ['usa', 'us', 'u.s.', 'u.s.a.', 'america'],
+    'united kingdom': ['uk', 'u.k.', 'britain', 'england', 'scotland', 'wales'],
+    'united arab emirates': ['uae', 'u.a.e.'],
+    japan: ['日本', 'jp'],
+    spain: ['españa', 'es'],
+    france: ['fr'],
+    germany: ['deutschland', 'de'],
+    italy: ['italia', 'it'],
+    china: ['中国', 'cn'],
+    'south korea': ['korea', '한국', 'kr'],
+  };
   const favorites = useMemo<VisitedPlace[]>(() => {
     if (!group) return [];
     const idSet = new Set(favoriteIds);
     const candidates = favoritePool.filter((p) => idSet.has(p.id));
     if (candidates.length === 0) return [];
     const targetLower = group.country.toLowerCase();
+    const aliases = COUNTRY_ALIASES[targetLower] ?? [];
     const cityLower = group.cities.map((c) => c.toLowerCase());
     let visBounds: { minLat: number; maxLat: number; minLng: number; maxLng: number } | null = null;
     const visitedWithCoords = visited.filter(
@@ -741,7 +766,11 @@ function PassportCountryModal({
       .filter((p) => {
         const addr = (p.address || '').toLowerCase();
         if (addr.includes(targetLower)) return true;
+        if (aliases.some((alias) => alias && addr.includes(alias))) return true;
         if (cityLower.some((c) => c && addr.includes(c))) return true;
+        // Trailing-segment fallback: address tail matches country or alias.
+        const tail = addr.split(',').slice(-1)[0]?.trim();
+        if (tail && (tail === targetLower || aliases.includes(tail))) return true;
         if (visBounds && p.latitude != null && p.longitude != null) {
           if (
             p.latitude >= visBounds.minLat && p.latitude <= visBounds.maxLat &&
@@ -1667,7 +1696,7 @@ export default function ProfileScreen() {
     isFetchingNextPage: isFetchingDiscoverNext,
     isLoading: discoverLoading,
   } = useInfiniteQuery({
-    queryKey: ['mobile-places-discover', userLocation?.lat],
+    queryKey: ['mobile-places-discover', userLocation?.lat, userLocation?.lng],
     queryFn: ({ pageParam }) => fetchDiscoverPage(pageParam, userLocation),
     initialPageParam: 0,
     getNextPageParam: (lastPage: DiscoverPageResult) =>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -10,9 +10,18 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useEffect, useRef } from 'react';
 import 'react-native-reanimated';
 
-import { Text, TextInput } from 'react-native';
+import { LogBox, Text, TextInput } from 'react-native';
 import { useAuthStore, configureSupabase } from '@travyl/shared';
 import { Platform } from 'react-native';
+
+// Reanimated 4 fires a (currently false-positive) warning whenever a
+// style array combines a static object with a `useAnimatedStyle` result.
+// We do this throughout the app (e.g. PlaceCard crossfade, MosaicTile
+// press scale, FlipCard) and confirmed each `.value` access is inside a
+// worklet. Suppress the warning so it stops drowning out real logs.
+LogBox.ignoreLogs([
+  'It looks like you might be using shared value\'s .value inside reanimated inline style',
+]);
 
 // Set Satoshi as the default font for all Text and TextInput components
 const originalTextRender = (Text as any).render;

--- a/apps/mobile/app/trip/[id]/budget.tsx
+++ b/apps/mobile/app/trip/[id]/budget.tsx
@@ -134,26 +134,64 @@ export default function BudgetScreen() {
   }, [displayCurrency, rates]);
   const fx = useCallback((usd: number) => fmtCurrency(cx(usd), displayCurrency), [cx, displayCurrency]);
 
-  // Build budget items from trip_context (cost_of_living + hotels + trip.budget)
+  // Build budget items from trip_context (cost_of_living + hotels + flights + trip.budget)
   const initialBudget = useMemo((): BudgetItem[] => {
     const ctx = trip?.trip_context as any;
     const cost = ctx?.cost_of_living;
     const hotel = (ctx?.hotels?.[0] || ctx?.all_hotels?.[0]) as any;
+    const flights: any[] = ctx?.flights ?? [];
     const days = trip?.start_date && trip?.end_date
       ? Math.max(1, Math.ceil((new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000))
       : 5;
 
     const items: BudgetItem[] = [];
 
-    // Accommodation
+    // Flights — sums every flight in trip_context.flights[]. Each flight
+    // has a `price` (set by savePlanToSupabase / SerpAPI). Skipped if
+    // the trip wasn't generated with flights or none have a price.
+    const flightExpenses = flights
+      .map((f, i) => {
+        const price = typeof f?.price === 'number' ? f.price : parseFloat(String(f?.price ?? '').replace(/[^0-9.]/g, ''));
+        if (!price || !isFinite(price) || price <= 0) return null;
+        const desc = [f?.airline, f?.dest_iata || f?.destination, f?.depart_date].filter(Boolean).join(' · ') || `Flight ${i + 1}`;
+        return { id: `flight-${i}`, description: desc, amount: price };
+      })
+      .filter((e): e is { id: string; description: string; amount: number } => e !== null);
+    const flightTotal = flightExpenses.reduce((s, e) => s + e.amount, 0);
+    if (flightTotal > 0 || flights.length > 0) {
+      items.push({
+        id: 'flights',
+        category: 'Flights',
+        budgeted: flightTotal,
+        actual: 0,
+        fixed: true,
+        expenses: flightExpenses,
+      });
+    }
+
+    // Accommodation. If hotel.price is missing, fall back to a
+    // cost-of-living estimate so the category isn't always $0 for
+    // older trips. mid_range_hotel is the typical SerpAPI field.
     const hotelPrice = hotel?.price ?? hotel?.price_per_night ?? 0;
+    const colHotel = cost?.mid_range_hotel
+      ? parseFloat(String(cost.mid_range_hotel).replace(/[^0-9.]/g, ''))
+      : (cost?.budget_hotel ? parseFloat(String(cost.budget_hotel).replace(/[^0-9.]/g, '')) : 0);
+    const effectiveNightly = hotelPrice > 0 ? hotelPrice : (colHotel > 0 ? colHotel : 0);
     items.push({
       id: 'accommodation',
       category: 'Accommodation',
-      budgeted: hotelPrice * days,
+      budgeted: effectiveNightly * days,
       actual: 0,
       fixed: true,
-      expenses: hotelPrice ? [{ id: 'hotel-1', description: `${hotel?.name || 'Hotel'} (${days} nights × $${hotelPrice})`, amount: hotelPrice * days }] : [],
+      expenses: effectiveNightly > 0
+        ? [{
+            id: 'hotel-1',
+            description: hotelPrice > 0
+              ? `${hotel?.name || 'Hotel'} (${days} nights × $${hotelPrice})`
+              : `Estimated lodging (${days} nights × $${effectiveNightly}/nt — typical mid-range rate)`,
+            amount: effectiveNightly * days,
+          }]
+        : [],
     });
 
     // Food & Dining

--- a/apps/mobile/app/trip/[id]/budget.tsx
+++ b/apps/mobile/app/trip/[id]/budget.tsx
@@ -147,13 +147,19 @@ export default function BudgetScreen() {
     const items: BudgetItem[] = [];
 
     // Flights — sums every flight in trip_context.flights[]. Each flight
-    // has a `price` (set by savePlanToSupabase / SerpAPI). Skipped if
-    // the trip wasn't generated with flights or none have a price.
+    // has a `price` (set by savePlanToSupabase / SerpAPI). The expense
+    // description packs in route + airline + date + duration so the user
+    // sees the full booking, not just a price line.
     const flightExpenses = flights
       .map((f, i) => {
         const price = typeof f?.price === 'number' ? f.price : parseFloat(String(f?.price ?? '').replace(/[^0-9.]/g, ''));
         if (!price || !isFinite(price) || price <= 0) return null;
-        const desc = [f?.airline, f?.dest_iata || f?.destination, f?.depart_date].filter(Boolean).join(' · ') || `Flight ${i + 1}`;
+        const route = [f?.origin_iata || f?.origin, f?.dest_iata || f?.destination].filter(Boolean).join('→');
+        const airline = f?.airline || f?.carrier || '';
+        const date = f?.depart_date || f?.date || '';
+        const duration = f?.duration ? ` · ${f.duration}` : '';
+        const stops = typeof f?.stops === 'number' ? (f.stops === 0 ? ' · nonstop' : ` · ${f.stops} stop${f.stops === 1 ? '' : 's'}`) : '';
+        const desc = [airline, route, date].filter(Boolean).join(' · ') + duration + stops || `Flight ${i + 1}`;
         return { id: `flight-${i}`, description: desc, amount: price };
       })
       .filter((e): e is { id: string; description: string; amount: number } => e !== null);
@@ -177,6 +183,28 @@ export default function BudgetScreen() {
       ? parseFloat(String(cost.mid_range_hotel).replace(/[^0-9.]/g, ''))
       : (cost?.budget_hotel ? parseFloat(String(cost.budget_hotel).replace(/[^0-9.]/g, '')) : 0);
     const effectiveNightly = hotelPrice > 0 ? hotelPrice : (colHotel > 0 ? colHotel : 0);
+    // Build a richer description that names the hotel + room type +
+    // check-in/out dates so the user sees their selection at a glance.
+    const hotelRoom = hotel?.roomTypes?.[0]?.type || hotel?.room_type || '';
+    const checkInLabel = trip?.start_date
+      ? new Date(trip.start_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      : '';
+    const checkOutLabel = trip?.end_date
+      ? new Date(trip.end_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      : '';
+    const hotelDateRange = checkInLabel && checkOutLabel ? `${checkInLabel}–${checkOutLabel}` : '';
+    const hotelDescParts: string[] = [];
+    if (hotelPrice > 0) {
+      hotelDescParts.push(hotel?.name || 'Hotel');
+      if (hotelRoom) hotelDescParts.push(hotelRoom);
+      if (hotelDateRange) hotelDescParts.push(hotelDateRange);
+      hotelDescParts.push(`${days} night${days === 1 ? '' : 's'} × $${hotelPrice}`);
+    } else {
+      hotelDescParts.push(hotel?.name ? `${hotel.name} (estimated)` : 'Estimated lodging');
+      if (hotelDateRange) hotelDescParts.push(hotelDateRange);
+      hotelDescParts.push(`${days} night${days === 1 ? '' : 's'} × $${effectiveNightly}/nt`);
+      hotelDescParts.push('typical mid-range rate');
+    }
     items.push({
       id: 'accommodation',
       category: 'Accommodation',
@@ -186,9 +214,7 @@ export default function BudgetScreen() {
       expenses: effectiveNightly > 0
         ? [{
             id: 'hotel-1',
-            description: hotelPrice > 0
-              ? `${hotel?.name || 'Hotel'} (${days} nights × $${hotelPrice})`
-              : `Estimated lodging (${days} nights × $${effectiveNightly}/nt — typical mid-range rate)`,
+            description: hotelDescParts.join(' · '),
             amount: effectiveNightly * days,
           }]
         : [],

--- a/apps/mobile/app/trip/[id]/budget.tsx
+++ b/apps/mobile/app/trip/[id]/budget.tsx
@@ -243,12 +243,40 @@ export default function BudgetScreen() {
   const [budgetData, setBudgetData] = useState<BudgetItem[]>(initialBudget);
   const seeded = useRef(false);
 
-  // Load saved budget from trip_context if available
+  // Load saved budget from trip_context if available. Merge with the
+  // freshly-computed initial budget so newly-added categories (e.g.
+  // Flights, which didn't exist in older snapshots) get picked up
+  // automatically. Saved categories keep their user-edited values;
+  // missing ones are appended; "fixed" categories (Flights,
+  // Accommodation) get refreshed from initialBudget every load so a
+  // re-saved hotel price or new flight is reflected immediately
+  // instead of being frozen at whatever was last persisted.
   useEffect(() => {
     if (trip && !seeded.current) {
       const saved = (trip.trip_context as any)?.budget_data;
       if (saved && Array.isArray(saved) && saved.length > 0) {
-        setBudgetData(saved);
+        const initialById = new Map(initialBudget.map((b) => [b.id, b]));
+        const savedById = new Map<string, BudgetItem>(saved.map((b: BudgetItem) => [b.id, b]));
+        const merged: BudgetItem[] = [];
+        // Refresh fixed categories from initial; preserve user edits on others.
+        for (const item of initialBudget) {
+          const savedItem = savedById.get(item.id);
+          if (item.fixed) {
+            merged.push(item);
+          } else if (savedItem) {
+            merged.push(savedItem);
+          } else {
+            merged.push(item);
+          }
+        }
+        // Append saved categories the user added that aren't in the
+        // freshly-built initial set (custom categories, etc.).
+        for (const savedItem of saved) {
+          if (!initialById.has((savedItem as BudgetItem).id)) {
+            merged.push(savedItem as BudgetItem);
+          }
+        }
+        setBudgetData(merged);
       } else {
         setBudgetData(initialBudget);
       }

--- a/apps/mobile/app/trip/[id]/flights.tsx
+++ b/apps/mobile/app/trip/[id]/flights.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useMemo, useContext } from 'react';
-import { View, ScrollView, Text, Pressable, Linking, Modal, TextInput, FlatList, Image } from 'react-native';
+import { View, ScrollView, Text, Pressable, Linking, Modal, TextInput, FlatList, Image, Alert } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useQueryClient } from '@tanstack/react-query';
 import { PageTransition, useTabAccent, TabCtx } from './_layout';
-import { adjustBrightness, TextStyles, FontFamily, useItineraryScreen, useFlightSearch, getWebApiBase, useSettingsStore } from '@travyl/shared';
+import { adjustBrightness, TextStyles, FontFamily, useItineraryScreen, useFlightSearch, getWebApiBase, useSettingsStore, supabase } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 // Airport cache — populated dynamically from API search results
 const airportCache: { code: string; name: string; city: string }[] = [];
@@ -1276,6 +1277,54 @@ export default function FlightsScreen() {
 
   // Search results from FlightSearchSection
   const [searchFlights, setSearchFlights] = useState<any[]>([]);
+  const queryClient = useQueryClient();
+  const [savingFlightId, setSavingFlightId] = useState<string | null>(null);
+
+  // Persist a selected search-result flight into trip_context.flights[].
+  // The budget tab reads from trip_context.flights[] so this is what makes
+  // the price show up in Budget after the user picks a flight.
+  const addFlightToTrip = async (rawFlight: any, fallbackKey: string) => {
+    if (!id) return;
+    setSavingFlightId(fallbackKey);
+    try {
+      const legs: any[] = Array.isArray(rawFlight.legs) ? rawFlight.legs : [];
+      const firstLeg = legs[0] ?? {};
+      const lastLeg = legs[legs.length - 1] ?? firstLeg;
+      const ctxFlight = {
+        airline: firstLeg.airline || rawFlight.airline || 'Airline',
+        airlineLogo: rawFlight.airlineLogo || '',
+        origin: firstLeg.departure?.id || rawFlight.origin || '',
+        origin_iata: firstLeg.departure?.id || rawFlight.origin || '',
+        destination: lastLeg.arrival?.id || rawFlight.destination || '',
+        dest_iata: lastLeg.arrival?.id || rawFlight.destination || '',
+        departure_time: firstLeg.departure?.time || rawFlight.departure_time || null,
+        arrival_time: lastLeg.arrival?.time || rawFlight.arrival_time || null,
+        duration: rawFlight.totalDuration ?? rawFlight.duration ?? 0,
+        stops: typeof rawFlight.stops === 'number' ? rawFlight.stops : Math.max(0, legs.length - 1),
+        price: rawFlight.price ?? 0,
+        link: rawFlight.link || '',
+        depart_date: trip?.start_date ?? '',
+      };
+      const { data: row } = await supabase.from('trips').select('trip_context').eq('id', id).single();
+      const ctx = (row?.trip_context || {}) as Record<string, unknown>;
+      const existing = Array.isArray((ctx as any).flights) ? ((ctx as any).flights as any[]) : [];
+      // Replace the outbound (index 0) with the new selection. Keep any
+      // return leg in slot 1. Users typically swap their outbound; we don't
+      // stack endless flights.
+      const next = existing.length > 0
+        ? [ctxFlight, ...existing.slice(1)]
+        : [ctxFlight];
+      (ctx as any).flights = next;
+      const { error } = await supabase.from('trips').update({ trip_context: ctx }).eq('id', id);
+      if (error) throw error;
+      await queryClient.invalidateQueries({ queryKey: ['trip', id] });
+      Alert.alert('Flight added', 'This flight is now in your trip and budget.');
+    } catch (e: any) {
+      Alert.alert('Could not add flight', e?.message || 'Please try again.');
+    } finally {
+      setSavingFlightId(null);
+    }
+  };
 
   if (isLoading) return <PageTransition><FlightSkeleton /></PageTransition>;
 
@@ -1387,11 +1436,22 @@ export default function FlightsScreen() {
                   <Text style={{ ...TextStyles.caption, color: colors.textSecondary }}>{durationLabel}</Text>
                   <Text style={{ ...TextStyles.smEm, color: stops === 0 ? colors.success : colors.warning }}>{stops === 0 ? 'Direct' : `${stops} stop${stops === 1 ? '' : 's'}`}</Text>
                 </View>
-                {f.link && (
-                  <Pressable onPress={() => Linking.openURL(f.link)} style={{ marginTop: 10, backgroundColor: ACCENT, borderRadius: 8, paddingVertical: 10, alignItems: 'center' }}>
-                    <Text style={{ ...TextStyles.bodyEm, color: '#fff' }}>Book Flight</Text>
+                <View style={{ flexDirection: 'row', gap: 8, marginTop: 10 }}>
+                  <Pressable
+                    onPress={() => addFlightToTrip(f, f.id || `search-${i}`)}
+                    disabled={savingFlightId !== null}
+                    style={{ flex: 1, backgroundColor: ACCENT, borderRadius: 8, paddingVertical: 10, alignItems: 'center', opacity: savingFlightId === (f.id || `search-${i}`) ? 0.6 : 1 }}
+                  >
+                    <Text style={{ ...TextStyles.bodyEm, color: '#fff' }}>
+                      {savingFlightId === (f.id || `search-${i}`) ? 'Adding…' : 'Add to Trip'}
+                    </Text>
                   </Pressable>
-                )}
+                  {f.link && (
+                    <Pressable onPress={() => Linking.openURL(f.link)} style={{ flex: 1, backgroundColor: colors.cardBackground, borderRadius: 8, paddingVertical: 10, alignItems: 'center', borderWidth: 1, borderColor: ACCENT }}>
+                      <Text style={{ ...TextStyles.bodyEm, color: ACCENT }}>Book</Text>
+                    </Pressable>
+                  )}
+                </View>
               </View>
             );
           })}

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -67,6 +67,14 @@ interface HotelData {
   phone: string;
   bookingLink: string;
   guestRatings: GuestRatings;
+  /** Free-text "About this hotel" — populated from SerpAPI/Booking when available. */
+  description?: string;
+  /** Lodging category (Hotel, Resort, Boutique, Hostel, etc.) — pulled from API tags. */
+  category?: string;
+  /** Optional opening / front-desk hours summary. */
+  hours?: string;
+  /** Walking-distance landmarks summary. */
+  nearby?: string;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1402,9 +1410,15 @@ export default function HotelsScreen() {
       roomTypes,
       checkIn: trip?.start_date ? new Date(trip.start_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '',
       checkOut: trip?.end_date ? new Date(trip.end_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '',
-      cancellation: '',
-      phone: '',
-      bookingLink: h.link ?? '',
+      cancellation: h.cancellation ?? '',
+      // Surface phone if the source has one — was hardcoded to '' before,
+      // which silently disabled the Call button.
+      phone: h.phone ?? h.formatted_phone_number ?? '',
+      bookingLink: h.link ?? h.website ?? h.url ?? '',
+      description: h.description ?? h.about ?? h.summary ?? h.tagline ?? '',
+      category: h.category ?? h.type ?? (Array.isArray(h.types) ? h.types[0] : undefined) ?? '',
+      hours: h.hours ?? h.opening_hours_summary ?? '',
+      nearby: h.nearby_summary ?? h.transit ?? '',
       guestRatings: {
         overall: rating,
         label: ratingLabel,
@@ -1524,10 +1538,44 @@ export default function HotelsScreen() {
           {/* Hotel Name */}
           <Text style={{ ...TextStyles.title, fontFamily: FontFamily.serif, color: colors.text, paddingHorizontal: 14, marginTop: 8 }} numberOfLines={2}>{hotel.name}</Text>
 
-          {/* Stars row */}
-          {hotel.stars > 0 && (
-            <View style={{ paddingHorizontal: 14, marginTop: 4 }}>
-              <StarRow count={hotel.stars} />
+          {/* Stars + Type pill */}
+          <View style={{ paddingHorizontal: 14, marginTop: 4, flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 8 }}>
+            {hotel.stars > 0 && <StarRow count={hotel.stars} />}
+            {!!hotel.category && (
+              <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10, backgroundColor: colors.borderLight }}>
+                <Text style={{ ...TextStyles.xs, color: colors.textSecondary, fontWeight: '600' }}>{hotel.category}</Text>
+              </View>
+            )}
+            {!!hotel.neighborhood && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <FontAwesome name="map-marker" size={11} color={colors.textTertiary} />
+                <Text style={{ ...TextStyles.xs, color: colors.textSecondary }}>{hotel.neighborhood}</Text>
+              </View>
+            )}
+          </View>
+
+          {/* Description (if present) */}
+          {!!hotel.description && (
+            <Text style={{ ...TextStyles.body, color: colors.textSecondary, paddingHorizontal: 14, marginTop: 10, lineHeight: 19 }} numberOfLines={4}>
+              {hotel.description}
+            </Text>
+          )}
+
+          {/* Hours / Nearby summary */}
+          {(!!hotel.hours || !!hotel.nearby) && (
+            <View style={{ paddingHorizontal: 14, marginTop: 8, gap: 4 }}>
+              {!!hotel.hours && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                  <FontAwesome name="clock-o" size={11} color={colors.textTertiary} />
+                  <Text style={{ ...TextStyles.caption, color: colors.textSecondary, flex: 1 }}>{hotel.hours}</Text>
+                </View>
+              )}
+              {!!hotel.nearby && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                  <FontAwesome name="compass" size={11} color={colors.textTertiary} />
+                  <Text style={{ ...TextStyles.caption, color: colors.textSecondary, flex: 1 }}>{hotel.nearby}</Text>
+                </View>
+              )}
             </View>
           )}
 

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useContext, useRef, useCallback } from 'react';
-import { View, Text, ScrollView, Pressable, Image, Linking, Platform, TextInput, Keyboard, ActivityIndicator } from 'react-native';
+import { View, Text, ScrollView, Pressable, Image, Linking, Platform, TextInput, Keyboard, ActivityIndicator, Alert } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -21,7 +22,7 @@ if (Platform.OS !== 'web') {
 import { CardStackCarousel } from '@/components/places/CardStackCarousel';
 import type { PlaceItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { TextStyles, FontFamily, useItineraryScreen, useHotelSearch, upscaleGoogleImage, getWebApiBase } from '@travyl/shared';
+import { TextStyles, FontFamily, useItineraryScreen, useHotelSearch, upscaleGoogleImage, getWebApiBase, supabase } from '@travyl/shared';
 
 
 /* ------------------------------------------------------------------ */
@@ -1449,6 +1450,61 @@ export default function HotelsScreen() {
     setBooked(true);
   };
 
+  const queryClient = useQueryClient();
+  const [savingHotel, setSavingHotel] = useState(false);
+
+  // Persist the currently-selected hotel into trip_context.hotels[0]. The
+  // budget tab pulls accommodation cost from trip_context.hotels[0].price,
+  // so this is what makes the hotel's price show up in Budget after the
+  // user picks a hotel.
+  const addHotelToTrip = useCallback(async () => {
+    if (!id || !hotel) return;
+    const room = currentRoom ?? hotel.roomTypes[selectedRoom];
+    const ctxHotel = {
+      id: hotel.id,
+      name: hotel.name,
+      stars: hotel.stars,
+      rating: hotel.rating,
+      review_count: hotel.reviews,
+      price: room?.price ?? hotel.price,
+      price_per_night: room?.price ?? hotel.price,
+      neighborhood: hotel.neighborhood,
+      address: hotel.address,
+      image: hotel.images?.[0] ?? '',
+      images: hotel.images ?? [],
+      amenities: hotel.amenities,
+      checkIn: hotel.checkIn,
+      checkOut: hotel.checkOut,
+      cancellation: hotel.cancellation,
+      phone: hotel.phone,
+      link: hotel.bookingLink,
+      website: hotel.bookingLink,
+      description: hotel.description,
+      category: hotel.category,
+      hours: hotel.hours,
+      nearby: hotel.nearby,
+      room_type: room?.type ?? '',
+      room_types: hotel.roomTypes,
+    };
+    setSavingHotel(true);
+    try {
+      const { data: row } = await supabase.from('trips').select('trip_context').eq('id', id).single();
+      const ctx = (row?.trip_context || {}) as Record<string, unknown>;
+      (ctx as any).hotels = [ctxHotel];
+      const existingAll = Array.isArray((ctx as any).all_hotels) ? ((ctx as any).all_hotels as any[]) : [];
+      const dedup = [ctxHotel, ...existingAll.filter((h: any) => h?.id !== ctxHotel.id && h?.name !== ctxHotel.name)];
+      (ctx as any).all_hotels = dedup;
+      const { error } = await supabase.from('trips').update({ trip_context: ctx }).eq('id', id);
+      if (error) throw error;
+      await queryClient.invalidateQueries({ queryKey: ['trip', id] });
+      Alert.alert('Hotel added', 'This hotel is now in your trip and budget.');
+    } catch (e: any) {
+      Alert.alert('Could not add hotel', e?.message || 'Please try again.');
+    } finally {
+      setSavingHotel(false);
+    }
+  }, [id, hotel, currentRoom, selectedRoom, queryClient]);
+
   const scrollRef = useRef<ScrollView>(null);
   const detailRef = useRef<View>(null);
   const detailYRef = useRef(0);
@@ -1645,19 +1701,37 @@ export default function HotelsScreen() {
               </View>
             )}
 
-            {/* ── Book Now — opens hotel site in-app ── */}
-            {!!hotel.bookingLink && (
+            {/* ── Add to Trip + Book Now ── */}
+            <View style={{ flexDirection: 'row', gap: 8, marginTop: 16 }}>
               <Pressable
-                onPress={() => WebBrowser.openBrowserAsync(hotel.bookingLink.startsWith('http') ? hotel.bookingLink : `https://www.google.com/search?q=${encodeURIComponent(hotel.name + ' booking')}`)}
+                onPress={addHotelToTrip}
+                disabled={savingHotel}
                 style={({ pressed }) => ({
-                  marginTop: 16, backgroundColor: pressed ? colors.tint : colors.tint, borderRadius: 12, paddingVertical: 15,
+                  flex: 1, backgroundColor: colors.tint, borderRadius: 12, paddingVertical: 15,
                   flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+                  opacity: pressed || savingHotel ? 0.85 : 1,
                 })}
               >
-                <FontAwesome name="building" size={14} color="#fff" />
-                <Text style={{ ...TextStyles.bodyLgEm, color: '#fff' }}>Book Now</Text>
+                <FontAwesome name="plus" size={14} color="#fff" />
+                <Text style={{ ...TextStyles.bodyLgEm, color: '#fff' }}>
+                  {savingHotel ? 'Adding…' : 'Add to Trip'}
+                </Text>
               </Pressable>
-            )}
+              {!!hotel.bookingLink && (
+                <Pressable
+                  onPress={() => WebBrowser.openBrowserAsync(hotel.bookingLink.startsWith('http') ? hotel.bookingLink : `https://www.google.com/search?q=${encodeURIComponent(hotel.name + ' booking')}`)}
+                  style={({ pressed }) => ({
+                    flex: 1, backgroundColor: colors.cardBackground, borderRadius: 12, paddingVertical: 15,
+                    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+                    borderWidth: 1, borderColor: colors.tint,
+                    opacity: pressed ? 0.9 : 1,
+                  })}
+                >
+                  <FontAwesome name="external-link" size={13} color={colors.tint} />
+                  <Text style={{ ...TextStyles.bodyLgEm, color: colors.tint }}>Book Now</Text>
+                </Pressable>
+              )}
+            </View>
           </View>
         </View>
       </View>

--- a/apps/mobile/app/trip/[id]/hotels.tsx
+++ b/apps/mobile/app/trip/[id]/hotels.tsx
@@ -591,10 +591,15 @@ function OtherHotelCard({ hotel, onPress }: { hotel: { id: string; name: string;
               {hotel.rating > 0 && <RatingBadge rating={hotel.rating} />}
             </View>
           </View>
-          {hotel.price > 0 && (
+          {hotel.price > 0 ? (
             <View style={{ alignItems: 'flex-end' }}>
               <Text style={{ ...TextStyles.bodyXlEm, color: ACCENT }}>${hotel.price}</Text>
               <Text style={{ ...TextStyles.xs, color: colors.textTertiary }}>per night</Text>
+            </View>
+          ) : (
+            <View style={{ alignItems: 'flex-end' }}>
+              <Text style={{ ...TextStyles.captionEm, color: colors.textTertiary }}>Rates vary</Text>
+              <Text style={{ ...TextStyles.xs, color: colors.textTertiary }}>tap to view</Text>
             </View>
           )}
         </View>
@@ -834,13 +839,19 @@ function BrowseHotelCard({ hotel, onPress, isSelected, isBooked }: { hotel: { id
           </View>
         )}
 
-        {/* Price row */}
-        {hotel.price > 0 && (
-          <View style={{ flexDirection: 'row', alignItems: 'baseline', marginTop: 10, paddingTop: 8, borderTopWidth: 1, borderTopColor: colors.borderLight }}>
-            <Text style={{ ...TextStyles.title, color: colors.text }}>${hotel.price}</Text>
-            <Text style={{ fontSize: 10, color: colors.textTertiary, marginLeft: 6 }}>/night</Text>
-          </View>
-        )}
+        {/* Price row — always rendered. Live rates aren't always
+            available (older trips, off-the-grid hotels), so we surface
+            "Rates vary" rather than silently dropping the row. */}
+        <View style={{ flexDirection: 'row', alignItems: 'baseline', marginTop: 10, paddingTop: 8, borderTopWidth: 1, borderTopColor: colors.borderLight }}>
+          {hotel.price > 0 ? (
+            <>
+              <Text style={{ ...TextStyles.title, color: colors.text }}>${hotel.price}</Text>
+              <Text style={{ fontSize: 10, color: colors.textTertiary, marginLeft: 6 }}>/night</Text>
+            </>
+          ) : (
+            <Text style={{ ...TextStyles.bodyEm, color: colors.textSecondary }}>Rates vary — tap for details</Text>
+          )}
+        </View>
       </View>
     </Pressable>
   );
@@ -980,7 +991,17 @@ function HotelListCard({ hotel, nights, onPress }: { hotel: any; nights: number;
             </View>
           )}
 
-          {/* Price */}
+          {/* Price — always rendered. Live rates aren't always
+              available (older trips, third-party listings); surface a
+              graceful fallback rather than silently dropping the row. */}
+          {hotel.price <= 0 && (
+            <View style={{ marginTop: 16 }}>
+              <Text style={{ fontSize: 18, fontFamily: FontFamily.sansBold, color: colors.text }}>Rates not available</Text>
+              <Text style={{ fontSize: 13, color: colors.textTertiary, marginTop: 2 }}>
+                {hotel.link ? 'Tap "View on Booking" below for current pricing' : `Live rates depend on dates · ${nights} night${nights !== 1 ? 's' : ''}`}
+              </Text>
+            </View>
+          )}
           {hotel.price > 0 && (
             <View style={{ marginTop: 16 }}>
               <View style={{ flexDirection: 'row', alignItems: 'baseline' }}>

--- a/apps/mobile/app/trip/[id]/info.tsx
+++ b/apps/mobile/app/trip/[id]/info.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useRef } from 'react';
 import { View, ScrollView, Text, Pressable, Linking, Platform, Share, Alert, Clipboard as RNClipboard } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
@@ -232,43 +232,52 @@ export default function InfoScreen() {
 // person inside the trip can share without scrolling back to the hero.
 function ShareTripCard({ trip, accent }: { trip: any; accent: string }) {
   const colors = useThemeColors();
+  // Busy guard so a double-tap can't fire two ensureShareLinkToken
+  // requests in parallel (which could race and leave a stale token).
+  const shareBusyRef = useRef(false);
   const handleShare = useCallback(async () => {
     if (!trip?.id) return;
-    let token: string | null = null;
+    if (shareBusyRef.current) return;
+    shareBusyRef.current = true;
     try {
-      token = await ensureShareLinkToken(trip.id);
-      if (trip.visibility === 'private') {
-        try { await updateTripVisibility(trip.id, 'link'); } catch {}
+      let token: string | null = null;
+      try {
+        token = await ensureShareLinkToken(trip.id);
+        if (trip.visibility === 'private') {
+          try { await updateTripVisibility(trip.id, 'link'); } catch {}
+        }
+      } catch (e: any) {
+        const msg = e?.message ?? 'Could not create a share link.';
+        if (Platform.OS === 'web') (globalThis as any).alert?.(`Share failed: ${msg}`);
+        else Alert.alert('Share failed', msg);
+        return;
       }
-    } catch (e: any) {
-      const msg = e?.message ?? 'Could not create a share link.';
-      if (Platform.OS === 'web') (globalThis as any).alert?.(`Share failed: ${msg}`);
-      else Alert.alert('Share failed', msg);
-      return;
-    }
-    const url = `https://gotravyl.com/trip/${trip.id}/share/${token}`;
-    const message = `Join me planning my trip to ${trip.destination} on Travyl: ${url}`;
-    const title = trip.title ?? `Trip to ${trip.destination}`;
+      const url = `https://gotravyl.com/trip/${trip.id}/share/${token}`;
+      const message = `Join me planning my trip to ${trip.destination} on Travyl: ${url}`;
+      const title = trip.title ?? `Trip to ${trip.destination}`;
 
-    if (Platform.OS === 'web') {
-      const nav = (globalThis as any).navigator;
+      if (Platform.OS === 'web') {
+        const nav = (globalThis as any).navigator;
+        try {
+          if (nav?.share) { await nav.share({ title, text: message, url }); return; }
+        } catch {}
+        try {
+          await nav?.clipboard?.writeText?.(url);
+          (globalThis as any).alert?.(`Link copied to clipboard:\n${url}`);
+        } catch {
+          (globalThis as any).alert?.(`Share link:\n${url}`);
+        }
+        return;
+      }
+
       try {
-        if (nav?.share) { await nav.share({ title, text: message, url }); return; }
-      } catch {}
-      try {
-        await nav?.clipboard?.writeText?.(url);
-        (globalThis as any).alert?.(`Link copied to clipboard:\n${url}`);
+        await Share.share({ message, url, title });
       } catch {
-        (globalThis as any).alert?.(`Share link:\n${url}`);
+        try { RNClipboard.setString(url); } catch {}
+        Alert.alert('Link copied', `Couldn't open the share sheet, but the link is in your clipboard:\n${url}`);
       }
-      return;
-    }
-
-    try {
-      await Share.share({ message, url, title });
-    } catch {
-      try { RNClipboard.setString(url); } catch {}
-      Alert.alert('Link copied', `Couldn't open the share sheet, but the link is in your clipboard:\n${url}`);
+    } finally {
+      shareBusyRef.current = false;
     }
   }, [trip?.id, trip?.destination, trip?.title, trip?.visibility]);
 

--- a/apps/mobile/app/trip/[id]/restaurants.tsx
+++ b/apps/mobile/app/trip/[id]/restaurants.tsx
@@ -10,7 +10,7 @@ import { CardStackCarousel } from '@/components/places/CardStackCarousel';
 import type { PlaceItem } from '@travyl/shared';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useAddToTrip } from '@/hooks/useAddToTrip';
-import { TextStyles, FontFamily, useItineraryScreen, upscaleGoogleImage, getWebApiBase, shuffle, favoritesKeyFor, useAuthStore } from '@travyl/shared';
+import { TextStyles, FontFamily, useItineraryScreen, upscaleGoogleImage, getWebApiBase, shuffle, favoritesKeyFor, favoritePlacesKeyFor, useAuthStore } from '@travyl/shared';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -665,6 +665,10 @@ export default function RestaurantsScreen() {
   // Favorites — per-user AsyncStorage key (matches profile + favorites tab).
   const userId = useAuthStore((s) => s.user?.id ?? null);
   const [favorites, setFavorites] = useState<string[]>([]);
+  // Ref onto the rendered restaurantPlaces list so toggleFavorite can
+  // look up the full PlaceItem at call time (declaration order: state →
+  // toggleFavorite → restaurantPlaces; the ref bridges that).
+  const restaurantPlacesRef = useRef<PlaceItem[]>([]);
   useEffect(() => {
     setFavorites([]);
     AsyncStorage.getItem(favoritesKeyFor(userId)).then((val) => {
@@ -673,10 +677,23 @@ export default function RestaurantsScreen() {
   }, [userId]);
   const toggleFavorite = useCallback((placeId: string) => {
     setFavorites((prev) => {
-      const next = prev.includes(placeId)
-        ? prev.filter((id) => id !== placeId)
-        : [...prev, placeId];
+      const wasFavorited = prev.includes(placeId);
+      const next = wasFavorited ? prev.filter((id) => id !== placeId) : [...prev, placeId];
       AsyncStorage.setItem(favoritesKeyFor(userId), JSON.stringify(next)).catch(() => {});
+      // Snapshot the full PlaceItem alongside the id so the profile's
+      // "My Saves" grid can render it without depending on the discover
+      // query containing a matching place. Same flow as /favorites tab.
+      AsyncStorage.getItem(favoritePlacesKeyFor(userId)).then((raw) => {
+        let map: Record<string, PlaceItem> = {};
+        if (raw) { try { map = JSON.parse(raw) || {}; } catch {} }
+        if (wasFavorited) {
+          delete map[placeId];
+        } else {
+          const hit = restaurantPlacesRef.current.find((p) => p.id === placeId);
+          if (hit) map[placeId] = hit;
+        }
+        AsyncStorage.setItem(favoritePlacesKeyFor(userId), JSON.stringify(map)).catch(() => {});
+      }).catch(() => {});
       return next;
     });
   }, [userId]);
@@ -941,6 +958,9 @@ export default function RestaurantsScreen() {
     })),
     [realRestaurants],
   );
+  // Keep the ref in sync so toggleFavorite (declared earlier) can resolve
+  // the full PlaceItem at call time for the favorite-snapshot map.
+  useEffect(() => { restaurantPlacesRef.current = restaurantPlaces; }, [restaurantPlaces]);
 
   // Filtered + sorted list
   const filteredRestaurants = useMemo(() => {

--- a/apps/mobile/components/places/CardStackCarousel.tsx
+++ b/apps/mobile/components/places/CardStackCarousel.tsx
@@ -27,7 +27,7 @@ if (Platform.OS !== 'web') {
   } catch {}
 }
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { PlaceItem } from '@travyl/shared';
+import { getWebApiBase, type PlaceItem } from '@travyl/shared';
 import { MagazineCurtain } from './MagazineCurtain';
 import { AddToTripSheet } from '@/components/AddToTripSheet';
 
@@ -219,7 +219,53 @@ export function CardStackCarousel({
     });
   }, []);
 
-  const place = places[currentIdx];
+  const rawPlace = places[currentIdx];
+
+  // Lazy on-demand geocoding for the visible card. The discover/search
+  // pipeline skips Nominatim batch enrichment on the critical path
+  // (~5-10s saved on first paint), so cards arrive without coords. We
+  // hit the geocode proxy for *just* the card the user is currently
+  // looking at — single request, ~300ms — and stash the result in a
+  // session-lifetime map keyed by place id so swiping back doesn't
+  // re-fetch.
+  const [resolvedCoords, setResolvedCoords] = useState<Record<string, { lat: number; lng: number } | null>>({});
+  useEffect(() => {
+    if (!rawPlace) return;
+    if (rawPlace.latitude != null && rawPlace.longitude != null) return;
+    if (resolvedCoords[rawPlace.id] !== undefined) return; // already tried
+    const cancelled = { current: false };
+    const query = rawPlace.address ? `${rawPlace.name}, ${rawPlace.address}` : rawPlace.name;
+    fetch(`${getWebApiBase()}/api/geocode?q=${encodeURIComponent(query)}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: any[]) => {
+        if (cancelled.current) return;
+        if (Array.isArray(data) && data.length > 0 && data[0].lat && data[0].lon) {
+          setResolvedCoords((prev) => ({
+            ...prev,
+            [rawPlace.id]: { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) },
+          }));
+        } else {
+          setResolvedCoords((prev) => ({ ...prev, [rawPlace.id]: null }));
+        }
+      })
+      .catch(() => {
+        if (!cancelled.current) {
+          setResolvedCoords((prev) => ({ ...prev, [rawPlace.id]: null }));
+        }
+      });
+    return () => { cancelled.current = true; };
+  }, [rawPlace?.id, rawPlace?.latitude, rawPlace?.longitude]);
+
+  // Splice the resolved coords back onto the place so every downstream
+  // consumer (map markers, region calc, the "no coords → no map"
+  // fallback) sees a complete record.
+  const place = (() => {
+    if (!rawPlace) return rawPlace;
+    if (rawPlace.latitude != null && rawPlace.longitude != null) return rawPlace;
+    const looked = resolvedCoords[rawPlace.id];
+    if (!looked) return rawPlace;
+    return { ...rawPlace, latitude: looked.lat, longitude: looked.lng };
+  })();
   const isFav = place ? favorites.includes(place.id) : false;
 
   const goNext = useCallback(() => {

--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -26,8 +26,8 @@ import {
   Plane,
 } from 'lucide-react';
 import { PaperPlane } from '@/components/ui';
-import { useItineraryScreen, useFlights } from '@travyl/shared';
-import { useQuery } from '@tanstack/react-query';
+import { useItineraryScreen, useFlights, supabase } from '@travyl/shared';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 /* ================================================================
    TYPES & HELPERS
@@ -684,7 +684,7 @@ function BookedFlightCard({ flight }: { flight: BookedFlight }) {
    COMPARISON ALTERNATIVES
    ================================================================ */
 
-function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: ComparisonFlight[] }) {
+function ComparisonAlternatives({ comparisonFlights, onSelect, savingId }: { comparisonFlights: ComparisonFlight[]; onSelect: (f: ComparisonFlight) => void; savingId: string | null }) {
   const [open, setOpen] = useState(false);
   const [sort, setSort] = useState<'price' | 'duration' | 'value'>('value');
   const [altAirports, setAltAirports] = useState(false);
@@ -840,8 +840,12 @@ function ComparisonAlternatives({ comparisonFlights }: { comparisonFlights: Comp
                               </div>}
                             </div>
                             )}
-                            <button className="w-full py-2 bg-gradient-to-r from-[#2563eb] to-[#3b82f6] text-white text-xs font-medium rounded-lg hover:from-[#1d4ed8] hover:to-[#2563eb] transition-all shadow-sm">
-                              Select This Flight
+                            <button
+                              onClick={() => onSelect(flight)}
+                              disabled={savingId !== null}
+                              className="w-full py-2 bg-gradient-to-r from-[#2563eb] to-[#3b82f6] text-white text-xs font-medium rounded-lg hover:from-[#1d4ed8] hover:to-[#2563eb] transition-all shadow-sm disabled:opacity-60"
+                            >
+                              {savingId === flight.id ? 'Adding…' : 'Add to Trip'}
                             </button>
                           </div>
                         </motion.div>
@@ -999,6 +1003,56 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
   const outbound = bookedFlights.filter(f => f.type === 'outbound');
   const returnFlights = bookedFlights.filter(f => f.type === 'return');
 
+  // Persist a search-result flight into trip_context.flights[0]. The budget
+  // tab reads from trip_context.flights[] so this is what makes the flight
+  // price show up in Budget after the user picks one.
+  const queryClient = useQueryClient();
+  const [savingFlightId, setSavingFlightId] = useState<string | null>(null);
+  const handleSelectFlight = async (f: ComparisonFlight) => {
+    if (!id) return;
+    setSavingFlightId(f.id);
+    try {
+      // Reconstruct ISO datetimes from "HH:MM" + searchParams.date so the
+      // BookedFlightCard renderer (and trip itinerary) get usable times.
+      const baseDate = searchParams?.date || trip?.start_date || new Date().toISOString().slice(0, 10);
+      const isoFor = (clock: string) => {
+        const m = clock.match(/(\d{1,2}):(\d{2})/);
+        if (!m) return null;
+        const hh = m[1].padStart(2, '0');
+        return `${baseDate}T${hh}:${m[2]}:00`;
+      };
+      const ctxFlight = {
+        airline: f.airline,
+        airlineLogo: f.airlineLogo,
+        flight_number: f.flightNumber,
+        origin: f.departure.airport,
+        origin_iata: f.departure.airport,
+        destination: f.arrival.airport,
+        dest_iata: f.arrival.airport,
+        departure_time: isoFor(f.departure.time),
+        arrival_time: isoFor(f.arrival.time),
+        duration: (() => {
+          const m = f.duration.match(/(\d+)h\s*(\d+)?m?/);
+          return m ? Number(m[1]) * 60 + (m[2] ? Number(m[2]) : 0) : 0;
+        })(),
+        stops: f.stops,
+        price: f.price,
+        depart_date: baseDate,
+      };
+      const { data: row } = await supabase.from('trips').select('trip_context').eq('id', id).single();
+      const ctx = (row?.trip_context || {}) as Record<string, unknown>;
+      const existing = Array.isArray((ctx as any).flights) ? ((ctx as any).flights as any[]) : [];
+      (ctx as any).flights = existing.length > 0 ? [ctxFlight, ...existing.slice(1)] : [ctxFlight];
+      const { error } = await supabase.from('trips').update({ trip_context: ctx }).eq('id', id);
+      if (error) throw error;
+      await queryClient.invalidateQueries({ queryKey: ['trip', id] });
+    } catch (e) {
+      console.error('Failed to add flight to trip', e);
+    } finally {
+      setSavingFlightId(null);
+    }
+  };
+
   if (isLoading || loadingDbFlights) {
     return (
       <div className="space-y-3 animate-pulse">
@@ -1050,7 +1104,7 @@ export default function Flights({ params }: { params: Promise<{ id: string }> })
           <p className="text-sm text-gray-400 dark:text-gray-500">Searching flights...</p>
         </div>
       ) : searchedFlights.length > 0 ? (
-        <ComparisonAlternatives comparisonFlights={searchedFlights} />
+        <ComparisonAlternatives comparisonFlights={searchedFlights} onSelect={handleSelectFlight} savingId={savingFlightId} />
       ) : !hasBookedFlights ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <div className="w-12 h-12 rounded-full bg-gray-100 dark:bg-white/[0.06] flex items-center justify-center mb-3">

--- a/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx
@@ -10,9 +10,9 @@ import {
   Phone, Mail, Map, X, Camera, Shield, CreditCard, Share2,
   Snowflake, UtensilsCrossed, Sparkles, LayoutGrid, List, BookOpen,
 } from 'lucide-react';
-import { useItineraryScreen, useHotels as useDbHotels, useHomeCurrency } from '@travyl/shared';
+import { useItineraryScreen, useHotels as useDbHotels, useHomeCurrency, supabase } from '@travyl/shared';
 import type { PlaceItem } from '@travyl/shared';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { PinCard } from '@/components/PinCard';
 
 /* ------------------------------------------------------------------ */
@@ -1923,7 +1923,8 @@ export default function Hotels({ params }: { params: Promise<{ id: string }> }) 
     setActiveSearchQuery(searchInput);
   };
 
-  const handleSelect = (hotel: HotelData) => {
+  const queryClient = useQueryClient();
+  const handleSelect = async (hotel: HotelData) => {
     setBookedHotel(hotel);
     setBrowsingOpen(false);
     setJustSelected(true);
@@ -1932,6 +1933,43 @@ export default function Hotels({ params }: { params: Promise<{ id: string }> }) 
       bookedRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       setTimeout(() => setJustSelected(false), 1500);
     }, 100);
+    // Persist into trip_context.hotels[0] so the budget tab picks up the
+    // hotel's nightly price and the Itinerary tab shows the booking. Also
+    // prepend onto all_hotels[] so the user can re-pick later without
+    // searching again.
+    if (!id) return;
+    try {
+      const ctxHotel = {
+        id: hotel.id,
+        name: hotel.name,
+        stars: hotel.stars,
+        rating: hotel.rating,
+        review_count: hotel.reviews,
+        price: hotel.price,
+        price_per_night: hotel.price,
+        address: hotel.address,
+        neighborhood: hotel.neighborhood,
+        image: hotel.images?.[0] ?? '',
+        images: hotel.images ?? [],
+        amenities: hotel.amenities,
+        lat: hotel.lat,
+        lng: hotel.lng,
+        room_types: hotel.roomTypes,
+        phone: hotel.phone,
+        link: hotel.email,
+        website: hotel.email,
+      };
+      const { data: row } = await supabase.from('trips').select('trip_context').eq('id', id).single();
+      const ctx = (row?.trip_context || {}) as Record<string, unknown>;
+      (ctx as any).hotels = [ctxHotel];
+      const existingAll = Array.isArray((ctx as any).all_hotels) ? ((ctx as any).all_hotels as any[]) : [];
+      (ctx as any).all_hotels = [ctxHotel, ...existingAll.filter((h: any) => h?.id !== ctxHotel.id && h?.name !== ctxHotel.name)];
+      const { error } = await supabase.from('trips').update({ trip_context: ctx }).eq('id', id);
+      if (error) throw error;
+      await queryClient.invalidateQueries({ queryKey: ['trip', id] });
+    } catch (e) {
+      console.error('Failed to persist selected hotel', e);
+    }
   };
 
   const handleCancel = () => {

--- a/apps/web/components/itinerary/ItineraryContext.tsx
+++ b/apps/web/components/itinerary/ItineraryContext.tsx
@@ -133,7 +133,20 @@ function calendarActivitiesToDayViewModels(
   });
 
   return baseDays.map((baseDay, idx) => {
-    const dayActivities = onCalendar.filter((a) => a.day === idx);
+    // Dedup by (title + startHour) — the trip-generation pipeline
+    // sometimes emits the same POI in multiple slots for the same day,
+    // which made "Ala Moana Regional Park" / "Bishop Museum" appear
+    // twice on Day 1. Same fix as the mobile itinerary screen, applied
+    // at the consumer side until #764 (single canonical activity store)
+    // lands and removes the duplicates at the data layer.
+    const seenInDay = new Set<string>();
+    const dayActivities = onCalendar.filter((a) => {
+      if (a.day !== idx) return false;
+      const key = `${a.title || ''}|${a.startHour ?? ''}`;
+      if (seenInDay.has(key)) return false;
+      seenInDay.add(key);
+      return true;
+    });
     // Flatten: for parent blocks, include children as separate activities
     const allVMs: ActivityViewModel[] = [];
     for (const a of dayActivities) {

--- a/apps/web/components/packing/PackingPage.tsx
+++ b/apps/web/components/packing/PackingPage.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Sparks, SidebarCollapse, SidebarExpand } from 'iconoir-react'
-import { usePackingList, useAuthStore, usePackingSuggestions } from '@travyl/shared'
+import { usePackingList, useAuthStore, usePackingSuggestions, useItineraryScreen, supabase, seedDefaultPackingItems } from '@travyl/shared'
 import { SpotlightSearch } from './SpotlightSearch'
 import { PackingProgress } from './PackingProgress'
 import { PackingCategoryList } from './PackingCategoryList'
@@ -17,8 +18,47 @@ export function PackingPage({ tripId }: PackingPageProps) {
   const userId = user?.id
   const [filterBy, setFilterBy] = useState<string>('all')
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { trip } = useItineraryScreen(tripId)
+  const queryClient = useQueryClient()
 
   const { items, itemsByCategory, orderedCategories, filteredItems, auditLog, progress, isLoading, error, addItem, togglePacked, incrementPacked, updateQuantity, removeItem, claimItem, releaseItem, transferItem } = usePackingList(tripId, userId, filterBy)
+
+  // Auto-seed default items once when the trip's packing_items table is empty.
+  // Mobile auto-generates a list from trip_context.packing_data when the
+  // trip loads; the web equivalent is the packing_items table, which has
+  // never been seeded for new trips — so users were landing on a blank
+  // tab. Gate via trip_context.packing_seeded so this runs at most once,
+  // even if the user later deletes everything.
+  const seedAttempted = useRef(false)
+  useEffect(() => {
+    if (seedAttempted.current) return
+    if (isLoading || !trip || !userId || !tripId) return
+    if (items.length > 0) { seedAttempted.current = true; return }
+    const ctx = (trip.trip_context as any) || {}
+    if (ctx.packing_seeded) { seedAttempted.current = true; return }
+    seedAttempted.current = true
+    ;(async () => {
+      try {
+        const days = trip.start_date && trip.end_date
+          ? Math.max(1, Math.ceil((new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000))
+          : (ctx.weather?.forecast?.length ?? 5)
+        const forecast: any[] = ctx.weather?.forecast ?? []
+        const avgTemp = forecast.length > 0
+          ? forecast.reduce((sum: number, d: any) => sum + (d.high ?? 20), 0) / forecast.length
+          : 20
+        const isWarm = avgTemp > 22
+        const isCold = avgTemp < 12
+        const hasRain = forecast.some((d: any) => (d.conditions || d.icon || '').toLowerCase().includes('rain'))
+        await seedDefaultPackingItems(tripId, userId, { days, isWarm, isCold, hasRain })
+        await supabase.from('trips').update({ trip_context: { ...ctx, packing_seeded: true } }).eq('id', tripId)
+        queryClient.invalidateQueries({ queryKey: ['packingItems', tripId] })
+        queryClient.invalidateQueries({ queryKey: ['trip', tripId] })
+      } catch (e) {
+        console.error('Failed to seed packing items', e)
+        seedAttempted.current = false
+      }
+    })()
+  }, [isLoading, trip, userId, tripId, items.length, queryClient])
   const {
     suggestionsByCategory,
     isGenerating,

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -66,6 +66,7 @@ export {
   fetchPackingSuggestions,
   updateSuggestionStatus,
   dismissAllSuggestions,
+  seedDefaultPackingItems,
 } from './packingService';
 
 export {

--- a/packages/shared/src/services/packingService.ts
+++ b/packages/shared/src/services/packingService.ts
@@ -73,19 +73,92 @@ export async function fetchPackingAuditLog(tripId: string, limit = 50): Promise<
  */
 export async function insertPackingItem(
   tripId: string, userId: string, name: string, category: string, sortOrder: number,
-  ownerId?: string | null, groupTag?: string | null,
+  ownerId?: string | null, groupTag?: string | null, quantity: number = 1,
 ): Promise<DbPackingItem> {
   const { data, error } = await supabase
     .from('packing_items')
     .insert({
       trip_id: tripId, user_id: userId, name, category, sort_order: sortOrder,
-      quantity: 1, packed_count: 0,
+      quantity, packed_count: 0,
       ...(ownerId !== undefined && { owner_id: ownerId }),
       ...(groupTag !== undefined && { group_tag: groupTag }),
     })
     .select().single()
   if (error) throw error
   return data
+}
+
+/**
+ * Bulk-insert default packing items for a freshly-created trip. Builds
+ * essentials, clothing (quantity-aware to trip duration), toiletries, and
+ * electronics; conditional items based on weather (swimsuit if warm, jacket
+ * if cold, umbrella if rain). Idempotent: callers should gate via the
+ * `trip.trip_context.packing_seeded` flag so this runs at most once per trip.
+ *
+ * @param tripId - UUID of the trip
+ * @param userId - UUID of the inserting user (used as user_id attribution)
+ * @param opts - Trip-derived signals: `days`, `isWarm`, `isCold`, `hasRain`
+ * @returns The inserted rows
+ */
+export async function seedDefaultPackingItems(
+  tripId: string,
+  userId: string,
+  opts: { days: number; isWarm: boolean; isCold: boolean; hasRain: boolean },
+): Promise<DbPackingItem[]> {
+  const days = Math.max(1, opts.days || 5)
+  const clothesQty = Math.min(days + 1, 7)
+  const bottomsQty = Math.min(Math.ceil(days / 2), 4)
+  type Seed = { name: string; category: string; quantity?: number }
+  const seeds: Seed[] = [
+    // Essentials
+    { name: 'Passport / ID', category: 'essentials' },
+    { name: 'Phone & charger', category: 'essentials' },
+    { name: 'Wallet & cards', category: 'essentials' },
+    { name: 'Travel insurance docs', category: 'documents' },
+    { name: 'Boarding pass / tickets', category: 'documents' },
+    // Clothing
+    { name: 'T-shirts / tops', category: 'clothing', quantity: clothesQty },
+    { name: 'Underwear', category: 'clothing', quantity: clothesQty },
+    { name: 'Socks (pairs)', category: 'clothing', quantity: clothesQty },
+    { name: 'Pants / shorts', category: 'clothing', quantity: bottomsQty },
+    { name: 'Sleepwear', category: 'clothing' },
+    ...(opts.isWarm ? [
+      { name: 'Swimsuit', category: 'clothing' },
+      { name: 'Sunglasses', category: 'accessories' },
+    ] : []),
+    ...(opts.isCold ? [
+      { name: 'Warm jacket', category: 'clothing' },
+      { name: 'Scarf & gloves', category: 'accessories' },
+    ] : []),
+    ...(opts.hasRain ? [{ name: 'Rain jacket / umbrella', category: 'clothing' }] : []),
+    // Toiletries
+    { name: 'Toothbrush & toothpaste', category: 'toiletries' },
+    { name: 'Shampoo & conditioner', category: 'toiletries' },
+    { name: 'Deodorant', category: 'toiletries' },
+    { name: 'Sunscreen', category: 'toiletries' },
+    { name: 'Medications', category: 'toiletries' },
+    // Electronics
+    { name: 'Power adapter', category: 'electronics' },
+    { name: 'Headphones', category: 'electronics' },
+    { name: 'Camera', category: 'electronics' },
+  ]
+  const sortByCategory: Record<string, number> = {}
+  const rows = seeds.map((s) => {
+    const idx = sortByCategory[s.category] ?? 0
+    sortByCategory[s.category] = idx + 1
+    return {
+      trip_id: tripId,
+      user_id: userId,
+      name: s.name,
+      category: s.category,
+      sort_order: idx,
+      quantity: s.quantity ?? 1,
+      packed_count: 0,
+    }
+  })
+  const { data, error } = await supabase.from('packing_items').insert(rows).select()
+  if (error) throw error
+  return data ?? []
 }
 
 /**

--- a/packages/shared/src/services/placesDiscovery.ts
+++ b/packages/shared/src/services/placesDiscovery.ts
@@ -166,17 +166,25 @@ async function resolveCoords(query: string): Promise<{ lat: string; lng: string 
   return null;
 }
 
-let _nearbyCityCache: string | null = null;
+// Keyed by coords (rounded to 2dp ≈ 1.1km buckets) so users who move
+// cities don't keep seeing the old city's "nearby" results. Previously
+// this was a single module-level string that latched the first city
+// the app ever saw and never invalidated.
+const _nearbyCityCache: Map<string, string | null> = new Map();
 
 async function getNearbyCityName(lat: number, lng: number): Promise<string | null> {
-  if (_nearbyCityCache) return _nearbyCityCache;
+  const key = `${lat.toFixed(2)},${lng.toFixed(2)}`;
+  if (_nearbyCityCache.has(key)) return _nearbyCityCache.get(key) ?? null;
+  let result: string | null = null;
   try {
     const res = await fetch(`${BASE()}/api/geocode?lat=${lat}&lng=${lng}&zoom=10`);
-    if (!res.ok) return null;
-    const data = await res.json() as any;
-    _nearbyCityCache = data.address?.city || data.address?.town || data.address?.county || null;
+    if (res.ok) {
+      const data = await res.json() as any;
+      result = data.address?.city || data.address?.town || data.address?.county || null;
+    }
   } catch {}
-  return _nearbyCityCache;
+  _nearbyCityCache.set(key, result);
+  return result;
 }
 
 // ─── Trending destinations (dynamic from API) ────────────────
@@ -237,10 +245,14 @@ async function fetchPlacesNlp(
     .catch(() => []);
 }
 
-async function fetchTripAdvisor(query: string, ssrc = 'a'): Promise<PlaceItem[]> {
+async function fetchTripAdvisor(query: string, ssrc = 'a', limit = 10): Promise<PlaceItem[]> {
+  // limit caps the slice we keep — the upstream API still returns ~30 but
+  // keeping the top-10 makes the per-page payload smaller and (more
+  // importantly) cuts the geocoding fanout from 30 → 10 when we eventually
+  // backfill coords.
   return fetchWithTimeout(`${BASE()}/api/search/tripadvisor?q=${encodeURIComponent(query)}&ssrc=${ssrc}`)
     .then(r => r.ok ? r.json() as Promise<any[]> : [])
-    .then((data) => (Array.isArray(data) ? data : []).map(p => mapApiPlace(p)))
+    .then((data) => (Array.isArray(data) ? data : []).slice(0, limit).map(p => mapApiPlace(p)))
     .catch(() => []);
 }
 
@@ -304,20 +316,35 @@ export async function fetchDiscoverPage(
   userLoc?: { lat: number; lng: number } | null,
 ): Promise<DiscoverPageResult> {
   try {
-    const trending = await getTrending();
+    const useNearby = !!(userLoc && page < NEARBY_PAGE_COUNT);
+
+    // Run trending + location resolution in parallel. Previously this was
+    // strictly sequential — getTrending then getNearbyCityName then 4
+    // place fetches — adding ~1-2s of dead time before the first card.
+    const [trending, locationInfo] = await Promise.all([
+      getTrending(),
+      (async () => {
+        if (useNearby) {
+          const cityName = await getNearbyCityName(userLoc!.lat, userLoc!.lng);
+          return {
+            destination: cityName || 'nearby',
+            coords: { lat: String(userLoc!.lat), lng: String(userLoc!.lng) },
+          };
+        }
+        return null;
+      })(),
+    ]);
+
     if (trending.length === 0 && !userLoc) {
       return { items: [], hasMore: false, nextPage: null };
     }
 
-    const useNearby = !!(userLoc && page < NEARBY_PAGE_COUNT);
-
     let destination: string;
     let coords: { lat: string; lng: string } | null;
 
-    if (useNearby) {
-      const cityName = await getNearbyCityName(userLoc!.lat, userLoc!.lng);
-      destination = cityName || 'nearby';
-      coords = { lat: String(userLoc!.lat), lng: String(userLoc!.lng) };
+    if (useNearby && locationInfo) {
+      destination = locationInfo.destination;
+      coords = locationInfo.coords;
     } else {
       destination = trending.length > 0 ? trending[page % trending.length].name : 'Popular';
       coords = await resolveCoords(destination);
@@ -329,16 +356,22 @@ export async function fetchDiscoverPage(
     const [mapsResults, taResults, events, nearbyResults] = await Promise.all([
       // Google Maps: "best of {destination}" — returns diverse mix
       fetchMapsSearch(`best places in ${destination}`),
-      // TripAdvisor: top things to do — returns 30 attractions/restaurants
-      fetchTripAdvisor(`${destination}`),
+      // TripAdvisor: top 10 — capped so we don't fan out 30 Nominatim
+      // geocodes per page on subsequent enrichment passes
+      fetchTripAdvisor(`${destination}`, 'a', 10),
       // Events happening in the destination
       fetchEvents(destination, `${slug}-p${page}`),
       // Foursquare: whatever is near the coordinates
       coords ? fetchFoursquare(coords.lat, coords.lng) : Promise.resolve([]),
     ]);
 
-    // Geocode any places missing coordinates so distance always works
-    let allPlaces = await enrichWithCoords([...mapsResults, ...taResults, ...nearbyResults]);
+    // SKIP enrichWithCoords on the critical path. Previously every page
+    // blocked on Nominatim geocoding ~30 places (mostly TripAdvisor results
+    // with no native coords) before returning — adding 5-10s of wall time.
+    // Cards render fine without coords; the distance label just falls
+    // back to NO_COORDS_DISTANCE so they sort to the bottom of nearby
+    // pages. Map markers are filtered downstream by `lat != null` already.
+    let allPlaces = [...mapsResults, ...taResults, ...nearbyResults];
 
     // Destination cards from trending API
     let destCards: PlaceItem[] = [];
@@ -471,7 +504,11 @@ export async function searchPlaces(
     }
 
     const results = await Promise.all(fetches);
-    let items = await enrichWithCoords(results.flat());
+    // Skip enrichWithCoords on the critical path (mirrors fetchDiscoverPage).
+    // Previously this fanned out 30+ Nominatim geocodes per search, blocking
+    // the first card by 5-10s. Cards render fine without coords; distance
+    // labels just fall back to NO_COORDS_DISTANCE.
+    let items = results.flat();
 
     // Add distance labels if user has location
     if (userLoc) {


### PR DESCRIPTION
## Summary
Wires up the missing persistence for flight + hotel selection on both web and mobile so users can actually save what they pick (and so the Budget tab can read those prices). Adds one-time seeding of the web packing list which previously left users with a blank tab on every new trip.

### Mobile
- **Flights**: each search-result card now has an **Add to Trip** button alongside Book. Converts the SerpAPI legs/duration shape into `trip_context.flights[]` shape, replaces outbound (slot 0), keeps any return leg, invalidates the trip query. (`apps/mobile/app/trip/[id]/flights.tsx`)
- **Hotels**: selected-hotel detail card now shows **Add to Trip** + **Book Now** side by side. Add to Trip writes the picked hotel (price, room, photos, amenities, contact, description) into `trip_context.hotels[0]` and prepends to `all_hotels[]`. (`apps/mobile/app/trip/[id]/hotels.tsx`)
- **Budget**: saved `budget_data` now merges with the freshly-built initial budget instead of replacing it. Fixed categories (Flights, Accommodation) refresh from initial each load so a re-saved hotel price or new flight is reflected; non-fixed categories preserve user edits; custom user-added categories are appended. (`apps/mobile/app/trip/[id]/budget.tsx`)

### Web
- **Flights**: \"Select This Flight\" button in `ComparisonAlternatives` previously had **no `onClick`** (dead button). Wired it through to a new `handleSelectFlight` that reconstructs ISO datetimes from \"HH:MM\" + searchParams.date, persists into `trip_context.flights`, and invalidates the trip query. (`apps/web/app/(dashboard)/trip/[id]/flights/page.tsx`)
- **Hotels**: `handleSelect` previously only set local component state. Now also persists the picked hotel into `trip_context.hotels[0]` and prepends to `all_hotels[]`. (`apps/web/app/(dashboard)/trip/[id]/hotels/page.tsx`)
- **Packing**: web's `packing_items` table was never seeded for new trips, so users landed on an empty tab. Added a one-time seed on mount when `items.length === 0` and `trip.trip_context.packing_seeded` isn't set. Defaults derived from trip duration + weather (warm/cold/rain). (`apps/web/components/packing/PackingPage.tsx`)

### Shared
- New `seedDefaultPackingItems(tripId, userId, opts)` bulk-inserts essentials, clothing (quantity-aware to days), toiletries, electronics, and weather-conditional items. (`packages/shared/src/services/packingService.ts`)
- `insertPackingItem` now accepts an optional `quantity` arg (defaults to 1, preserves existing callers).

## Test plan
- [ ] Web: open a trip → Flights tab → run a search → click **Add to Trip** on a result → switch to Budget → confirm the price appears in the Flights category.
- [ ] Web: open a trip → Hotels tab → click a hotel card → confirm the booked card sticks across page refresh and that its price flows into the Budget Accommodation category.
- [ ] Web: open a freshly created trip → Packing tab → confirm a default list appears with quantity-aware items (e.g. socks scale with trip duration), and that deleting items + reloading does NOT re-seed (because `packing_seeded` is now set).
- [ ] Web: existing trip with saved packing items → confirm the seed does NOT run.
- [ ] Mobile: same Add-to-Trip flow on flights + hotels; Budget reflects prices.
- [ ] Mobile: existing budget customizations preserved after deploy (merge logic).