### PR TITLE
fix(web+mobile): packing FK 400, flight search 400, /explore 400, avatar sync

### DIFF
--- a/apps/mobile/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/app/(tabs)/profile/index.tsx
@@ -2206,7 +2206,13 @@ export default function ProfileScreen() {
     if (user?.id) {
       try {
         const merged = { ...((profile?.preferences ?? {}) as Record<string, any>), ...nextLocalPrefs };
-        await updateProfile(user.id, { preferences: merged });
+        // Also mirror the avatar to the canonical `profiles.avatar_url`
+        // column so web (which reads that field directly) stays in sync.
+        // Without this, mobile-uploaded avatars only landed in
+        // `profiles.preferences.avatar_url` and web would never see them.
+        const updates: Parameters<typeof updateProfile>[1] = { preferences: merged };
+        if (pendingAvatar) updates.avatar_url = pendingAvatar;
+        await updateProfile(user.id, updates);
         queryClient.invalidateQueries({ queryKey: ['profile', user.id] });
       } catch {}
     }

--- a/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/flights/page.tsx
@@ -133,11 +133,12 @@ function useFlightSearch(tripId: string, searchParams?: FlightSearchParams) {
   const destAirport = searchParams?.destination || undefined;
   const originAirport = searchParams?.origin || '';
   const departDate = searchParams?.date || trip?.start_date || new Date(Date.now() + 14 * 86400000).toISOString().slice(0, 10);
+  const returnDate = trip?.end_date || '';
   const passengers = searchParams?.passengers || trip?.travelers || 1;
   const cabinClass = searchParams?.cabinClass || '';
 
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ['flights-search', originAirport, destAirport, departDate, passengers, cabinClass],
+    queryKey: ['flights-search', originAirport, destAirport, departDate, returnDate, passengers, cabinClass],
     queryFn: async (): Promise<ComparisonFlight[]> => {
       if (!originAirport || (!destAirport && !destination)) return [];
       // Backend resolves airports from city names, not IATA codes
@@ -151,6 +152,10 @@ function useFlightSearch(tripId: string, searchParams?: FlightSearchParams) {
         date: departDate,
         passengers: String(passengers),
       });
+      // Pass the trip's end_date as the return date when present so
+      // SerpAPI runs as round-trip; otherwise the route falls back to
+      // type=2 (one-way) so the request doesn't 400 on missing return.
+      if (returnDate) params.set('return', returnDate);
       if (originCtry) params.set('origin_country', originCtry);
       if (destCtry) params.set('destination_country', destCtry);
       if (cabinClass) params.set('cabin', cabinClass);

--- a/apps/web/app/api/flights/search/route.ts
+++ b/apps/web/app/api/flights/search/route.ts
@@ -37,7 +37,14 @@ export async function GET(req: NextRequest) {
   url.searchParams.set('departure_id', origin)
   url.searchParams.set('arrival_id', destination)
   url.searchParams.set('outbound_date', date)
-  if (returnDate) url.searchParams.set('return_date', returnDate)
+  if (returnDate) {
+    url.searchParams.set('return_date', returnDate)
+  } else {
+    // SerpAPI defaults to type=1 (round trip), which 400s without
+    // return_date. Mark one-way explicitly when the caller didn't supply
+    // a return date.
+    url.searchParams.set('type', '2')
+  }
   url.searchParams.set('adults', passengers)
   url.searchParams.set('travel_class', String(CABIN_MAP[cabin] || 1))
   url.searchParams.set('currency', 'USD')

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -419,7 +419,7 @@ export async function forkTrip(tripId: string): Promise<Trip> {
 export async function fetchPublicTrips(): Promise<Trip[]> {
   const { data, error } = await supabase
     .from('trips')
-    .select('*, profiles!trips_user_id_fkey(display_name, avatar_url)')
+    .select('*, profiles!user_id(display_name, avatar_url)')
     .eq('visibility', 'public')
     .order('created_at', { ascending: false });
   if (error) throw error;

--- a/packages/shared/src/services/packingService.ts
+++ b/packages/shared/src/services/packingService.ts
@@ -19,7 +19,11 @@ import type { DbPackingItem, PackingAuditEntry, PackingSuggestion } from '../typ
 export async function fetchPackingItems(tripId: string): Promise<DbPackingItem[]> {
   const { data, error } = await supabase
     .from('packing_items')
-    .select('*, user:profiles!packing_items_user_id_fkey(display_name, avatar_url), owner:profiles!packing_items_owner_id_fkey(display_name)')
+    // Use the column-name disambiguator form (`profiles!user_id`) instead
+    // of the explicit FK constraint name. PostgREST stopped resolving the
+    // `packing_items_user_id_fkey` hint on prod, returning 400 — same root
+    // cause as the trip_collaborators FK fix in #765.
+    .select('*, user:profiles!user_id(display_name, avatar_url), owner:profiles!owner_id(display_name)')
     .eq('trip_id', tripId)
     .order('category')
     .order('sort_order', { ascending: true })
@@ -45,7 +49,7 @@ export async function fetchPackingItems(tripId: string): Promise<DbPackingItem[]
 export async function fetchPackingAuditLog(tripId: string, limit = 50): Promise<PackingAuditEntry[]> {
   const { data, error } = await supabase
     .from('packing_audit_log')
-    .select('*, user:profiles!packing_audit_log_user_id_fkey(display_name,email), target:profiles!packing_audit_log_target_user_id_fkey(display_name,email)')
+    .select('*, user:profiles!user_id(display_name,email), target:profiles!target_user_id(display_name,email)')
     .eq('trip_id', tripId)
     .order('created_at', { ascending: false })
     .limit(limit)


### PR DESCRIPTION
## Summary
Four production regressions surfaced after #767 deployed to dev:

1. **Packing list \"failed to load\"** — `fetchPackingItems` and `fetchPackingAuditLog` used explicit FK constraint hints (`packing_items_user_id_fkey`, etc.) that PostgREST no longer resolves on prod. Same root cause as #765 (which fixed `trip_collaborators_user_id_fkey`). Switched to the column-name disambiguator form (`profiles!user_id`, `profiles!owner_id`).

2. **/explore page 400** — `fetchPublicTrips` had the same FK-hint pattern (`profiles!trips_user_id_fkey`). Same fix.

3. **Flight search returns zero results** — `/api/flights/search` proxies to SerpAPI's google_flights, which defaults to `type=1` (Round trip) and 400s without a `return_date`. Added `type=2` fallback when no return date supplied. Also the web flights hook now passes `trip.end_date` as `return` when present so round-trip search runs as intended.

4. **Mobile-uploaded avatar didn't appear on web** — mobile profile save only wrote `profiles.preferences.avatar_url` (a JSONB sub-key). Web reads canonical `profiles.avatar_url`. `handleSave` now mirrors the pending avatar to the top-level column.

## Test plan
- [ ] Web: open a trip → Packing tab → confirm items load (or seeded for new trip).
- [ ] Web: visit /explore → no 400 in console; public trips render.
- [ ] Web: open a trip → Flights tab → run a search → confirm flights are returned (round-trip when trip has end_date, one-way otherwise).
- [ ] Mobile: change avatar → save → reload web → confirm new avatar shows.