### PR TITLE
fix: packing 500, /explore 400, expo-preview workflow Node 20

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          # eas-cli 18+ requires Node 20+. Was pinned to 18 here, which
+          # made every push to develop fail with "engine node ... Expected
+          # version >=20.0.0" while installing eas-cli@18.11.
+          node-version: 20
           cache: 'npm'
 
       - name: Setup Expo

--- a/packages/shared/src/services/api.ts
+++ b/packages/shared/src/services/api.ts
@@ -417,13 +417,30 @@ export async function forkTrip(tripId: string): Promise<Trip> {
  * Fetch all public trips (for explore page)
  */
 export async function fetchPublicTrips(): Promise<Trip[]> {
-  const { data, error } = await supabase
+  // The previous `profiles!user_id(...)` PostgREST embed 400s on prod
+  // because the relation between `trips.user_id` and `public.profiles`
+  // isn't reliably resolvable (trips.user_id FKs to auth.users; the
+  // public.profiles row is keyed by the same id but PostgREST can't
+  // always follow that). Fetch trips first, then batch-fetch the
+  // referenced profiles in a single follow-up query and merge.
+  const { data: trips, error } = await supabase
     .from('trips')
-    .select('*, profiles!user_id(display_name, avatar_url)')
+    .select('*')
     .eq('visibility', 'public')
     .order('created_at', { ascending: false });
   if (error) throw error;
-  return data ?? [];
+  const rows = (trips ?? []) as Trip[];
+  const userIds = Array.from(new Set(rows.map((t) => t.user_id).filter(Boolean)));
+  if (userIds.length === 0) return rows;
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, display_name, avatar_url')
+    .in('id', userIds);
+  const byId = new Map((profiles ?? []).map((p: any) => [p.id, p]));
+  return rows.map((t) => ({
+    ...t,
+    profiles: byId.get(t.user_id) ?? null,
+  })) as Trip[];
 }
 
 /**

--- a/packages/shared/src/services/packingService.ts
+++ b/packages/shared/src/services/packingService.ts
@@ -17,24 +17,35 @@ import type { DbPackingItem, PackingAuditEntry, PackingSuggestion } from '../typ
  * @throws PostgrestError if the query fails
  */
 export async function fetchPackingItems(tripId: string): Promise<DbPackingItem[]> {
+  // The PostgREST embed of profiles via `packing_items_user_id_fkey` /
+  // `profiles!user_id` was returning 400 (FK hint) and then 500 (column
+  // disambiguator) on prod. Bypass the relation resolution entirely:
+  // fetch items, then batch-fetch the referenced profiles in one query.
   const { data, error } = await supabase
     .from('packing_items')
-    // Use the column-name disambiguator form (`profiles!user_id`) instead
-    // of the explicit FK constraint name. PostgREST stopped resolving the
-    // `packing_items_user_id_fkey` hint on prod, returning 400 — same root
-    // cause as the trip_collaborators FK fix in #765.
-    .select('*, user:profiles!user_id(display_name, avatar_url), owner:profiles!owner_id(display_name)')
+    .select('*')
     .eq('trip_id', tripId)
     .order('category')
     .order('sort_order', { ascending: true })
   if (error) throw error
-  return (data ?? []).map((row: any) => ({
+  const rows = (data ?? []) as any[]
+  const ids = Array.from(new Set([
+    ...rows.map((r) => r.user_id),
+    ...rows.map((r) => r.owner_id),
+  ].filter(Boolean)))
+  let byId = new Map<string, any>()
+  if (ids.length > 0) {
+    const { data: profs } = await supabase
+      .from('profiles')
+      .select('id, display_name, avatar_url')
+      .in('id', ids)
+    byId = new Map((profs ?? []).map((p: any) => [p.id, p]))
+  }
+  return rows.map((row: any) => ({
     ...row,
-    user_display_name: row.user?.display_name ?? null,
-    user_avatar_url: row.user?.avatar_url ?? null,
-    owner_display_name: row.owner?.display_name ?? null,
-    user: undefined,
-    owner: undefined,
+    user_display_name: byId.get(row.user_id)?.display_name ?? null,
+    user_avatar_url: byId.get(row.user_id)?.avatar_url ?? null,
+    owner_display_name: row.owner_id ? (byId.get(row.owner_id)?.display_name ?? null) : null,
   }))
 }
 
@@ -47,19 +58,33 @@ export async function fetchPackingItems(tripId: string): Promise<DbPackingItem[]
  * @throws PostgrestError if the query fails
  */
 export async function fetchPackingAuditLog(tripId: string, limit = 50): Promise<PackingAuditEntry[]> {
+  // Same approach as fetchPackingItems — drop the embedded profile join,
+  // batch-fetch profiles separately so this is resilient to PostgREST FK
+  // resolution quirks.
   const { data, error } = await supabase
     .from('packing_audit_log')
-    .select('*, user:profiles!user_id(display_name,email), target:profiles!target_user_id(display_name,email)')
+    .select('*')
     .eq('trip_id', tripId)
     .order('created_at', { ascending: false })
     .limit(limit)
   if (error) throw error
-  return (data ?? []).map((row: any) => ({
+  const rows = (data ?? []) as any[]
+  const ids = Array.from(new Set([
+    ...rows.map((r) => r.user_id),
+    ...rows.map((r) => r.target_user_id),
+  ].filter(Boolean)))
+  let byId = new Map<string, any>()
+  if (ids.length > 0) {
+    const { data: profs } = await supabase
+      .from('profiles')
+      .select('id, display_name, email')
+      .in('id', ids)
+    byId = new Map((profs ?? []).map((p: any) => [p.id, p]))
+  }
+  return rows.map((row: any) => ({
     ...row,
-    user_display_name: row.user?.display_name ?? row.user?.email ?? null,
-    target_display_name: row.target?.display_name ?? row.target?.email ?? null,
-    user: undefined,
-    target: undefined,
+    user_display_name: byId.get(row.user_id)?.display_name ?? byId.get(row.user_id)?.email ?? null,
+    target_display_name: row.target_user_id ? (byId.get(row.target_user_id)?.display_name ?? byId.get(row.target_user_id)?.email ?? null) : null,
   }))
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #768 — three issues caught while testing on dev:

1. **Packing list still failing (500 instead of 400)** — the `profiles!user_id` column-disambiguator I tried in #768 fixed `fetchCollaborators` (#765's pattern) but does NOT work for `packing_items` or `packing_audit_log`. Replaced the embedded join with a two-step fetch: load items → batch-fetch profiles by id → merge. Resilient to whatever FK quirk PostgREST is hitting on prod.
2. **/explore still 400** — same FK relation problem on `trips.user_id` → `public.profiles`. Same drop-join-batch-fetch pattern applied to `fetchPublicTrips`.
3. **Expo Preview workflow crashing every push to develop** — eas-cli@18.11 requires Node ≥20, but `.github/workflows/expo-preview.yml` was pinned to Node 18 (build was failing with `engine node ... Expected version >=20.0.0`). Bumped to Node 20 to match the Deploy workflow. This is what's been causing the \"merged to main crashed the build\" appearance — actually the Expo Preview workflow on develop pushes.

## Test plan
- [ ] Packing tab on dev loads (no 500), seeds default items for new trips.
- [ ] /explore on dev no longer 400s in console; public trip cards render with author avatars.
- [ ] Next push to develop kicks off Expo Preview workflow that succeeds (Node 20 + eas-cli install OK).