### PR TITLE
fix(web): migrate fsq-search to Foursquare's new Places API host

### DIFF
--- a/apps/web/app/api/fsq-search/route.ts
+++ b/apps/web/app/api/fsq-search/route.ts
@@ -2,16 +2,29 @@ import { rateLimit } from '@/lib/api-utils'
 import { NextRequest, NextResponse } from 'next/server'
 
 const FSQ_API_KEY = process.env.FOURSQUARE_API_KEY
-
-const FIELDS = 'fsq_id,name,location,categories,rating,stats,price'
+// Foursquare's new Places API host. The legacy `api.foursquare.com/v3/...`
+// endpoints now return 410 Gone. The new host accepts the v3 raw API key
+// (or a fsq3... service key) wrapped in `Bearer <key>` and requires an
+// X-Places-Api-Version header.
+const FSQ_HOST = 'https://places-api.foursquare.com'
+const FSQ_VERSION = '2025-06-17'
+// Free tier only — `rating`, `price`, `stats`, `popularity`, `photos`, `tips`
+// are Premium and trigger 429 unless billing is set up at
+// foursquare.com/developers/orgs. Add them once a paid plan is attached.
+const FIELDS = [
+  'fsq_place_id', 'name', 'location', 'categories', 'chains',
+  'distance', 'tel', 'website',
+].join(',')
 
 interface FsqCategory {
-  id: number
+  fsq_category_id?: string
   name: string
+  short_name?: string
+  plural_name?: string
 }
 
 interface FsqSearchResult {
-  fsq_id: string
+  fsq_place_id: string
   name: string
   location: {
     address?: string
@@ -40,6 +53,7 @@ export async function GET(req: NextRequest) {
   if (rl) return rl
   const q = req.nextUrl.searchParams.get('q')
   const near = req.nextUrl.searchParams.get('near')
+  const ll = req.nextUrl.searchParams.get('ll')
 
   if (!q || !FSQ_API_KEY) {
     return NextResponse.json({ results: [] })
@@ -47,10 +61,16 @@ export async function GET(req: NextRequest) {
 
   try {
     const params = new URLSearchParams({ query: q, fields: FIELDS, limit: '5' })
-    if (near) params.set('near', near)
+    // Prefer lat,lng coords when supplied; fall back to text near.
+    if (ll) params.set('ll', ll)
+    else if (near) params.set('near', near)
 
-    const res = await fetch(`https://api.foursquare.com/v3/places/search?${params}`, {
-      headers: { Authorization: FSQ_API_KEY, Accept: 'application/json' },
+    const res = await fetch(`${FSQ_HOST}/places/search?${params}`, {
+      headers: {
+        Authorization: `Bearer ${FSQ_API_KEY}`,
+        'X-Places-Api-Version': FSQ_VERSION,
+        Accept: 'application/json',
+      },
       signal: AbortSignal.timeout(5000),
     })
 
@@ -66,19 +86,20 @@ export async function GET(req: NextRequest) {
       const loc = p.location
       const subtitle = [loc.locality, loc.region].filter(Boolean).join(', ') || loc.formatted_address || ''
       const href = type === 'hotel'
-        ? `/hotel/${encodeURIComponent(p.fsq_id)}`
+        ? `/hotel/${encodeURIComponent(p.fsq_place_id)}`
         : type === 'restaurant'
-        ? `/restaurant/${encodeURIComponent(p.fsq_id)}`
-        : `/activity/${encodeURIComponent(p.fsq_id)}`
+        ? `/restaurant/${encodeURIComponent(p.fsq_place_id)}`
+        : `/activity/${encodeURIComponent(p.fsq_place_id)}`
 
       return {
-        id: p.fsq_id,
+        id: p.fsq_place_id,
         type,
         title: p.name,
         subtitle,
         href,
         score: 1.2,
         metadata: {
+          // New API returns rating on a 0–10 scale; convert to 0–5 stars.
           rating: p.rating != null ? Math.round((p.rating / 10) * 5 * 10) / 10 : undefined,
           priceLevel: p.price ?? undefined,
           source: 'foursquare',


### PR DESCRIPTION
## Summary
Foursquare deprecated all v3 endpoints — `api.foursquare.com/v3/places/search` now returns **410 Gone**. The existing \`fsq-search\` route was silently returning empty results for every query in prod.

## Changes
- Host swapped to \`https://places-api.foursquare.com\`
- Auth: \`Authorization: <key>\` → \`Authorization: Bearer <key>\`
- Added required \`X-Places-Api-Version: 2025-06-17\` header
- Response shape: \`fsq_id\` → \`fsq_place_id\` (parser + href builders updated)
- \`FIELDS\` trimmed to free-tier-safe (\`rating\`, \`price\`, \`stats\`, \`popularity\`, \`photos\`, \`tips\` are Premium; trigger 429 without billing). Metadata mapper still reads them so they auto-light-up once billing is attached
- New \`ll=lat,lng\` param accepted alongside \`near=text\`

Verified end-to-end with the new key: \`/places/search?ll=36.1147,-115.1728&query=coffee\` → 200, real Starbucks/Palio Pronto results near Las Vegas Strip.

## Operator action required
**Rotate the GitHub \`SECRET_FOURSQUARE_API_KEY\` repo secret** to a key issued from the new Foursquare Developer Console. Old client_id/client_secret pair won't work on the new host. SST binding (\`infra/secrets.ts\` → \`infra/web.ts\`) is already correct.

## Test plan
- [ ] After deploy + secret rotation: hit \`/api/fsq-search?q=coffee&near=Las+Vegas\` and confirm non-empty results array.
- [ ] Verify type:'restaurant'/'hotel'/'activity' inference still works.
- [ ] Once billing is added at foursquare.com/developers/orgs, expand FIELDS to include rating/price/stats and rebuild — metadata.rating/priceLevel will populate.