### PR TITLE
fix(web): unblock SST build (missing PlaceholderAvatar, homepage sections, ThemePicker props)

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -12,7 +12,6 @@ import { savePlanToSupabase } from "@travyl/shared/src/services/api";
 import { PaperPlane } from "@/components/icons/PaperPlane";
 import { TypeWriter } from "@/components/TypeWriter";
 import { useCyclingPlaceholder } from "@/hooks/useCyclingPlaceholder";
-import { SafeImage } from "@/components/ui/SafeImage";
 import dynamic from "next/dynamic";
 
 const TakeoffTransition = dynamic(
@@ -27,32 +26,17 @@ const ProductDemo = dynamic(
   () => import("@/components/home/ProductDemo").then((m) => ({ default: m.ProductDemo })),
   { ssr: false }
 );
-const UseCases = dynamic(
-  () => import("@/components/home/UseCases").then((m) => ({ default: m.UseCases })),
-  { ssr: false }
-);
+// `UseCases`, `PressStats`, `PressMarquee`, `FinalCTA`, `MobileShowcase`
+// were imported here from `bcaba4e7 feat: UI homogenization` but the
+// component files themselves were never committed. Removing the imports
+// + their JSX usage below so the homepage builds; restore the imports
+// (and the corresponding sections) once the components actually land.
 const Testimonials = dynamic(
   () => import("@/components/home/Testimonials").then((m) => ({ default: m.Testimonials })),
   { ssr: false }
 );
-const PressStats = dynamic(
-  () => import("@/components/home/PressStats").then((m) => ({ default: m.PressStats })),
-  { ssr: false }
-);
-const PressMarquee = dynamic(
-  () => import("@/components/home/PressMarquee").then((m) => ({ default: m.PressMarquee })),
-  { ssr: false }
-);
-const FinalCTA = dynamic(
-  () => import("@/components/home/FinalCTA").then((m) => ({ default: m.FinalCTA })),
-  { ssr: false }
-);
 const TagUs = dynamic(
   () => import("@/components/home/TagUs").then((m) => ({ default: m.TagUs })),
-  { ssr: false }
-);
-const MobileShowcase = dynamic(
-  () => import("@/components/home/MobileShowcase").then((m) => ({ default: m.MobileShowcase })),
   { ssr: false }
 );
 
@@ -959,15 +943,6 @@ export default function Home() {
 
       </section>
 
-      {/* ─── Use Cases — warm sand ────────────────────────── */}
-      <UseCases />
-
-      {/* ─── Stats — trust signals ────────────────────────── */}
-      <PressStats statsOnly />
-
-      {/* ─── Press Marquee — As Seen In ──────────────────── */}
-      <PressMarquee />
-
       {/* ─── Product Demo — existing, dark bg ─────────────── */}
       <ProductDemo />
 
@@ -976,12 +951,6 @@ export default function Home() {
 
       {/* ─── Tag Us — social feed ─────────────────────────── */}
       <TagUs />
-
-      {/* ─── Final CTA — full-bleed dark ──────────────────── */}
-      <FinalCTA />
-
-      {/* ─── Mobile Showcase — iOS device mockup ───────────── */}
-      <MobileShowcase />
 
       {/* ─── Footer ────────────────────────────────────────── */}
       <Footer />

--- a/apps/web/components/trip/ThemePicker.tsx
+++ b/apps/web/components/trip/ThemePicker.tsx
@@ -56,14 +56,18 @@ interface ThemePickerProps {
   currentTheme: string;
   customColor?: string | null;
   onSelectTheme: (themeId: string, customColor?: string) => void;
-  tabColors: Record<string, string>;
-  tabColorOverrides: Record<string, string>;
-  onTabColorChange: (tabName: string, color: string) => void;
-  onResetTabColors: () => void;
-  itineraryColors: TripTheme['itineraryColors'];
-  itineraryColorOverrides: Record<string, string>;
-  onItineraryColorChange: (section: string, color: string) => void;
-  onResetItineraryColors: () => void;
+  // The per-tab and per-itinerary-section color customization is opt-in:
+  // when callers don't pass setters (current settings page case), those
+  // sections of the picker are hidden and the picker just shows the
+  // base theme grid + custom hex input.
+  tabColors?: Record<string, string>;
+  tabColorOverrides?: Record<string, string>;
+  onTabColorChange?: (tabName: string, color: string) => void;
+  onResetTabColors?: () => void;
+  itineraryColors?: TripTheme['itineraryColors'];
+  itineraryColorOverrides?: Record<string, string>;
+  onItineraryColorChange?: (section: string, color: string) => void;
+  onResetItineraryColors?: () => void;
 }
 
 export function ThemePicker({
@@ -79,6 +83,8 @@ export function ThemePicker({
   onItineraryColorChange,
   onResetItineraryColors,
 }: ThemePickerProps) {
+  const showTabColors = !!(tabColors && tabColorOverrides && onTabColorChange && onResetTabColors);
+  const showItineraryColors = !!(itineraryColors && itineraryColorOverrides && onItineraryColorChange && onResetItineraryColors);
   const [showCustom, setShowCustom] = useState(currentTheme === 'custom');
   const [hexInput, setHexInput] = useState(customColor ?? '#3498db');
   const [editingTab, setEditingTab] = useState<string | null>(null);
@@ -187,10 +193,11 @@ export function ThemePicker({
       </div>
 
       {/* ── Day Colors ── */}
+      {showItineraryColors && (
       <div>
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-sm font-semibold text-gray-900">Day Colors</h3>
-          {Object.keys(itineraryColorOverrides).length > 0 && (
+          {Object.keys(itineraryColorOverrides!).length > 0 && (
             <button onClick={onResetItineraryColors} className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 transition">
               <RotateCcw size={11} />
               Reset
@@ -199,7 +206,7 @@ export function ThemePicker({
         </div>
         <div className="flex flex-wrap gap-2">
           {DAY_SECTIONS.map(({ key, label, icon: Icon }) => {
-            const color = itineraryColorOverrides[key] ?? itineraryColors[key as keyof typeof itineraryColors] ?? '#1e3a5f';
+            const color = itineraryColorOverrides![key] ?? itineraryColors![key as keyof typeof itineraryColors] ?? '#1e3a5f';
             const isEditing = editingDay === key;
             return (
               <button
@@ -225,11 +232,11 @@ export function ThemePicker({
             </p>
             <div className="flex flex-wrap gap-2">
               {COLOR_SWATCHES.map((color) => {
-                const isActive = (itineraryColorOverrides[editingDay] ?? itineraryColors[editingDay as keyof typeof itineraryColors]) === color;
+                const isActive = (itineraryColorOverrides![editingDay] ?? itineraryColors![editingDay as keyof typeof itineraryColors]) === color;
                 return (
                   <button
                     key={color}
-                    onClick={() => onItineraryColorChange(editingDay, color)}
+                    onClick={() => onItineraryColorChange!(editingDay, color)}
                     className="w-8 h-8 rounded-lg flex items-center justify-center transition-all"
                     style={{
                       backgroundColor: color,
@@ -244,12 +251,14 @@ export function ThemePicker({
           </div>
         )}
       </div>
+      )}
 
       {/* ── Tab Colors ── */}
+      {showTabColors && (
       <div>
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-sm font-semibold text-gray-900">Tab Colors</h3>
-          {Object.keys(tabColorOverrides).length > 0 && (
+          {Object.keys(tabColorOverrides!).length > 0 && (
             <button onClick={onResetTabColors} className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 transition">
               <RotateCcw size={11} />
               Reset
@@ -258,7 +267,7 @@ export function ThemePicker({
         </div>
         <div className="flex flex-wrap gap-2">
           {TAB_LIST.map(({ name, title, icon: Icon }) => {
-            const color = tabColorOverrides[name] ?? tabColors[name] ?? '#1e3a5f';
+            const color = tabColorOverrides![name] ?? tabColors![name] ?? '#1e3a5f';
             const isEditing = editingTab === name;
             return (
               <button
@@ -284,11 +293,11 @@ export function ThemePicker({
             </p>
             <div className="flex flex-wrap gap-2">
               {COLOR_SWATCHES.map((color) => {
-                const isActive = (tabColorOverrides[editingTab] ?? tabColors[editingTab]) === color;
+                const isActive = (tabColorOverrides![editingTab] ?? tabColors![editingTab]) === color;
                 return (
                   <button
                     key={color}
-                    onClick={() => onTabColorChange(editingTab, color)}
+                    onClick={() => onTabColorChange!(editingTab, color)}
                     className="w-8 h-8 rounded-lg flex items-center justify-center transition-all"
                     style={{
                       backgroundColor: color,
@@ -303,6 +312,7 @@ export function ThemePicker({
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/ui/PlaceholderAvatar.tsx
+++ b/apps/web/components/ui/PlaceholderAvatar.tsx
@@ -1,0 +1,48 @@
+/**
+ * PlaceholderAvatar — gradient circle shown when a user has no avatar_url.
+ *
+ * The component was referenced from `bcaba4e7 feat: UI homogenization` but
+ * the file was never committed; rather than scatter inline placeholder
+ * markup across the 3 consumers (GlobalNavbar, profile/page, user/page),
+ * we restore the component with the obvious implementation: deterministic
+ * gradient seeded by userId so the same user always gets the same color
+ * across the app, with a static fallback for anon users.
+ */
+
+interface Props {
+  userId?: string | null
+  size?: number
+}
+
+const GRADIENTS = [
+  ['#1e3a5f', '#3b82f6'],
+  ['#7c3aed', '#a855f7'],
+  ['#059669', '#10b981'],
+  ['#d97706', '#f59e0b'],
+  ['#dc2626', '#f87171'],
+  ['#0891b2', '#06b6d4'],
+  ['#be185d', '#ec4899'],
+  ['#65a30d', '#84cc16'],
+] as const
+
+function pickGradient(userId: string | null | undefined): readonly [string, string] {
+  if (!userId) return GRADIENTS[0]
+  let h = 0
+  for (let i = 0; i < userId.length; i++) h = (h * 31 + userId.charCodeAt(i)) | 0
+  return GRADIENTS[Math.abs(h) % GRADIENTS.length]
+}
+
+export function PlaceholderAvatar({ userId, size = 32 }: Props) {
+  const [from, to] = pickGradient(userId)
+  return (
+    <div
+      aria-hidden
+      className="rounded-full"
+      style={{
+        width: size,
+        height: size,
+        background: `linear-gradient(135deg, ${from}, ${to})`,
+      }}
+    />
+  )
+}

--- a/infra/api.ts
+++ b/infra/api.ts
@@ -339,8 +339,15 @@ api.route('GET /places/nearby', {
   timeout: '15 seconds',
 })
 
-api.route('GET /api/places/{id}', {
-  handler: 'services/place-detail.handler',
-  link: [foursquareApiKey],
-  timeout: '10 seconds',
-})
+// `services/place-detail.handler` was added by `bcaba4e7 feat: UI
+// homogenization` but the handler file itself was never committed —
+// SST then refused to deploy with "Handler not found". The Next.js
+// route at `apps/web/app/api/search/place-detail/route.ts` already
+// covers the same surface for the web app, so commenting this Lambda
+// out doesn't lose any user-visible functionality. Restore once the
+// real `services/place-detail.ts` lands.
+// api.route('GET /api/places/{id}', {
+//   handler: 'services/place-detail.handler',
+//   link: [foursquareApiKey],
+//   timeout: '10 seconds',
+// })


### PR DESCRIPTION
## Summary
After #778 fixed the lockfile, the next dev Deploy failed on Next.js build because \`bcaba4e7 feat: UI homogenization\` had referenced 6 web components and 1 SST handler that were never committed:

\`\`\`
Module not found: Can't resolve '@/components/home/FinalCTA'
Module not found: Can't resolve '@/components/home/MobileShowcase'
Module not found: Can't resolve '@/components/home/PressMarquee'
Module not found: Can't resolve '@/components/home/PressStats'
Module not found: Can't resolve '@/components/home/UseCases'
Module not found: Can't resolve '@/components/ui/PlaceholderAvatar'
Error: Handler not found: services/place-detail.handler
Type error: Expected 3 arguments, but got 8 (ThemePickerProps)
\`\`\`

Surgical fix — does not unwind the 30+ commits stacked on top of \`bcaba4e7\`:

1. **PlaceholderAvatar** built as a real component (\`apps/web/components/ui/PlaceholderAvatar.tsx\`). Gradient circle deterministically seeded by \`userId\` so every call site (GlobalNavbar, /profile, /user/[username]) gets a consistent per-user color. Not a stub — this is what the name means.
2. **Homepage missing sections dropped** from \`app/(main)/page.tsx\`: \`UseCases\`, \`PressStats\`, \`PressMarquee\`, \`FinalCTA\`, \`MobileShowcase\` imports + JSX removed. Homepage still renders Hero → ProductDemo → Testimonials → TagUs → Footer. Restore them when the components actually land.
3. **ThemePicker color customizer props made optional**. The new tab/day color editor needs setters that \`useTripTheme()\` never exposed. Sections now render only when handlers are wired through; settings page works unchanged.
4. **\`services/place-detail.handler\`** SST Lambda commented out — file never committed. The Next.js route at \`app/api/search/place-detail/route.ts\` already covers the same surface.

## Verified locally
- \`npm ci\` clean (1382 packages, postinstall \`patch-package\` runs)
- \`npx next build\` completes — all routes generated, no errors

## Test plan
- [ ] Merge → next develop push → Deploy succeeds → dev rebuilds.
- [ ] dev.gotravyl.com homepage renders without missing-section gaps.
- [ ] Avatars (anonymous + signed in) show gradient circles in nav.
- [ ] Trip → Settings → Theme tab still works (only base themes visible; no Day Colors / Tab Colors sections until store is extended).