### PR TITLE
Prod: Bring places/FastAPI fix + rescope TS sig fix to main

### DIFF
--- a/apps/web/app/api/places/route.ts
+++ b/apps/web/app/api/places/route.ts
@@ -8,7 +8,11 @@ import {
 import { filterByRadius } from '@/lib/haversine'
 import { createServerClient } from '@supabase/ssr'
 
-const API_URL = process.env.NEXT_PUBLIC_RECOMMENDATION_API_URL
+// FastAPI backend (EC2, separate from SST API Gateway). The SST APIGW
+// exposes `/places/nearby` (no `/api` prefix) and requires auth, whereas
+// FastAPI serves `/api/places/nearby` openly — and that's the path this
+// route hits. Defaults to staging so local dev works without env config.
+const API_URL = process.env.FASTAPI_URL || 'https://api.dev.gotravyl.com'
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)!
 

--- a/apps/web/components/calendar/hooks/useRescope.ts
+++ b/apps/web/components/calendar/hooks/useRescope.ts
@@ -19,8 +19,10 @@ export type RescoperStatus = 'idle' | 'pending-conflict' | 'loading' | 'error'
 export interface UseRescopeReturn {
   status: RescoperStatus
   conflicts: CalendarActivity[]
-  // oldStartDate / oldEndDate tell the hook how to classify the change
-  rescope: (patch: RescopePatch, oldStartDate: Date, oldEndDate: Date) => void
+  // oldStartDate / oldEndDate tell the hook how to classify the change.
+  // oldDestination is logged into itinerary_edits so the audit log shows
+  // what the destination used to be when this rescope happened.
+  rescope: (patch: RescopePatch, oldStartDate: Date, oldEndDate: Date, oldDestination: string) => void
   confirmRescope: (resolution: ConflictResolution) => Promise<void>
   cancelRescope: () => void
 }


### PR DESCRIPTION
## Summary
- Brings the dev-side places/route.ts fix (use FASTAPI_URL fallback) to main so prod hits the FastAPI backend at `/api/places/nearby` (path that exists on FastAPI but 404s on SST APIGW).
- Brings the rescope type-signature fix (`useRescope.ts`) — already on develop as `a46d31bb` — that's been blocking Amplify's `main` build since 2026-05-03 with `Type error: Expected 3 arguments, but got 4`.

## Why target main
PRs normally target develop, but these two changes are needed on main for the next Amplify deploy to succeed and for the explore page on www.gotravyl.com to keep functioning if Amplify env vars change.

## Test plan
- [ ] After merge: confirm Amplify build for main succeeds (last 2 builds failed at TypeScript step)
- [ ] After deploy: hit https://www.gotravyl.com/api/places?lat=37.7749&lng=-122.4194&category=attraction&limit=3 — should return populated list
- [ ] Repeat for restaurant, museum, park, nightlife, cafe categories
- [ ] Optional follow-up: set FASTAPI_URL=https://api.gotravyl.com on Amplify env vars so prod hits prod FastAPI backend rather than dev fallback