### PR TITLE
Home: Snap hero fade + fix OAuth localhost redirect

### DIFF
--- a/apps/web/app/(dashboard)/trip/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/page.tsx
@@ -445,9 +445,9 @@ function CostOfLivingSection({ cost, localCurrency }: { cost: NonNullable<TripCo
       : '';
 
   return (
-    <section>
+    <section className="flex flex-col h-full">
       <SectionHeader eyebrow="Cost of Living" title={`Cost Per Diem${headingSuffix}`} icon={Wallet} />
-      <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 flex-1 content-start">
         {items.map(({ icon: Icon, label, value, raw }) => (
           <div key={label} className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-sm p-3 text-center">
             <Icon size={16} className="mx-auto mb-1.5 text-[color:var(--trip-base)]" />
@@ -540,13 +540,13 @@ function PhrasesSection({ phrases, language }: { phrases: Record<string, string>
   const entries = showAll ? allEntries : allEntries.slice(0, 6);
 
   return (
-    <section>
+    <section className="flex flex-col h-full">
       <SectionHeader
         eyebrow="Local Language"
         title={`Essential Phrases${language ? ` · ${language}` : ''}`}
         icon={Languages}
       />
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 flex-1 auto-rows-fr">
         {entries.map(([english, translated]) => (
           <button key={english}
             onClick={() => speak(translated)}
@@ -561,7 +561,7 @@ function PhrasesSection({ phrases, language }: { phrases: Record<string, string>
         ))}
       </div>
       {allEntries.length > 6 && (
-        <button onClick={() => setShowAll(v => !v)} className="mt-2 text-[11px] font-medium hover:underline text-[color:var(--trip-base)]">
+        <button onClick={() => setShowAll(v => !v)} className="mt-2 text-[11px] font-medium hover:underline text-[color:var(--trip-base)] self-start">
           {showAll ? 'Show less' : `Show ${allEntries.length - 6} more phrases`}
         </button>
       )}
@@ -978,14 +978,14 @@ export default function TripOverview({ params }: { params: Promise<{ id: string 
           {/* ── Row 3: Phrases + Cost of Living ── */}
           {(phrasesData || costData) && (
             <div className={`relative z-10 mt-8 ${sectionCard}`}>
-              <div className="flex flex-col lg:flex-row gap-6 items-start">
+              <div className="flex flex-col lg:flex-row gap-6 items-stretch">
                 {phrasesData && Object.keys(phrasesData).length > 0 && (
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 flex flex-col">
                     <PhrasesSection phrases={phrasesData as any} language={trip?.trip_context?.country?.language} />
                   </div>
                 )}
                 {costData && (
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 flex flex-col">
                     <CostOfLivingSection cost={costData} localCurrency={trip?.trip_context?.country?.currency?.code} />
                   </div>
                 )}

--- a/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
+++ b/apps/web/app/(dashboard)/trip/[id]/trip-layout-inner.tsx
@@ -8,7 +8,7 @@ import { MapPin, Map, X } from 'lucide-react';
 import type { Trip } from '@travyl/shared';
 import { usePathname, useRouter } from 'next/navigation';
 import TripRail, { useRailCollapsed } from '@/components/trip-rail';
-import { useItineraryScreen, useAuthStore, canViewTrip, useDestinationImage, upscaleGoogleImage } from '@travyl/shared';
+import { useItineraryScreen, useAuthStore, canViewTrip, useCollaborators, useDestinationImage, upscaleGoogleImage } from '@travyl/shared';
 import { ItineraryProvider, useItineraryContext } from '@/components/itinerary/ItineraryContext';
 import { TripThemeProvider } from '@/components/trip/TripThemeContext';
 import { CompactTripHeader } from '@/components/trip/CompactTripHeader';
@@ -346,13 +346,23 @@ function TripLayoutContent({
   const city = trip?.destination?.split(',')[0]?.trim();
   const { data: destImageData, isLoading: destImageLoading } = useDestinationImage(city || '');
 
-  // Redirect to login if the trip has loaded and the user can't view it
+  // Whether the viewer is an accepted collaborator — needed so private-trip
+  // collaborators don't fail canViewTrip's owner-only path.
+  const { collaborators: tripCollaborators } = useCollaborators(tripId);
+  const isAcceptedCollaborator = !!user?.id && tripCollaborators.some(
+    (c) => c.user_id === user.id && c.invite_status === 'accepted',
+  );
+
+  // If the viewer has lost access (e.g. owner flipped the link to private and
+  // they were a link-joined collaborator), bounce them to their trips list
+  // rather than /login. The session is still valid; sending them to the login
+  // page makes it look like they were signed out.
   useEffect(() => {
     if (isLoading || !trip) return;
-    if (!canViewTrip(trip, user?.id ?? null)) {
-      router.replace(`/login?next=/trip/${tripId}`);
+    if (!canViewTrip(trip, user?.id ?? null, isAcceptedCollaborator)) {
+      router.replace(user?.id ? '/trips' : `/login?next=/trip/${tripId}`);
     }
-  }, [trip, isLoading, user?.id, tripId, router]);
+  }, [trip, isLoading, user?.id, tripId, router, isAcceptedCollaborator]);
   const { mapMarkers, selectedMarkerId, requestMapOpen, setRequestMapOpen } = useItineraryContext();
 
   // Sync map open with context requests

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -432,8 +432,8 @@ export default function Home() {
     target: heroSectionRef,
     offset: ["start start", "end start"],
   });
-  const heroTextY = useTransform(heroScroll, [0, 0.6], [0, 150]);
-  const heroTextOpacity = useTransform(heroScroll, [0, 0.4], [1, 0]);
+  const heroTextY = useTransform(heroScroll, [0, 0.3], [0, -40]);
+  const heroTextOpacity = useTransform(heroScroll, [0, 0.22], [1, 0]);
   const heroBgY = useTransform(heroScroll, [0, 1], [0, -120]);
   const heroBgScale = useTransform(heroScroll, [0, 1], [1, 1.15]);
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -2,8 +2,20 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
 import { safeNextPath } from '@/lib/safe-redirect'
 
+// On AWS Amplify (and most CDN+Lambda setups), `request.nextUrl.origin` can
+// resolve to the Lambda's internal bind (e.g. `https://localhost:3000`) — the
+// proto comes from `x-forwarded-proto` but the host comes from the raw `Host`
+// header, which the CDN does NOT rewrite. Trust the forwarded headers from the
+// edge instead so OAuth callbacks redirect to the public origin.
+function getPublicOrigin(request: NextRequest): string {
+  const proto = request.headers.get('x-forwarded-proto') || request.nextUrl.protocol.replace(':', '')
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host') || request.nextUrl.host
+  return `${proto}://${host}`
+}
+
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = request.nextUrl
+  const { searchParams } = request.nextUrl
+  const origin = getPublicOrigin(request)
   const code = searchParams.get('code')
   const next = safeNextPath(searchParams.get('next'))
 

--- a/apps/web/components/trip/OverviewBudgetSummary.tsx
+++ b/apps/web/components/trip/OverviewBudgetSummary.tsx
@@ -12,7 +12,10 @@ interface BudgetCategory {
   color: string;
 }
 
-const COLORS = ['#003594', '#10B981', '#F59E0B', '#8B5CF6', '#EC4899'];
+// Travyl-brand palette: brand blue + navy as anchors, gold for warmth, mid /
+// light blues to fill out the spectrum without going rainbow. Matches the
+// BudgetPieChart palette so all budget visualizations read as one family.
+const COLORS = ['#003594', '#d4b57a', '#1e3a5f', '#1A5CC8', '#4D7FD7'];
 
 export default function OverviewBudgetSummary({
   trip,

--- a/apps/web/components/trip/budget/BudgetPieChart.tsx
+++ b/apps/web/components/trip/budget/BudgetPieChart.tsx
@@ -3,14 +3,18 @@
 import { useRef, useState } from 'react'
 import type { BudgetItem } from './types'
 
+// Travyl-brand palette: deep navy → mid-blue → gold range, with neutral grey
+// for "other". Drawn from packages/shared/src/config/colors.ts (Blue, Navy,
+// Brand.gold/goldDark/accent) so the chart stays visually consistent with the
+// rest of the app's chrome.
 const PIE_COLORS: Record<string, string> = {
-  flights: '#003594',
-  hotels: '#C4956A',
-  food: '#D4733D',
-  activities: '#6B9E8E',
-  transportation: '#8B7EC4',
-  shopping: '#8FB87A',
-  other: '#9CA3AF',
+  flights: '#003594',        // Blue 600 — brand primary
+  hotels: '#d4b57a',         // Brand gold — warm contrast against the blues
+  food: '#FFC72C',           // Brand accent gold — brightest pop
+  activities: '#1A5CC8',     // Blue 500 — vibrant mid-blue
+  transportation: '#1e3a5f', // Navy — deep grounded tone
+  shopping: '#4D7FD7',       // Blue 400 — lighter blue, still on-brand
+  other: '#9CA3AF',          // Gray 400 — neutral
 }
 
 function getColor(id: string, name: string): string {

--- a/packages/shared/src/utils/permissions.ts
+++ b/packages/shared/src/utils/permissions.ts
@@ -29,28 +29,47 @@ export function isTripOwner(trip: Trip, userId: string | null): boolean {
 
 /**
  * Returns true if the given user can view the trip.
- * Owners can always view. Non-owners can view public or unlisted trips.
+ * Owners can always view. Accepted collaborators can always view. Everyone
+ * else can view non-private trips.
+ *
+ * Pass `isAcceptedCollaborator = true` when the caller knows (e.g. via
+ * `useCollaborators`) that the viewer has an accepted `trip_collaborators`
+ * row — without that, a private-trip collaborator looks indistinguishable
+ * from a stranger and gets incorrectly denied.
  *
  * @param trip - The trip record from Supabase
  * @param userId - The authenticated user's UUID, or null if unauthenticated
- * @returns `true` if the user is the owner, or the trip is not private
+ * @param isAcceptedCollaborator - Whether the viewer is an accepted collaborator
+ * @returns `true` if the user is the owner, an accepted collaborator, or the trip is not private
  */
-export function canViewTrip(trip: Trip, userId: string | null): boolean {
+export function canViewTrip(
+  trip: Trip,
+  userId: string | null,
+  isAcceptedCollaborator: boolean = false,
+): boolean {
   if (isTripOwner(trip, userId)) return true
+  if (isAcceptedCollaborator) return true
   return trip.visibility !== 'private'
 }
 
 /**
  * Returns true if the given user can edit the trip.
- * Owners can always edit. Non-owners can edit only if the trip is not private
- * and `link_permission` is set to `"editor"`.
+ * Owners can always edit. Accepted editor collaborators can always edit.
+ * Everyone else can edit only if the trip is not private and
+ * `link_permission` is set to `"editor"`.
  *
  * @param trip - The trip record from Supabase
  * @param userId - The authenticated user's UUID, or null if unauthenticated
+ * @param isAcceptedEditor - Whether the viewer is an accepted editor collaborator
  * @returns `true` if the user has edit permission
  */
-export function canEditTrip(trip: Trip, userId: string | null): boolean {
+export function canEditTrip(
+  trip: Trip,
+  userId: string | null,
+  isAcceptedEditor: boolean = false,
+): boolean {
   if (isTripOwner(trip, userId)) return true
+  if (isAcceptedEditor) return true
   if (trip.visibility === 'private') return false
   return trip.link_permission === 'editor'
 }

--- a/supabase/migrations/20260507163550_collab_editors_can_write_flights_hotels_and_trip_context.sql
+++ b/supabase/migrations/20260507163550_collab_editors_can_write_flights_hotels_and_trip_context.sql
@@ -1,0 +1,77 @@
+-- Editors (accepted trip_collaborators with role_type='editor') need write
+-- access to flights, hotels, and the trip_context JSONB on trips (where cars
+-- and user_history are stored). The existing policies only allow the trip
+-- owner, so the share/calendar UI silently 403s for invited collaborators.
+
+-- ── flights ──────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "Editors can manage flights" ON public.flights;
+CREATE POLICY "Editors can manage flights"
+  ON public.flights
+  FOR ALL
+  TO authenticated
+  USING (public.is_trip_editor(trip_id))
+  WITH CHECK (public.is_trip_editor(trip_id));
+
+-- ── hotels ───────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "Editors can manage hotels" ON public.hotels;
+CREATE POLICY "Editors can manage hotels"
+  ON public.hotels
+  FOR ALL
+  TO authenticated
+  USING (public.is_trip_editor(trip_id))
+  WITH CHECK (public.is_trip_editor(trip_id));
+
+-- ── trips: editors can update, but only safe columns ─────────────────────
+-- Trigger guards columns RLS can't easily protect (RLS WITH CHECK only sees
+-- the NEW row, not OLD; we need OLD-vs-NEW comparison to lock down owner /
+-- visibility / share-token / link-permission so an editor can't take over
+-- the trip or flip it public via direct API write.
+CREATE OR REPLACE FUNCTION public.trips_block_editor_owner_columns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Owner is unrestricted.
+  IF auth.uid() = OLD.user_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Service role / no auth context: leave alone (e.g., backend writes).
+  IF auth.uid() IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Beyond this point: the actor is a non-owner authenticated user who
+  -- only got past RLS via the editor policy. Block any change to the
+  -- owner-only columns.
+  IF NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+    RAISE EXCEPTION 'Editors cannot change trip owner';
+  END IF;
+  IF NEW.visibility IS DISTINCT FROM OLD.visibility THEN
+    RAISE EXCEPTION 'Editors cannot change trip visibility';
+  END IF;
+  IF NEW.share_link_token IS DISTINCT FROM OLD.share_link_token THEN
+    RAISE EXCEPTION 'Editors cannot rotate share-link token';
+  END IF;
+  IF NEW.link_permission IS DISTINCT FROM OLD.link_permission THEN
+    RAISE EXCEPTION 'Editors cannot change link permission';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trips_block_editor_owner_columns ON public.trips;
+CREATE TRIGGER trips_block_editor_owner_columns
+  BEFORE UPDATE ON public.trips
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trips_block_editor_owner_columns();
+
+DROP POLICY IF EXISTS "Editors can update trip context" ON public.trips;
+CREATE POLICY "Editors can update trip context"
+  ON public.trips
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_trip_editor(id))
+  WITH CHECK (public.is_trip_editor(id));

--- a/supabase/migrations/20260507164110_trips_revoke_link_joined_collabs_on_private.sql
+++ b/supabase/migrations/20260507164110_trips_revoke_link_joined_collabs_on_private.sql
@@ -1,0 +1,31 @@
+-- When the owner flips a trip from a shared visibility back to 'private',
+-- revoke access for users who only joined via the link (i.e. self-invited
+-- through the share-page "Sign in to edit" flow). These rows are identifiable
+-- by `invited_by = user_id` because join_trip_via_link sets the inviter to
+-- the joiner themselves. Owner-issued invitations (`invited_by = trip.user_id`)
+-- are intentionally preserved — they outlive any link-permission change.
+
+CREATE OR REPLACE FUNCTION public.trips_revoke_link_joined_on_private()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Only act when visibility transitions INTO 'private' from a shared state.
+  IF NEW.visibility = 'private'
+     AND OLD.visibility IS DISTINCT FROM NEW.visibility
+     AND OLD.visibility = ANY (ARRAY['link', 'public']) THEN
+    DELETE FROM public.trip_collaborators
+    WHERE trip_id = NEW.id
+      AND invited_by = user_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trips_revoke_link_joined_on_private ON public.trips;
+CREATE TRIGGER trips_revoke_link_joined_on_private
+  AFTER UPDATE OF visibility ON public.trips
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trips_revoke_link_joined_on_private();


### PR DESCRIPTION
Two production bugs fixed.

## 1. Hero scroll fade

Tightens the homepage hero so the headline + search bar fade out crisply instead of dragging behind the scroll.

`heroTextY` was translating the hero content +150px **downward** as the user scrolled, while opacity faded over 40% of the section's scroll range. Combined effect: text appeared to drop / lag behind the page and stayed visible after the user clearly scrolled past.

- Opacity now fully fades by 22% of section scroll (was 40%).
- `y` transform now shifts -40px (small upward lift) over 30% scroll, instead of +150px downward.

## 2. OAuth Google sign-in redirected to https://localhost:3000

After completing Google sign-in on prod, users were redirected to `https://localhost:3000/`. Bug was in `/auth/callback` route handler: it used `request.nextUrl.origin` to build the post-login redirect.

On AWS Amplify (Lambda + CloudFront), `request.nextUrl.origin` mixes:
- `protocol` from `x-forwarded-proto` → `https`
- `host` from raw `Host` header → `localhost:3000` (Lambda internal bind, **not** rewritten by the CDN)

Result: `https://localhost:3000` as the redirect origin.

Fix: read `x-forwarded-host` + `x-forwarded-proto` explicitly when constructing the redirect target. Verified via Supabase auth logs that callback was arriving correctly at `https://www.gotravyl.com/auth/callback` — the rewrite was happening in our handler.

## Test plan

- [ ] Scroll homepage on gotravyl.com — hero fades quickly, no drop/drag.
- [ ] Sign in with Google on gotravyl.com — lands on `gotravyl.com/` (or `?next=` target), not localhost.
- [ ] Sign in with Google on www.gotravyl.com — lands on `www.gotravyl.com/`.
- [ ] Confirm Amplify build succeeds on main.