### PR TITLE
fix(mobile): wire Google Maps Android key + register fonts via expo-font plugin

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,0 +1,22 @@
+// app.config.js — read by Expo CLI / EAS Build at prebuild time.
+// Extends the static app.json with values that come from env vars so
+// secrets never land in source control. The Android Google Maps key
+// gets injected into AndroidManifest.xml as the
+// `com.google.android.geo.API_KEY` meta-data tag.
+//
+// Set `GOOGLE_MAPS_API_KEY_ANDROID` in EAS env vars (preview + production
+// environments) with visibility "sensitive" so it stays out of build logs
+// and out of the JS bundle.
+
+module.exports = ({ config }) => ({
+  ...config,
+  android: {
+    ...config.android,
+    config: {
+      ...config.android?.config,
+      googleMaps: {
+        apiKey: process.env.GOOGLE_MAPS_API_KEY_ANDROID,
+      },
+    },
+  },
+});

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -36,7 +36,22 @@
     },
     "plugins": [
       "expo-router",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      [
+        "expo-font",
+        {
+          "fonts": [
+            "./assets/fonts/Lustria-Regular.ttf",
+            "./assets/fonts/Satoshi-Light.ttf",
+            "./assets/fonts/Satoshi-Regular.ttf",
+            "./assets/fonts/Satoshi-Medium.ttf",
+            "./assets/fonts/Satoshi-Bold.ttf",
+            "./assets/fonts/Satoshi-Black.ttf",
+            "./assets/fonts/SpaceMono-Regular.ttf",
+            "./assets/fonts/FontAwesome.ttf"
+          ]
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true


### PR DESCRIPTION
## Summary

Two Android-only crashes/regressions surfaced when the first Android preview APK was built (off the Zod branch from #786). iOS hides both because `react-native-maps` defaults to Apple Maps on iOS and runtime `useFonts()` is more lenient there. ngallego's iOS-only build cycle never tripped these.

## Changes

**`apps/mobile/app.config.js` (new, 22 lines)**
- Reads `GOOGLE_MAPS_API_KEY_ANDROID` from the EAS env (sensitive, set on **preview** + **production** environments)
- Injects it as the `com.google.android.geo.API_KEY` meta-data tag in `AndroidManifest.xml` at prebuild
- Without this, every `<MapView>` mount on Android throws `RuntimeException: API key not found` and tears down the React context. Profile → Past Trips and Places card detail both render maps, so both were crashing on Android

**`apps/mobile/app.json` (+16 lines)**
- Adds the `expo-font` config plugin entry listing all 8 `.ttf` files in `assets/fonts/`
- Native build-time linking, so fonts ship embedded in the APK / IPA and resolve via the platform font system
- Previously fonts were only loaded at runtime via `useFonts()` in `_layout.tsx` — works in dev and on iOS, but Android release builds silently fell back to Roboto

## Verification

- ✅ Android preview APK installs cleanly on Pixel 8 Pro emulator
- ✅ Profile + Past Trips renders the trip-map modal (no more crash)
- ✅ Places card detail shows venue map (no more crash)
- ✅ Headings render in **Lustria** (serif), body in **Satoshi** (sans) — not Roboto
- ✅ iOS preview build queued from the same branch (build `4a6cc5cb`); confirmed running and renders on registered device
- ✅ Local typecheck clean across all 3 workspaces

## Required env var (already configured for preview)

`GOOGLE_MAPS_API_KEY_ANDROID` is set on the preview environment with `Sensitive` visibility. **Same variable also needs to be added to the `production` environment before the next production Android build.** Restrict the key in Google Cloud Console to package `com.zeee.mobile` + EAS keystore SHA-1 + Maps SDK for Android only.

## Test plan
- [ ] Pull `fix/mobile-android-maps-fonts`, run `eas build --platform android --profile preview`
- [ ] Install resulting APK on Android emulator/device
- [ ] Verify Profile → Past Trips, Places → swipe card, both render maps
- [ ] Verify headings/body use Lustria/Satoshi typography
- [ ] iOS regression check: `eas build --platform ios --profile preview` — confirm no impact